### PR TITLE
feat: catalog-qualified SAP function calls (issue #55)

### DIFF
--- a/rfc/src/sap_storage.cpp
+++ b/rfc/src/sap_storage.cpp
@@ -5,17 +5,29 @@
 #include "duckdb/catalog/catalog_entry/duck_schema_entry.hpp"
 #include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
 #include "duckdb/parser/parsed_data/create_view_info.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "duckdb/main/config.hpp"
 
 // entry_lookup_info.hpp was introduced alongside TryLookupEntryInternal in DuckDB v1.5+
 #if DUCKDB_MINOR_VERSION >= 5
 #include "duckdb/catalog/entry_lookup_info.hpp"
+#include "scanner_invoke.hpp"
+#include "scanner_read_table.hpp"
+#include "scanner_show_functions.hpp"
+#include "scanner_show_groups.hpp"
+#include "scanner_describe_function.hpp"
+#include "scanner_show_tables.hpp"
+#include "scanner_describe_fields.hpp"
 #endif
 
 #include "sap_storage.hpp"
 #include "sap_connection.hpp"
 
 namespace duckdb {
+
+// ---------------------------------------------------------------------------
+// SapDefaultGenerator — lazy on-demand SAP table views
+// ---------------------------------------------------------------------------
 
 class SapDefaultGenerator : public DefaultGenerator {
 public:
@@ -63,37 +75,78 @@ private:
 	vector<string> allowed_tables;
 };
 
+// ---------------------------------------------------------------------------
+// SapSecretInjectorInfo / SapSecretBind — secret injection trampoline
+//
+// table_function_bind_t is a raw function pointer, so lambdas with captures
+// cannot be used.  Instead, we carry the secret and original bind through
+// function_info (a shared_ptr<TableFunctionInfo>) and forward to the original
+// bind from a static trampoline.  This is installed on every overload of each
+// SAP table function that is inserted into an attached catalog (issue #55).
+// ---------------------------------------------------------------------------
+
 #if DUCKDB_MINOR_VERSION >= 5
-// SapCatalog wraps DuckCatalog and overrides the private virtual TryLookupEntryInternal
-// (the NVI hook that backs all entry lookups) to reset created_all_entries on the
-// DefaultGenerator before each lookup.
+
+struct SapSecretInjectorInfo : public TableFunctionInfo {
+	string secret_name;
+	table_function_bind_t orig_bind;
+	SapSecretInjectorInfo(string secret, table_function_bind_t bind)
+	    : secret_name(std::move(secret)), orig_bind(bind) {
+	}
+};
+
+static unique_ptr<FunctionData> SapSecretBind(ClientContext &ctx, TableFunctionBindInput &input,
+                                              vector<LogicalType> &return_types, vector<string> &names) {
+	D_ASSERT(input.info);
+	auto &injector = input.info->Cast<SapSecretInjectorInfo>();
+	if (input.named_parameters.find("secret") == input.named_parameters.end()) {
+		input.named_parameters["secret"] = Value(injector.secret_name);
+	}
+	return injector.orig_bind(ctx, input, return_types, names);
+}
+
+// Wrap every overload in info.functions to inject the secret via the trampoline.
+static void WrapFunctionInfoWithSecret(CreateTableFunctionInfo &info, const string &secret_name) {
+	for (auto &func : info.functions.functions) {
+		if (!func.bind) {
+			continue;
+		}
+		func.function_info = make_shared_ptr<SapSecretInjectorInfo>(secret_name, func.bind);
+		func.bind = SapSecretBind;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SapCatalog — DuckCatalog subclass that keeps the view DefaultGenerator
+// active after Scan() calls (issue #54).
 //
-// Background: DuckDB's CatalogSet::CreateDefaultEntries() sets created_all_entries=true
-// after iterating GetDefaultEntries(), even when it returns [] (the no-TABLES case where
-// any SAP table name is valid on demand). After a Scan() — triggered e.g. by Ducklake
-// enumerating all attached catalogs — this flag is permanently true, so GetEntryDefault()
-// skips the generator and every subsequent SAP table lookup fails.
-//
-// By resetting the flag immediately before the catalog-set lookup we ensure the generator
-// stays active across Scans without requiring any change to DuckDB's own code.
+// DuckDB's CatalogSet::CreateDefaultEntries() sets created_all_entries=true
+// after iterating GetDefaultEntries().  When that returns [] (the no-TABLES
+// case for the view generator), this permanently disables GetEntryDefault()
+// for on-demand view creation.  Overriding TryLookupEntryInternal() to reset
+// the flag before each lookup keeps the generator alive across Scans.
+// ---------------------------------------------------------------------------
+
 class SapCatalog : public DuckCatalog {
 public:
-	explicit SapCatalog(AttachedDatabase &db) : DuckCatalog(db), sap_generator_(nullptr) {}
+	explicit SapCatalog(AttachedDatabase &db) : DuckCatalog(db), view_generator_(nullptr) {}
 
-	void SetGenerator(SapDefaultGenerator *gen) {
-		sap_generator_ = gen;
+	void SetViewGenerator(SapDefaultGenerator *gen) {
+		view_generator_ = gen;
 	}
 
 private:
-	SapDefaultGenerator *sap_generator_; // non-owning; lifetime tied to this catalog's CatalogSet
+	// Non-owning pointer; generator is owned by the CatalogSet inside this catalog.
+	SapDefaultGenerator *view_generator_;
 
 	CatalogEntryLookup TryLookupEntryInternal(CatalogTransaction transaction, const string &schema_name,
 	                                          const EntryLookupInfo &lookup_info) override {
-		if (sap_generator_) {
-			sap_generator_->created_all_entries = false;
+		// Reset so GetEntryDefault() still calls CreateDefaultEntry() even after
+		// a Scan() (e.g. from Ducklake) has set created_all_entries=true.
+		if (view_generator_) {
+			view_generator_->created_all_entries = false;
 		}
 		if (lookup_info.GetAtClause()) {
-			// SAP catalog does not support time-travel AT CLAUSE syntax
 			return {nullptr, nullptr, ErrorData(BinderException("SAP catalog does not support time travel"))};
 		}
 		auto schema_lookup = EntryLookupInfo::SchemaLookup(lookup_info, schema_name);
@@ -108,7 +161,12 @@ private:
 		return {schema_entry, entry, ErrorData()};
 	}
 };
-#endif
+
+#endif // DUCKDB_MINOR_VERSION >= 5
+
+// ---------------------------------------------------------------------------
+// SapStorageAttach
+// ---------------------------------------------------------------------------
 
 static unique_ptr<Catalog> SapStorageAttach(optional_ptr<StorageExtensionInfo> storage_info, ClientContext &context,
                                             AttachedDatabase &db, const string &name, AttachInfo &info,
@@ -156,11 +214,39 @@ static unique_ptr<Catalog> SapStorageAttach(optional_ptr<StorageExtensionInfo> s
 	auto system_transaction = CatalogTransaction::GetSystemTransaction(db.GetDatabase());
 	auto &schema = sap_catalog->GetSchema(system_transaction, DEFAULT_SCHEMA);
 	auto &duck_schema = schema.Cast<DuckSchemaEntry>();
-	auto &catalog_set = duck_schema.GetCatalogSet(CatalogType::VIEW_ENTRY);
-	auto default_generator =
-	    make_uniq<SapDefaultGenerator>(*sap_catalog, schema, std::move(secret_name), std::move(allowed_tables));
-	sap_catalog->SetGenerator(default_generator.get());
-	catalog_set.SetDefaultGenerator(std::move(default_generator));
+
+	// ── View generator (on-demand SAP table views) ────────────────────────
+	auto &view_catalog_set = duck_schema.GetCatalogSet(CatalogType::VIEW_ENTRY);
+	auto view_gen = make_uniq<SapDefaultGenerator>(*sap_catalog, schema, secret_name, allowed_tables);
+	sap_catalog->SetViewGenerator(view_gen.get());
+	view_catalog_set.SetDefaultGenerator(std::move(view_gen));
+
+	// ── SAP table functions (catalog-qualified calls, issue #55) ────────────
+	// Insert each SAP table function directly into the catalog at attach time.
+	// The bind trampoline injects the attachment secret when the caller hasn't
+	// provided one explicitly.  Using scanner factory functions avoids including
+	// table_function_catalog_entry.hpp (which causes an ODR conflict with the
+	// explicit out-of-line Name definition in libduckdb_static.a).
+	{
+		vector<CreateTableFunctionInfo> funcs;
+		funcs.emplace_back(CreateRfcInvokeScanFunction());
+		funcs.emplace_back(CreateRfcReadTableScanFunction());
+		funcs.emplace_back(CreateRfcShowFunctionScanFunction());
+		funcs.emplace_back(CreateRfcShowGroupScanFunction());
+		funcs.emplace_back(CreateRfcDescribeFunctionScanFunction());
+		funcs.emplace_back(CreateRfcShowTablesScanFunction());
+		funcs.emplace_back(CreateRfcDescribeFieldsScanFunction());
+
+		for (auto &info : funcs) {
+			// Functions registered in the system catalog are marked internal; strip
+			// that flag so DuckDB allows them to be created in the sap_rfc catalog.
+			info.internal = false;
+			if (!secret_name.empty()) {
+				WrapFunctionInfoWithSecret(info, secret_name);
+			}
+			duck_schema.CreateTableFunction(system_transaction, info);
+		}
+	}
 
 	return std::move(sap_catalog);
 #else

--- a/rfc/test/sql/sap_rfc_catalog_functions.test
+++ b/rfc/test/sql/sap_rfc_catalog_functions.test
@@ -1,0 +1,114 @@
+# name: test/sql/sap_rfc_catalog_functions.test
+# description: catalog-qualified SAP function calls via attached catalog (issue #55)
+# group: [rfc]
+
+require erpl_rfc
+
+require-env ERPL_SAP_ASHOST
+
+require-env ERPL_SAP_SYSNR
+
+require-env ERPL_SAP_USER
+
+require-env ERPL_SAP_PASSWORD
+
+require-env ERPL_SAP_CLIENT
+
+require-env ERPL_SAP_LANG
+
+statement ok
+CREATE SECRET abap_trial (
+    TYPE sap_rfc,
+    ASHOST '${ERPL_SAP_ASHOST}',
+    SYSNR '${ERPL_SAP_SYSNR}',
+    CLIENT '${ERPL_SAP_CLIENT}',
+    USER '${ERPL_SAP_USER}',
+    PASSWD '${ERPL_SAP_PASSWORD}',
+    LANG '${ERPL_SAP_LANG}'
+);
+
+# -----------------------------------------------------------------------
+# Feature: catalog-qualified SAP functions (issue #55)
+#
+# After ATTACH '' AS sap (TYPE sap_rfc, SECRET '...'), SAP table functions
+# should be accessible as sap.sap_rfc_invoke(...), sap.sap_read_table(...),
+# etc. The catalog qualifier implicitly selects the secret from the ATTACH,
+# enabling query federation across multiple SAP systems in one session.
+# -----------------------------------------------------------------------
+
+statement ok
+ATTACH '' AS sap_fn (TYPE sap_rfc, SECRET 'abap_trial');
+
+# -----------------------------------------------------------------------
+# Test 1: sap_rfc_invoke via catalog qualifier
+# -----------------------------------------------------------------------
+query I
+SELECT count(*) > 0 FROM sap_fn.sap_rfc_invoke('RFC_SYSTEM_INFO');
+----
+true
+
+# -----------------------------------------------------------------------
+# Test 2: sap_read_table via catalog qualifier
+# -----------------------------------------------------------------------
+query I
+SELECT count(*) > 0 FROM sap_fn.sap_read_table('/DMO/FLIGHT');
+----
+true
+
+# -----------------------------------------------------------------------
+# Test 3: sap_show_tables via catalog qualifier
+# -----------------------------------------------------------------------
+query I
+SELECT count(*) > 0 FROM sap_fn.sap_show_tables();
+----
+true
+
+# -----------------------------------------------------------------------
+# Test 4: sap_describe_fields via catalog qualifier
+# -----------------------------------------------------------------------
+query I
+SELECT count(*) > 0 FROM sap_fn.sap_describe_fields('/DMO/FLIGHT');
+----
+true
+
+# -----------------------------------------------------------------------
+# Test 5: sap_rfc_describe_function via catalog qualifier
+# -----------------------------------------------------------------------
+query I
+SELECT count(*) > 0 FROM sap_fn.sap_rfc_describe_function('RFC_SYSTEM_INFO');
+----
+true
+
+# -----------------------------------------------------------------------
+# Test 6: sap_rfc_show_function via catalog qualifier
+# -----------------------------------------------------------------------
+query I
+SELECT count(*) > 0 FROM sap_fn.sap_rfc_show_function();
+----
+true
+
+# -----------------------------------------------------------------------
+# Test 7: catalog-qualified function uses attachment secret (no explicit SECRET=)
+# A second attach with the same secret should also work independently.
+# -----------------------------------------------------------------------
+statement ok
+ATTACH '' AS sap_fn2 (TYPE sap_rfc, SECRET 'abap_trial');
+
+query I
+SELECT count(*) > 0 FROM sap_fn2.sap_rfc_invoke('RFC_SYSTEM_INFO');
+----
+true
+
+# -----------------------------------------------------------------------
+# Test 8: explicit SECRET= parameter still overrides the attachment default
+# -----------------------------------------------------------------------
+query I
+SELECT count(*) > 0 FROM sap_fn.sap_rfc_invoke('RFC_SYSTEM_INFO', SECRET='abap_trial');
+----
+true
+
+statement ok
+DETACH sap_fn;
+
+statement ok
+DETACH sap_fn2;


### PR DESCRIPTION
## Summary

- `ATTACH '' AS sap_s4 (TYPE sap_rfc, SECRET 'my_secret')` now pre-inserts all 7 SAP table functions into the attached catalog, making them accessible as `sap_s4.sap_rfc_invoke(...)`, `sap_s4.sap_read_table(...)`, etc.
- The attachment secret is injected automatically — callers don't need to specify `SECRET=` unless they want to override it.
- Multiple attachments to different SAP systems can coexist in one session, each routing through its own secret.

## Implementation

**`rfc/src/sap_storage.cpp`** — `SapStorageAttach` (v1.5+ path):
- Adds `SapSecretInjectorInfo : public TableFunctionInfo` to carry the secret + original bind pointer.
- Adds static `SapSecretBind` trampoline that injects the secret into `input.named_parameters["secret"]` before calling the original bind. Raw function pointer constraint requires this pattern (`table_function_bind_t` cannot hold a capturing lambda).
- At ATTACH time, calls each scanner factory (`CreateRfcInvokeScanFunction()` etc.), sets `info.internal = false` (strips the system-catalog-only restriction), wraps binds, then calls `duck_schema.CreateTableFunction()` to pre-insert.
- Avoids including `table_function_catalog_entry.hpp` directly to prevent ODR conflict with the explicit out-of-line `constexpr const char* Name` definition in `libduckdb_static.a`.

**`rfc/test/sql/sap_rfc_catalog_functions.test`** — 8 test cases:
1–6: catalog-qualified calls to each of the 7 SAP functions
7: second ATTACH with same secret works independently  
8: explicit `SECRET=` override still respected

## Test plan

- [ ] `make sql_tests_rfc TEST_FILE=sap_rfc_catalog_functions.test` — all 8 tests pass
- [ ] `make sql_tests_rfc TEST_FILE=sap_rfc_attach.test` — existing attach tests unaffected
- [ ] Verify `sap_s4.sap_rfc_invoke('RFC_SYSTEM_INFO')` returns rows (no explicit `SECRET=`)
- [ ] Verify two concurrent attachments to the same system both work independently

Closes #55