### PR TITLE
fix(rfc): sap_read_table parallelism + sap_rfc_invoke type-coverage

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -707,12 +707,32 @@ SELECT * FROM sap_odp_show_cursors();
 
 ---
 
-#### `PRAGMA odp_drop(subscription_id)`
+#### `PRAGMA sap_odp_drop(odp_context, subscriber_name, subscriber_process, odp_name)`
 
-Drop/delete an ODP subscription.
+Drop an ODP subscription/cursor on the SAP system (invokes `RODPS_REPL_ODP_RESET`).
+A subsequent `sap_odp_read_full` will re-create the subscription from scratch.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `odp_context` | VARCHAR | ODP context (e.g. `'ABAP_CDS'`, `'BW'`, `'SAPI'`) |
+| `subscriber_name` | VARCHAR | Subscriber name registered against the queue |
+| `subscriber_process` | VARCHAR | Subscriber process identifier |
+| `odp_name` | VARCHAR | ODP object name |
+
+**Named parameters:** `secret` — optional secret name.
 
 ```sql
-PRAGMA odp_drop('SUB_12345');
+-- Find the subscription to drop
+SELECT queue_name, subscriber_name, subscriber_proc
+  FROM sap_odp_show_subscriptions();
+
+-- Drop it (values come from the row above)
+PRAGMA sap_odp_drop(
+    'ABAP_CDS',
+    'ERPL_BW',
+    'ERPL_ABAP_CDS_SEPM_IBUPA_4271',
+    'SEPM_IBUPA$P'
+);
 ```
 
 ---

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -67,7 +67,9 @@ SELECT * FROM sap_bics_show_cubes();
 | `sap_describe_fields` | Get table field metadata | `SELECT * FROM sap_describe_fields('SFLIGHT')` |
 | `sap_bics_show_cubes` | List BW cubes | `SELECT * FROM sap_bics_show_cubes()` |
 | `sap_bics_hierarchy` | Extract BW hierarchy | `SELECT * FROM sap_bics_hierarchy('MY_HIER')` |
-| `sap_odp_read_full` | Extract ODP data | `SELECT * FROM sap_odp_read_full('BW', 'MY_ODP')` |
+| `sap_bics_set_char_prop` | AO-style char property (Display/Sort/Totals) | `SELECT * FROM sap_bics_set_char_prop('q1', '0CNTRY', 'DISPLAY', 'TEXT')` |
+| `sap_odp_read_full` | Extract ODP data (full snapshot) | `SELECT * FROM sap_odp_read_full('BW', 'MY_ODP')` |
+| `sap_odp_read_delta` | Extract ODP data (incremental delta) | `SELECT * FROM sap_odp_read_delta('BW', 'MY_ODP', 'MY_PIPELINE')` |
 | `ATTACH` | Mount SAP as database | `ATTACH '' AS sap (TYPE sap_rfc)` |
 
 ---
@@ -503,18 +505,69 @@ Configure column axis characteristics. Same signature as `sap_bics_rows`.
 SELECT * FROM sap_bics_columns('my_session', '0AMOUNT', op='SET');
 ```
 
-#### Step 3: `sap_bics_filter(state_id, filters [, op, return])`
+#### Step 3: `sap_bics_filter(state_id, char_name, member1 [, member2, ..., op, return])`
 
-Apply filters to query.
+Restrict a characteristic to specific member values (AO "Keep Only" /
+"Exclude" gesture). Members are positional varargs after the characteristic
+name; pass zero members with `op='SET'` to clear the filter.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `state_id` | VARCHAR | *required* | State ID |
-| `filters` | varies | *required* | Filter definitions |
-| `op` | BICS_OPERATION | — | Operation type |
+| `char_name` | VARCHAR | *required* | Characteristic technical name |
+| `member1, …` | VARCHAR (varargs) | — | Member values to include (or remove with `op='REMOVE'`) |
+| `op` | BICS_OPERATION | `'ADD'` if members supplied, else `'SET'` | `'SET'`, `'ADD'`, `'REMOVE'` |
 | `return` | BICS_RETURN | `'DESCRIBE'` | Return format |
 
-#### Step 4: `sap_bics_result(state_id)`
+```sql
+-- "Keep Only Germany and France" on country
+SELECT * FROM sap_bics_filter('q1', '0D_NW_CNTRY', 'DE', 'FR', op='SET');
+-- Append USA to the existing selection
+SELECT * FROM sap_bics_filter('q1', '0D_NW_CNTRY', 'US', op='ADD');
+-- Clear the filter
+SELECT * FROM sap_bics_filter('q1', '0D_NW_CNTRY', op='SET');
+```
+
+#### Step 4 (optional): `sap_bics_set_char_prop(state_id, char_name, prop, value [, return])`
+
+Set an AO-style per-characteristic property (Display, Sort, or Totals
+visibility). Mutates `/E_TH_STATE_CHARACTERISTICS/<id>/<field>` on the
+server and the change is honoured by the next `sap_bics_result` call.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `state_id` | VARCHAR | *required* | State ID |
+| `char_name` | VARCHAR | *required* | Characteristic technical name |
+| `prop` | VARCHAR | *required* | One of `'DISPLAY'`, `'TOTALS'`, `'SORT'` |
+| `value` | VARCHAR | *required* | See table below |
+| `return` | BICS_RETURN | `'DESCRIBE'` | Return format |
+
+| `prop`    | Allowed `value`                | Server field mutated                                        |
+|-----------|--------------------------------|-------------------------------------------------------------|
+| `DISPLAY` | `'KEY'` \| `'TEXT'` \| `'BOTH'` | `RESULT_SET_PRESENTATION` + `MEMBER_ACCESS_PRESENTATION` (bitflag: KEY=4, TEXT=32) |
+| `TOTALS`  | `'SHOW'` \| `'HIDE'`            | `RESULT_VISIBILITY` ('A' / 'N')                             |
+| `SORT`    | `'ASC'` \| `'DESC'` \| `'NONE'`  | `RESULT_SET_SORTING.DIRECTION` ('A' / 'D' / '')             |
+
+```sql
+-- Show member texts instead of keys
+SELECT * FROM sap_bics_set_char_prop('q1', '0D_NW_CNTRY', 'DISPLAY', 'TEXT');
+-- Sort products descending
+SELECT * FROM sap_bics_set_char_prop('q1', '0D_NW_PROD', 'SORT', 'DESC');
+```
+
+The result-set parser is display-mode aware: when BICS returns both key and
+text presentation entries for a member, the renderer picks key / text / both
+according to the per-char setting. The DESCRIBE payload of `state_rows`,
+`state_columns`, and `state_free` now carries `{display, totals, sort}` so
+clients can read the current values without an extra round-trip.
+
+> **Note:** the grand-total "SUMME" / "Overall Result" row in `sap_bics_result`
+> is not affected by per-char `TOTALS='HIDE'` — BICS does not expose a state
+> field for grand-total visibility. The flag is applied to the server state
+> (visible in DESCRIBE) but the SUMME row still appears in the result set;
+> downstream clients can filter it out client-side. AO does the same.
+
+#### Step 5: `sap_bics_result(state_id)`
 
 Fetch result set from configured query state.
 
@@ -527,6 +580,8 @@ Fetch result set from configured query state.
 SELECT * FROM sap_bics_begin('MY_CUBE', id='q1');
 SELECT * FROM sap_bics_rows('q1', '0CALDAY', '0MATERIAL');
 SELECT * FROM sap_bics_columns('q1', '0AMOUNT');
+SELECT * FROM sap_bics_set_char_prop('q1', '0CALDAY', 'SORT', 'DESC');  -- optional
+SELECT * FROM sap_bics_filter('q1', '0MATERIAL', 'M01', 'M02', op='SET');  -- optional
 SELECT * FROM sap_bics_result('q1');
 ```
 
@@ -667,7 +722,10 @@ SELECT * FROM sap_odp_preview('BW', 'MY_ODP_SOURCE');
 
 #### `sap_odp_read_full(odp_context, odp_name [, threads, columns, filters, secret])`
 
-Full extraction of ODP provider data with parallel processing.
+Full extraction of ODP provider data with parallel processing. The cursor on
+the SAP side is opened in **FULL** mode and auto-closed when the scan ends —
+this is one-shot. For incremental extraction use
+[`sap_odp_read_delta`](#sap_odp_read_deltaodp_context-odp_name-subscriber_process).
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -675,13 +733,88 @@ Full extraction of ODP provider data with parallel processing.
 | `odp_name` | VARCHAR | *required* | ODP provider name |
 | `threads` | UINTEGER | 5 | Parallel read threads |
 | `columns` | LIST(VARCHAR) | all | Columns to extract |
-| `filters` | LIST | — | Selection filters |
+| `filters` | LIST(STRUCT) | — | Server-side selection filters (see below) |
 | `secret` | VARCHAR | — | Named secret |
 
+**`filters` shape** — `LIST<STRUCT(FIELDNAME, SIGN, OP, LOW, HIGH)>` mapped
+onto SAP's `RODPS_REPL_S_SELECTION` row type. Predicates are OR-combined
+within the list:
+
+| Field | Type | Semantics |
+|-------|------|-----------|
+| `FIELDNAME` | VARCHAR | ODP source field name |
+| `SIGN` | VARCHAR | `'I'` (include) or `'E'` (exclude) |
+| `OP` | VARCHAR | `'EQ'`, `'NE'`, `'GT'`, `'LT'`, `'GE'`, `'LE'`, `'BT'`, `'CP'`, ... |
+| `LOW` | VARCHAR | Lower / single-value comparand |
+| `HIGH` | VARCHAR | Upper comparand (only for `BT`) |
+
 ```sql
+-- Simple equality
 SELECT * FROM sap_odp_read_full('BW', 'MY_ODP_SOURCE');
 SELECT * FROM sap_odp_read_full('ABAP_CDS', 'MY_CDS_VIEW', threads=8);
+
+-- Server-side range filter (between two business partners, inclusive)
+SELECT * FROM sap_odp_read_full('ABAP_CDS', 'SEPM_IBUPA$P',
+    COLUMNS=['BUSINESSPARTNER','COMPANYNAME'],
+    FILTERS=[{
+        'FIELDNAME': 'BUSINESSPARTNER',
+        'SIGN':      'I',
+        'OP':        'BT',
+        'LOW':       '0100000000',
+        'HIGH':      '0100000099'
+    }]);
 ```
+
+---
+
+#### `sap_odp_read_delta(odp_context, odp_name, subscriber_process [, …])`
+
+Incremental delta extraction. The first call with a given `subscriber_process`
+performs SAP's **auto-DELTAINIT** — returns the full current snapshot AND
+registers a server-side delta pointer keyed by the subscriber tuple. Subsequent
+calls with the same `subscriber_process` resume from the previous pointer and
+return only the changes since then.
+
+The cursor persists across calls (FULL cursors auto-close on scan completion;
+DELTA cursors do not). Close them explicitly with
+[`PRAGMA sap_odp_close_delta_cursor`](#pragma-sap_odp_close_delta_cursor) when
+your pipeline is done.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `odp_context` | VARCHAR | *required* | ODP context (e.g. `'BW'`, `'ABAP_CDS'`) |
+| `odp_name` | VARCHAR | *required* | ODP provider name |
+| `subscriber_process` | VARCHAR | *required* | **Stable** identifier that keys the server-side delta pointer across calls. Choose a deterministic name per pipeline (e.g. `'MY_ETL_BUPA_DAILY'`). |
+| `threads` | UINTEGER | 5 | Parallel read threads |
+| `columns` | LIST(VARCHAR) | all | Columns to extract |
+| `filters` | LIST(STRUCT) | — | Server-side selection predicates (same shape as `sap_odp_read_full`) |
+| `recover` | BOOLEAN | `false` | When true, re-stream the last unconfirmed packet (`I_EXTRACTION_MODE='R'`) without advancing the pointer. Useful after a fetch was interrupted. |
+| `secret` | VARCHAR | — | Named secret |
+
+**Concurrency note:** do not run two `sap_odp_read_delta` calls with the same
+`subscriber_process` in parallel — they will race the server-side pointer.
+
+```sql
+-- First call: SAP auto-DELTAINIT — returns full current snapshot, registers
+-- a server-side delta pointer under subscriber_process 'NIGHTLY_ETL'.
+SELECT * FROM sap_odp_read_delta('BW', '0D_FC_C01$F', 'NIGHTLY_ETL');
+
+-- Run the same call later (e.g. next day): returns only the rows that
+-- changed in the cube since the previous call.
+SELECT * FROM sap_odp_read_delta('BW', '0D_FC_C01$F', 'NIGHTLY_ETL');
+
+-- If a previous DELTA call was interrupted, re-stream its last packet:
+SELECT * FROM sap_odp_read_delta('BW', '0D_FC_C01$F', 'NIGHTLY_ETL',
+                                 recover=true);
+
+-- Release the cursor when done:
+PRAGMA sap_odp_close_delta_cursor('BW', 'NIGHTLY_ETL', '0D_FC_C01$F');
+```
+
+Delta-capable sources are identified by `supports_delta=true` in
+[`sap_odp_describe`](#sap_odp_describe). Not every CDS view is delta-capable —
+the underlying DDL must carry the `@Analytics.dataExtraction.delta.byElement`
+annotation; BW fact tables (`*$F`) are typically delta-capable.
 
 ---
 
@@ -699,11 +832,43 @@ SELECT * FROM sap_odp_show_subscriptions();
 
 #### `sap_odp_show_cursors([secret])`
 
-List ODP extraction cursors for delta tracking.
+List ODP extraction cursors for delta tracking. Cursors created by
+`sap_odp_read_delta` appear here with `is_delta_extension=true`; their
+`subscriber_proc` column matches the `subscriber_process` argument you passed.
 
 ```sql
 SELECT * FROM sap_odp_show_cursors();
 ```
+
+---
+
+#### `PRAGMA sap_odp_close_delta_cursor(odp_context, subscriber_process, odp_name [, secret=...])`
+
+Graceful counterpart to `sap_odp_drop`. Looks up the cursor for the given
+subscriber tuple and calls `RODPS_REPL_ODP_CLOSE` on its pointer. **Idempotent**:
+returns `'CLOSED'` if a cursor existed (open or already closed) and
+`'NOT_FOUND'` if no cursor of that name was found.
+
+Prefer this over `sap_odp_drop` at the end of a delta pipeline — close leaves
+the subscription registered and resumable from its last pointer; drop wipes the
+subscription so the next call performs DELTAINIT again.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `odp_context` | VARCHAR | ODP context (e.g. `'BW'`, `'ABAP_CDS'`) |
+| `subscriber_process` | VARCHAR | Subscriber process identifier (the one passed to `sap_odp_read_delta`) |
+| `odp_name` | VARCHAR | ODP object name |
+
+**Named parameters:** `secret` — optional secret name.
+
+```sql
+PRAGMA sap_odp_close_delta_cursor('BW', 'NIGHTLY_ETL', '0D_FC_C01$F');
+```
+
+Cleanup hygiene matters: leaked open cursors accumulate server-side. If a
+pipeline crashes mid-fetch the cursor may not be closeable via this pragma —
+fall back to `sap_odp_drop` to fully reset, accepting that the next call
+will re-snapshot via DELTAINIT.
 
 ---
 
@@ -888,35 +1053,45 @@ CREATE SECRET my_ssh_key (
 
 ### SAP ↔ DuckDB Type Mapping
 
-| SAP RFC Type | DuckDB Type | Notes |
-|-------------|-------------|-------|
-| CHAR | VARCHAR | Fixed-length, right-trimmed |
-| NUM (NUMC) | VARCHAR | Numeric characters, preserves leading zeros |
-| INT | INTEGER | 4-byte integer |
-| INT1 | TINYINT | 1-byte integer |
-| INT2 | SMALLINT | 2-byte integer |
-| INT8 | INTEGER | 8-byte mapped to INTEGER |
-| FLOAT | DOUBLE | Floating point |
-| BCD | DECIMAL | Binary coded decimal |
-| DECF16 | DECIMAL | Decimal floating point 16 |
-| DECF34 | DECIMAL | Decimal floating point 34 |
-| STRING | VARCHAR | Variable-length string |
-| XSTRING | VARCHAR | Hex string |
-| XMLDATA | VARCHAR | XML data |
-| BYTE | BLOB | Raw bytes |
-| DATE | DATE | Format YYYYMMDD |
-| TIME | TIME | Format HHMMSS |
-| UTCLONG | TIMESTAMP | UTC timestamp (long) |
-| UTCSECOND | TIMESTAMP | UTC timestamp (seconds) |
-| UTCMINUTE | TIMESTAMP | UTC timestamp (minutes) |
-| DTDAY | INTEGER | Date duration in days |
-| DTWEEK | INTEGER | Date duration in weeks |
-| DTMONTH | INTEGER | Date duration in months |
-| TSECOND | INTEGER | Time duration in seconds |
-| TMINUTE | INTEGER | Time duration in minutes |
-| CDAY | INTEGER | Calendar day |
-| STRUCTURE | STRUCT | Nested structure |
-| TABLE | LIST | Table parameter |
+The DDIC name on the left is what `sap_describe_fields()` reports; the RFCTYPE
+shown in parentheses is the internal RFC-SDK type the ERPL scanners use.
+
+| DDIC type | RFCTYPE | DuckDB type | Notes |
+|-----------|---------|-------------|-------|
+| CHAR / CLNT / LANG / CUKY / UNIT | RFCTYPE_CHAR | VARCHAR | Fixed-length, right-trimmed |
+| NUMC / ACCP | RFCTYPE_NUM | VARCHAR | Numeric characters; preserves leading zeros |
+| INT4 | RFCTYPE_INT | BIGINT | 4-byte integer (signed) |
+| INT1 | RFCTYPE_INT1 | TINYINT | 1-byte integer |
+| INT2 / PREC | RFCTYPE_INT2 | SMALLINT | 2-byte integer (PREC is a DDIC alias) |
+| INT8 | RFCTYPE_INT8 | BIGINT | 8-byte integer (signed) |
+| FLTP | RFCTYPE_FLOAT | DOUBLE | IEEE 754 floating point |
+| DEC / CURR / QUAN | RFCTYPE_BCD | DECIMAL(min(2N-1,38), S) | Packed-decimal; precision capped at DuckDB's max |
+| DECF16 / D16D / D16N / D16R / D16S | RFCTYPE_DECF16 | DECIMAL(min(LENG,16), S) | IEEE 754-2008 decimal floating point (16 digit) |
+| DECF34 / D34D / D34N / D34R / D34S | RFCTYPE_DECF34 | DECIMAL(min(LENG,34), S) | IEEE 754-2008 decimal floating point (34 digit) |
+| STRING / STRG / SSTR / LCHR | RFCTYPE_STRING | VARCHAR | Variable-length character data |
+| XMLDATA | RFCTYPE_XMLDATA | VARCHAR | XML payload (text) |
+| RAW / LRAW | RFCTYPE_BYTE | BLOB | Fixed-length raw bytes (incl. RAW(16) UUIDs) |
+| RAWSTRING / RSTR | RFCTYPE_XSTRING | BLOB | Variable-length raw bytes |
+| DATS | RFCTYPE_DATE | DATE | Format YYYYMMDD |
+| TIMS | RFCTYPE_TIME | TIME | Format HHMMSS |
+| UTCLONG / UTCL | RFCTYPE_UTCLONG | TIMESTAMP | UTC timestamp, microsecond precision |
+| UTCS | RFCTYPE_UTCSECOND | TIMESTAMP | UTC timestamp, second precision |
+| UTCM | RFCTYPE_UTCMINUTE | TIMESTAMP | UTC timestamp, minute precision |
+| (n/a — RFC parameter only) | RFCTYPE_DTDAY / DTWEEK / DTMONTH | INTEGER | Date durations (days / weeks / months) |
+| (n/a — RFC parameter only) | RFCTYPE_TSECOND / TMINUTE | INTEGER | Time durations (seconds / minutes) |
+| (n/a — RFC parameter only) | RFCTYPE_CDAY | INTEGER | Calendar day |
+| (n/a — RFC parameter only) | RFCTYPE_STRUCTURE | STRUCT | Nested structure |
+| (n/a — RFC parameter only) | RFCTYPE_TABLE | LIST | Table parameter (each row is a STRUCT) |
+| (any unrecognized RFCTYPE, with `erpl_rfc_strict_type_check=false`) | — | VARCHAR | Lenient fallback (issue #53) |
+
+Notes:
+- The same mapping applies to `sap_read_table`, `sap_rfc_invoke`, and `sap_odp_*`
+  scanners because they share `RfcType::CreateDuckDbType()`. BICS characteristic
+  axes use the equivalent `bicstype2rfctype → rfctype2logicaltype` path.
+- DDIC `CLNT`, `LANG`, `CUKY`, and `UNIT` are CHAR aliases — they surface as
+  VARCHAR with a fixed width, not as a dedicated type.
+- BCD precision is capped at DuckDB's `DECIMAL(38)` maximum; SAP fields wider
+  than `DEC(20)` will be reported with `precision=38` and scale clamped to it.
 
 ---
 

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1,0 +1,986 @@
+# ERPL Extension Suite — API Reference
+
+> Complete function reference for SAP data integration in DuckDB
+
+**DuckDB Version:** >= v1.2.0
+**Extensions:** erpl_rfc, erpl_bics, erpl_odp, erpl_tunnel
+
+---
+
+## Overview
+
+The ERPL extension suite brings SAP data integration directly into DuckDB. It enables analysts, data engineers, and scientists to query SAP ERP tables, SAP BW cubes, and replicate data using familiar SQL — no middleware, no data movement.
+
+**Key Benefits:**
+- **SQL-native**: All operations expressed as SQL functions, pragmas, and secrets
+- **Zero middleware**: Connect directly to SAP via RFC and BICS protocols
+- **Parallel extraction**: Multi-threaded reads for large tables
+- **Virtual catalog**: ATTACH SAP systems as DuckDB databases
+
+| Extension | Purpose |
+|-----------|---------|
+| **erpl_rfc** | Core SAP RFC connectivity — table reads, function calls, metadata |
+| **erpl_bics** | SAP BW queries via BICS — cubes, hierarchies, lineage |
+| **erpl_odp** | SAP ODP data extraction and replication |
+| **erpl_tunnel** | SSH tunneling for secure SAP connections |
+
+---
+
+## Quick Start
+
+```sql
+-- 1. Install and load
+INSTALL 'erpl' FROM 'http://get.erpl.io';
+LOAD 'erpl';
+
+-- 2. Create SAP connection secret
+CREATE SECRET my_sap (
+    TYPE sap_rfc,
+    ASHOST 'sap-server.example.com',
+    SYSNR '00',
+    CLIENT '100',
+    USER 'DEVELOPER',
+    PASSWD 'secret',
+    LANG 'EN'
+);
+
+-- 3. Read a table
+SELECT * FROM sap_read_table('SFLIGHT');
+
+-- 4. Attach SAP as a virtual database
+ATTACH '' AS sap (TYPE sap_rfc);
+SELECT * FROM sap."SFLIGHT" WHERE CARRID = 'LH';
+
+-- 5. Query SAP BW
+SELECT * FROM sap_bics_show_cubes();
+```
+
+---
+
+## Quick Reference
+
+| Function | Purpose | Example |
+|----------|---------|---------|
+| `sap_read_table` | Read SAP table data | `SELECT * FROM sap_read_table('SFLIGHT')` |
+| `sap_rfc_invoke` | Call any RFC function | `SELECT * FROM sap_rfc_invoke('STFC_CONNECTION', {'REQUTEXT': 'Hi'})` |
+| `sap_show_tables` | Search SAP tables | `SELECT * FROM sap_show_tables(TABLENAME='*FLIGHT*')` |
+| `sap_describe_fields` | Get table field metadata | `SELECT * FROM sap_describe_fields('SFLIGHT')` |
+| `sap_bics_show_cubes` | List BW cubes | `SELECT * FROM sap_bics_show_cubes()` |
+| `sap_bics_hierarchy` | Extract BW hierarchy | `SELECT * FROM sap_bics_hierarchy('MY_HIER')` |
+| `sap_odp_read_full` | Extract ODP data | `SELECT * FROM sap_odp_read_full('BW', 'MY_ODP')` |
+| `ATTACH` | Mount SAP as database | `ATTACH '' AS sap (TYPE sap_rfc)` |
+
+---
+
+## erpl_rfc — SAP RFC Connectivity
+
+### Data Access
+
+#### `sap_read_table(table_name [, THREADS, COLUMNS, FILTER, ...])`
+
+Read data from an SAP table or CDS view. Supports projection pushdown, filter pushdown, and parallel reads.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `table_name` | VARCHAR | *required* | SAP table or CDS view name |
+| `THREADS` | UINTEGER | 0 | Number of parallel read threads |
+| `COLUMNS` | LIST(VARCHAR) | all | Columns to retrieve |
+| `FILTER` | VARCHAR | — | SAP WHERE clause filter |
+| `MAX_ROWS` | UINTEGER | 0 (all) | Maximum rows to return |
+| `READ_TABLE_FUNCTION` | VARCHAR | `'RFC_READ_TABLE'` | RFC function to use (see note) |
+| `READ_TABLE_DELIMITER` | VARCHAR | — | Delimiter for TABLE2 variants |
+| `SECRET` | VARCHAR | — | Named secret to use |
+
+**Supported `READ_TABLE_FUNCTION` values:** `RFC_READ_TABLE`, `/BODS/RFC_READ_TABLE`, `/SAPDS/RFC_READ_TABLE`, `/BODS/RFC_READ_TABLE2`, `/SAPDS/RFC_READ_TABLE2`
+
+```sql
+-- Basic read
+SELECT * FROM sap_read_table('SFLIGHT');
+
+-- With DuckDB filter pushdown (automatically pushed to SAP)
+SELECT * FROM sap_read_table('SFLIGHT') WHERE CARRID = 'LH';
+
+-- SAP-side filter, column selection, parallel threads, row limit
+SELECT * FROM sap_read_table('SFLIGHT',
+    COLUMNS=['CARRID', 'CONNID', 'FLDATE'],
+    FILTER='CARRID = ''LH''',
+    THREADS=4,
+    MAX_ROWS=1000
+);
+
+-- Using a named secret
+SELECT * FROM sap_read_table('SFLIGHT', SECRET='my_sap');
+```
+
+---
+
+#### `sap_rfc_invoke(function_name, ...args [, path, secret])`
+
+Invoke any SAP RFC function module. Accepts variable arguments as STRUCT or scalar values.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `function_name` | VARCHAR | *required* | RFC function module name |
+| `...args` | ANY (varargs) | — | Function parameters as structs/values |
+| `path` | VARCHAR | — | Path to select specific output (e.g. `'/RFCTABLE'`) |
+| `secret` | VARCHAR | — | Named secret to use |
+
+```sql
+-- Simple function call
+SELECT * FROM sap_rfc_invoke('STFC_CONNECTION', {'REQUTEXT': 'Hello SAP'});
+
+-- Select specific output table via path
+SELECT * FROM sap_rfc_invoke('BAPI_FLIGHT_GETLIST',
+    {'AIRLINE': 'LH'},
+    path='/FLIGHT_LIST'
+);
+```
+
+---
+
+### Discovery & Metadata
+
+#### `sap_show_tables([TABLENAME, TEXT, THREADS])`
+
+Search for SAP tables and views. No positional arguments.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `TABLENAME` | VARCHAR | `'%'` | Table name pattern (supports `*` and `%` wildcards) |
+| `TEXT` | VARCHAR | `'%'` | Description text pattern |
+| `THREADS` | UINTEGER | 0 | Parallel read threads |
+
+**Returns:** `table_name`, `text`, `class` (VIEW, TRANSP, POOL, CLUSTER)
+
+```sql
+SELECT * FROM sap_show_tables(TABLENAME='*FLIGHT*');
+SELECT * FROM sap_show_tables(TEXT='%booking%');
+```
+
+---
+
+#### `sap_describe_fields(table_name [, LANGUAGE])`
+
+Get field metadata for an SAP table or view.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `table_name` | VARCHAR | *required* | Table/view name |
+| `LANGUAGE` | VARCHAR | `'E'` | Language for descriptions |
+
+**Returns:** `pos`, `is_key`, `field`, `text`, `sap_type`, `length`, `decimals`, `check_table`, `ref_table`, `ref_field`, `language`
+
+```sql
+SELECT field, is_key, sap_type, length FROM sap_describe_fields('SFLIGHT');
+```
+
+---
+
+#### `sap_rfc_show_function([FUNCNAME, GROUPNAME, LANGUAGE])`
+
+Search for RFC function modules by name or group.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `FUNCNAME` | VARCHAR | `'*'` | Function name pattern (wildcard `*`) |
+| `GROUPNAME` | VARCHAR | — | Function group name pattern |
+| `LANGUAGE` | VARCHAR | — | Language for descriptions |
+
+```sql
+SELECT * FROM sap_rfc_show_function(FUNCNAME='BAPI_FLIGHT*');
+SELECT * FROM sap_rfc_show_function(GROUPNAME='RSBOLAP_BICS');
+```
+
+---
+
+#### `sap_rfc_show_groups([GROUPNAME, LANGUAGE])`
+
+Search for RFC function groups.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `GROUPNAME` | VARCHAR | `'*'` | Group name pattern (wildcard `*`) |
+| `LANGUAGE` | VARCHAR | — | Language for descriptions |
+
+**Returns:** `name`, `text`
+
+```sql
+SELECT * FROM sap_rfc_show_groups(GROUPNAME='RSBOLAP*');
+```
+
+---
+
+#### `sap_rfc_describe_function(function_name)`
+
+Get detailed metadata about an RFC function module (parameters, types, structures).
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `function_name` | VARCHAR | *required* | Function module name |
+
+```sql
+SELECT * FROM sap_rfc_describe_function('STFC_CONNECTION');
+```
+
+---
+
+### Connection & Diagnostics
+
+#### `PRAGMA sap_rfc_ping([secret])`
+
+Test SAP RFC connection. Returns `'PONG'` on success.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `secret` | VARCHAR | — | Named secret to use |
+
+```sql
+PRAGMA sap_rfc_ping;
+PRAGMA sap_rfc_ping(secret='my_sap');
+```
+
+---
+
+#### `PRAGMA sap_rfc_set_trace_level(level)`
+
+Set SAP NetWeaver RFC SDK trace level.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `level` | INTEGER | 0=Off, 1=Brief, 2=Verbose, 3=Detailed, 4=Full |
+
+```sql
+PRAGMA sap_rfc_set_trace_level(2);
+```
+
+---
+
+#### `PRAGMA sap_rfc_set_trace_dir(directory)`
+
+Set directory for SAP RFC SDK trace files.
+
+```sql
+PRAGMA sap_rfc_set_trace_dir('/tmp/sap_traces');
+```
+
+---
+
+#### `PRAGMA sap_rfc_set_maximum_trace_file_size(size, unit)`
+
+Set maximum size for SAP RFC trace files.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `size` | INTEGER | File size value |
+| `unit` | ENUM | `'M'` (megabytes) or `'G'` (gigabytes) |
+
+```sql
+PRAGMA sap_rfc_set_maximum_trace_file_size(100, 'M');
+```
+
+---
+
+#### `PRAGMA sap_rfc_set_maximum_stored_trace_files(count)`
+
+Set maximum number of trace files to keep.
+
+```sql
+PRAGMA sap_rfc_set_maximum_stored_trace_files(10);
+```
+
+---
+
+#### `PRAGMA sap_rfc_set_ini_path(path)`
+
+Set path to SAP RFC INI configuration file (`sapnwrfc.ini`).
+
+```sql
+PRAGMA sap_rfc_set_ini_path('/etc/sap/sapnwrfc.ini');
+```
+
+---
+
+#### `PRAGMA sap_rfc_reload_ini_file`
+
+Reload the SAP RFC INI configuration file.
+
+```sql
+PRAGMA sap_rfc_reload_ini_file;
+```
+
+---
+
+### ATTACH — Virtual SAP Catalog
+
+Attach an SAP system as a virtual DuckDB database. Tables appear as views backed by `sap_read_table()`.
+
+```sql
+-- Attach with default secret
+ATTACH '' AS sap (TYPE sap_rfc);
+SELECT * FROM sap."SFLIGHT";
+
+-- Attach with named secret
+ATTACH '' AS sap (TYPE sap_rfc, SECRET 'my_sap');
+
+-- Restrict to specific tables
+ATTACH '' AS sap (TYPE sap_rfc, TABLES 'SFLIGHT,SPFLI,SCARR');
+
+-- Detach
+DETACH sap;
+```
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `TYPE` | — | Must be `sap_rfc` |
+| `SECRET` | VARCHAR | Named secret for SAP connection |
+| `TABLES` | VARCHAR | Comma-separated list of tables to expose (empty = on-demand) |
+
+---
+
+## erpl_bics — SAP Business Warehouse
+
+### Discovery
+
+#### `sap_bics_show([obj_type, search, search_in_key, search_in_text, fetch_levels, secret])`
+
+List InfoProviders, cubes, queries, or info areas.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `obj_type` | ENUM | — | `'INFOPROVIDER'`, `'QUERY'`, `'CUBE'`, `'INFOAREA'` |
+| `search` | VARCHAR | — | Search pattern (supports wildcards) |
+| `search_in_key` | BOOLEAN | — | Search in technical names |
+| `search_in_text` | BOOLEAN | — | Search in descriptions |
+| `fetch_levels` | UINTEGER | — | Number of hierarchy levels to fetch |
+| `secret` | VARCHAR | — | Named secret to use |
+
+**Returns:** `technical_name`, `text`, `type`, `cube_name`, `is_folder`, `last_changed`, `last_changed_by`, `level`
+
+```sql
+SELECT * FROM sap_bics_show();
+SELECT * FROM sap_bics_show(obj_type='QUERY', search='*SALES*');
+```
+
+---
+
+#### `sap_bics_show_cubes([search, search_in_key, search_in_text, secret])`
+
+Convenience function to list only BW cubes. Same parameters as `sap_bics_show` minus `obj_type`.
+
+```sql
+SELECT * FROM sap_bics_show_cubes();
+SELECT * FROM sap_bics_show_cubes(search='*SALES*');
+```
+
+---
+
+#### `sap_bics_show_queries([search, search_in_key, search_in_text, secret])`
+
+Convenience function to list only BW queries.
+
+```sql
+SELECT * FROM sap_bics_show_queries();
+```
+
+---
+
+#### `sap_bics_show_hierarchies([search, info_object, secret])`
+
+List available BW hierarchies.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `search` | VARCHAR | — | Search pattern for hierarchy names |
+| `info_object` | VARCHAR | — | Filter by InfoObject |
+| `secret` | VARCHAR | — | Named secret |
+
+**Returns:** `technical_name`, `text`, `version`, `valid_to_date`
+
+```sql
+SELECT * FROM sap_bics_show_hierarchies();
+SELECT * FROM sap_bics_show_hierarchies(info_object='0COSTCENTER');
+```
+
+---
+
+### Describe
+
+#### `sap_bics_describe(cube_name [, query_name, id, version, secret])`
+
+Retrieve metadata structure for cubes or queries.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `cube_name` | VARCHAR | *required* | Cube technical name |
+| `query_name` | VARCHAR | — | Query technical name |
+| `id` | VARCHAR | — | State ID for persisted session |
+| `version` | UINTEGER | — | State version |
+| `secret` | VARCHAR | — | Named secret |
+
+```sql
+-- Describe a cube
+SELECT * FROM sap_bics_describe('MY_CUBE');
+
+-- Describe a query
+SELECT * FROM sap_bics_describe('MY_CUBE', 'MY_QUERY');
+```
+
+---
+
+#### `sap_bics_describe_infoobject(info_object_name [, secret])`
+
+Get technical details about a BW InfoObject.
+
+**Returns:** `info_object`, `data_type`, `conv_exit`, `output_length`, `length`, `decimals`
+
+```sql
+SELECT * FROM sap_bics_describe_infoobject('0COSTCENTER');
+```
+
+---
+
+### Hierarchy Extraction
+
+#### `sap_bics_hierarchy(hierarchy_name [, version, date_to, secret])`
+
+Extract hierarchy structure with node relationships and paths.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `hierarchy_name` | VARCHAR | *required* | Hierarchy technical name |
+| `version` | VARCHAR | `'A'` | Hierarchy version |
+| `date_to` | VARCHAR | — | Valid-to date (`YYYYMMDD`) |
+| `secret` | VARCHAR | — | Named secret |
+
+**Returns:** `node_id`, `parent_id`, `child_id`, `next_id`, `info_object`, `node_name`, `node_value`, `date_from`, `date_to`, `level`, `path`
+
+```sql
+SELECT * FROM sap_bics_hierarchy('ZCOSTCENTER_H01');
+SELECT * FROM sap_bics_hierarchy('ZCOSTCENTER_H01', version='A', date_to='20251231');
+```
+
+---
+
+### Query Workflow (Stateful)
+
+BICS queries use a stateful workflow: initialize a session, configure axes and filters, then fetch results.
+
+#### Step 1: `sap_bics_begin(cube_name [, id, return, secret])`
+
+Initialize a BICS query session.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `cube_name` | VARCHAR | *required* | Cube technical name |
+| `id` | VARCHAR | — | User-defined state ID |
+| `return` | BICS_RETURN | `'DESCRIBE'` | `'DESCRIBE'` for metadata, `'RESULT'` for data |
+| `secret` | VARCHAR | — | Named secret |
+
+```sql
+SELECT * FROM sap_bics_begin('MY_CUBE', id='my_session');
+```
+
+#### Step 2: `sap_bics_rows(state_id, char1 [, char2, ..., op, return])`
+
+Configure row axis characteristics.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `state_id` | VARCHAR | *required* | State ID from `sap_bics_begin` |
+| `char1, ...` | VARCHAR | *required* | Characteristics to add/set |
+| `op` | BICS_OPERATION | `'ADD'` | `'SET'`, `'ADD'`, or `'REMOVE'` |
+| `return` | BICS_RETURN | `'DESCRIBE'` | Return format |
+
+```sql
+SELECT * FROM sap_bics_rows('my_session', '0CALDAY', '0MATERIAL');
+```
+
+#### Step 2b: `sap_bics_columns(state_id, char1 [, char2, ..., op, return])`
+
+Configure column axis characteristics. Same signature as `sap_bics_rows`.
+
+```sql
+SELECT * FROM sap_bics_columns('my_session', '0AMOUNT', op='SET');
+```
+
+#### Step 3: `sap_bics_filter(state_id, filters [, op, return])`
+
+Apply filters to query.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `state_id` | VARCHAR | *required* | State ID |
+| `filters` | varies | *required* | Filter definitions |
+| `op` | BICS_OPERATION | — | Operation type |
+| `return` | BICS_RETURN | `'DESCRIBE'` | Return format |
+
+#### Step 4: `sap_bics_result(state_id)`
+
+Fetch result set from configured query state.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `state_id` | VARCHAR | *required* | State ID |
+
+```sql
+-- Complete workflow
+SELECT * FROM sap_bics_begin('MY_CUBE', id='q1');
+SELECT * FROM sap_bics_rows('q1', '0CALDAY', '0MATERIAL');
+SELECT * FROM sap_bics_columns('q1', '0AMOUNT');
+SELECT * FROM sap_bics_result('q1');
+```
+
+---
+
+### Metadata Views
+
+Functions for extracting BW system metadata. All accept an optional `secret` parameter.
+
+| Function | Description |
+|----------|-------------|
+| `sap_bics_meta_providers([provider_type, secret])` | List BW InfoProviders by type (CUBE, ADSO, HCPR, ODSO, ODSVIEW) |
+| `sap_bics_meta_provider_fields(provider_name [, secret])` | Fields/characteristics for a provider |
+| `sap_bics_meta_datasources([secret])` | List all DataSources |
+| `sap_bics_meta_datasource_fields(datasource_name [, secret])` | Fields for a DataSource |
+| `sap_bics_meta_transformations([secret])` | List all transformations |
+| `sap_bics_meta_transform_fields(transformation_name [, secret])` | Field mappings and rules |
+| `sap_bics_meta_hcpr([secret])` | List all CompositeProviders |
+| `sap_bics_meta_hcpr_mapping(hcpr_name [, secret])` | Field mappings for CompositeProviders |
+| `sap_bics_meta_queries([secret])` | List all BW queries |
+| `sap_bics_meta_query_usage(query_name [, secret])` | Query usage and dependencies |
+| `sap_bics_meta_query_elements(query_name [, secret])` | Detailed query structure elements |
+| `sap_bics_meta_query_stats([secret])` | Query performance and usage statistics |
+| `sap_bics_meta_objxref([secret])` | Dependencies between BW objects |
+| `sap_bics_meta_infoobjects([secret])` | List all InfoObjects |
+
+```sql
+SELECT * FROM sap_bics_meta_providers(provider_type='CUBE');
+SELECT * FROM sap_bics_meta_provider_fields('MY_CUBE');
+SELECT * FROM sap_bics_meta_queries();
+```
+
+---
+
+### Lineage & Impact Analysis
+
+Functions for BW data lineage extraction. All accept an optional `secret` parameter.
+
+#### `sap_bics_lineage_edges([scope, secret])`
+
+Extract lineage edges between BW objects.
+
+**Returns:** `edge_type`, `src_kind`, `src_name`, `src_field`, `tgt_kind`, `tgt_name`, `tgt_field`
+
+```sql
+SELECT * FROM sap_bics_lineage_edges();
+```
+
+---
+
+#### `sap_bics_lineage_graph_json([scope, secret])`
+
+Full lineage graph in JSON format.
+
+```sql
+SELECT * FROM sap_bics_lineage_graph_json();
+```
+
+---
+
+#### `sap_bics_lineage_trace(object_name [, secret])`
+
+Trace lineage from a specific object.
+
+```sql
+SELECT * FROM sap_bics_lineage_trace('MY_CUBE');
+```
+
+---
+
+#### `sap_bics_query_lineage(query_name [, secret])`
+
+Complete field-level lineage for a specific BW query.
+
+```sql
+SELECT * FROM sap_bics_query_lineage('MY_QUERY');
+```
+
+---
+
+## erpl_odp — SAP Operational Data Provisioning
+
+### Discovery
+
+#### `sap_odp_show_contexts([secret])`
+
+List available ODP contexts.
+
+**Returns:** `technical_name`, `text`, `release`
+
+```sql
+SELECT * FROM sap_odp_show_contexts();
+-- Typical contexts: BW, ABAP_CDS, SAPI, SLT, HANA
+```
+
+---
+
+#### `sap_odp_show(odp_context [, search, secret])`
+
+List ODP providers/sources within a context.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `odp_context` | VARCHAR | *required* | ODP context (e.g. `'BW'`, `'ABAP_CDS'`, `'SAPI'`) |
+| `search` | VARCHAR | — | Search pattern (wildcards) |
+| `secret` | VARCHAR | — | Named secret |
+
+**Returns:** `technical_name`, `text`, `semantics`, `semantics_text`
+
+```sql
+SELECT * FROM sap_odp_show('BW');
+SELECT * FROM sap_odp_show('ABAP_CDS', search='*FLIGHT*');
+```
+
+---
+
+#### `sap_odp_describe(odp_context, odp_name [, secret])`
+
+Get detailed metadata about an ODP provider.
+
+```sql
+SELECT * FROM sap_odp_describe('BW', 'MY_ODP_SOURCE');
+```
+
+---
+
+### Data Extraction
+
+#### `sap_odp_preview(odp_context, odp_name [, secret])`
+
+Preview a small sample of data from an ODP provider.
+
+```sql
+SELECT * FROM sap_odp_preview('BW', 'MY_ODP_SOURCE');
+```
+
+---
+
+#### `sap_odp_read_full(odp_context, odp_name [, threads, columns, filters, secret])`
+
+Full extraction of ODP provider data with parallel processing.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `odp_context` | VARCHAR | *required* | ODP context |
+| `odp_name` | VARCHAR | *required* | ODP provider name |
+| `threads` | UINTEGER | 5 | Parallel read threads |
+| `columns` | LIST(VARCHAR) | all | Columns to extract |
+| `filters` | LIST | — | Selection filters |
+| `secret` | VARCHAR | — | Named secret |
+
+```sql
+SELECT * FROM sap_odp_read_full('BW', 'MY_ODP_SOURCE');
+SELECT * FROM sap_odp_read_full('ABAP_CDS', 'MY_CDS_VIEW', threads=8);
+```
+
+---
+
+### Subscription Management
+
+#### `sap_odp_show_subscriptions([secret])`
+
+List active ODP subscriptions.
+
+```sql
+SELECT * FROM sap_odp_show_subscriptions();
+```
+
+---
+
+#### `sap_odp_show_cursors([secret])`
+
+List ODP extraction cursors for delta tracking.
+
+```sql
+SELECT * FROM sap_odp_show_cursors();
+```
+
+---
+
+#### `PRAGMA odp_drop(subscription_id)`
+
+Drop/delete an ODP subscription.
+
+```sql
+PRAGMA odp_drop('SUB_12345');
+```
+
+---
+
+## erpl_tunnel — SSH Tunneling
+
+### Tunnel Management
+
+#### `PRAGMA tunnel_create([secret, remote_host, remote_port, local_port, timeout])`
+
+Create a new SSH tunnel for port forwarding.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `secret` | VARCHAR | — | SSH tunnel secret name |
+| `remote_host` | VARCHAR | *required* | Target host to tunnel to |
+| `remote_port` | INTEGER | *required* | Target port |
+| `local_port` | INTEGER | *required* | Local port to bind |
+| `timeout` | INTEGER | 60 | Connection timeout in seconds |
+
+**Returns:** `tunnel_id`, `message`
+
+```sql
+PRAGMA tunnel_create(
+    secret='my_ssh',
+    remote_host='sap-internal.corp',
+    remote_port=3300,
+    local_port=13300
+);
+```
+
+---
+
+#### `PRAGMA tunnel_close(tunnel_id)`
+
+Close a specific tunnel by ID.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tunnel_id` | INTEGER | Tunnel ID to close |
+
+```sql
+PRAGMA tunnel_close(1);
+```
+
+---
+
+#### `PRAGMA tunnel_close_all`
+
+Close all active tunnels.
+
+```sql
+PRAGMA tunnel_close_all;
+```
+
+---
+
+#### `tunnels()`
+
+List all active SSH tunnels.
+
+**Returns:** `tunnel_id` (BIGINT), `ssh_host` (VARCHAR), `ssh_port` (INTEGER), `ssh_user` (VARCHAR), `remote_host` (VARCHAR), `remote_port` (INTEGER), `local_port` (INTEGER), `status` (VARCHAR)
+
+```sql
+SELECT * FROM tunnels();
+```
+
+---
+
+## Reference
+
+### Secret Types
+
+#### `sap_rfc` — SAP RFC Connection
+
+All parameters are VARCHAR. Choose either direct connection or load-balanced parameters.
+
+| Parameter | Description | Direct | Load-Balanced |
+|-----------|-------------|:------:|:-------------:|
+| `ashost` | Application server host | required | — |
+| `sysnr` | System number | required | — |
+| `mshost` | Message server host | — | required |
+| `msserv` | Message server service | — | optional |
+| `sysid` | System ID | — | required |
+| `group` | Logon group | — | required |
+| `client` | SAP client number | required | required |
+| `user` | Username | required | required |
+| `passwd` | Password (redacted) | required | required |
+| `lang` | Language (e.g. `'EN'`) | optional | optional |
+| `snc_qop` | SNC quality of protection | optional | optional |
+| `snc_myname` | SNC client name | optional | optional |
+| `snc_partnername` | SNC server name | optional | optional |
+| `snc_lib` | SNC library path | optional | optional |
+| `mysapsso2` | SSO2 ticket | optional | optional |
+
+```sql
+-- Direct connection
+CREATE SECRET my_sap (
+    TYPE sap_rfc,
+    ASHOST 'sap.example.com', SYSNR '00', CLIENT '100',
+    USER 'sapuser', PASSWD 'password', LANG 'EN'
+);
+
+-- Load-balanced connection
+CREATE SECRET my_sap_lb (
+    TYPE sap_rfc,
+    MSHOST 'sapms.example.com', SYSID 'PRD', GROUP 'PUBLIC',
+    CLIENT '100', USER 'sapuser', PASSWD 'password'
+);
+```
+
+---
+
+#### `ssh_tunnel` — SSH Tunnel Connection
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `ssh_host` | VARCHAR | *required* | SSH jump host |
+| `ssh_port` | INTEGER | 22 | SSH port |
+| `ssh_user` | VARCHAR | *required* | SSH username |
+| `password` | VARCHAR | — | SSH password (redacted) |
+| `private_key_path` | VARCHAR | — | Path to SSH private key (redacted) |
+| `passphrase` | VARCHAR | — | Private key passphrase (redacted) |
+| `auth_method` | VARCHAR | auto | `'password'`, `'key'`, or `'agent'` (auto-detected if omitted) |
+
+```sql
+-- Password authentication
+CREATE SECRET my_ssh (
+    TYPE ssh_tunnel,
+    ssh_host 'jumphost.example.com', ssh_user 'myuser',
+    password 'secret'
+);
+
+-- Key-based authentication
+CREATE SECRET my_ssh_key (
+    TYPE ssh_tunnel,
+    ssh_host 'jumphost.example.com', ssh_user 'myuser',
+    private_key_path '/home/user/.ssh/id_rsa'
+);
+```
+
+---
+
+### Custom Types
+
+| Type | Values | Used By |
+|------|--------|---------|
+| `BICS_RETURN` | `'DESCRIBE'`, `'RESULT'` | BICS query workflow functions |
+| `BICS_OPERATION` | `'SET'`, `'ADD'`, `'REMOVE'` | BICS axis/filter configuration |
+| `ODP_REPLICATION_MODE` | `'FULL'`, `'DELTA'`, `'RECOVER'` | ODP extraction mode |
+
+---
+
+### SAP ↔ DuckDB Type Mapping
+
+| SAP RFC Type | DuckDB Type | Notes |
+|-------------|-------------|-------|
+| CHAR | VARCHAR | Fixed-length, right-trimmed |
+| NUM (NUMC) | VARCHAR | Numeric characters, preserves leading zeros |
+| INT | INTEGER | 4-byte integer |
+| INT1 | TINYINT | 1-byte integer |
+| INT2 | SMALLINT | 2-byte integer |
+| INT8 | INTEGER | 8-byte mapped to INTEGER |
+| FLOAT | DOUBLE | Floating point |
+| BCD | DECIMAL | Binary coded decimal |
+| DECF16 | DECIMAL | Decimal floating point 16 |
+| DECF34 | DECIMAL | Decimal floating point 34 |
+| STRING | VARCHAR | Variable-length string |
+| XSTRING | VARCHAR | Hex string |
+| XMLDATA | VARCHAR | XML data |
+| BYTE | BLOB | Raw bytes |
+| DATE | DATE | Format YYYYMMDD |
+| TIME | TIME | Format HHMMSS |
+| UTCLONG | TIMESTAMP | UTC timestamp (long) |
+| UTCSECOND | TIMESTAMP | UTC timestamp (seconds) |
+| UTCMINUTE | TIMESTAMP | UTC timestamp (minutes) |
+| DTDAY | INTEGER | Date duration in days |
+| DTWEEK | INTEGER | Date duration in weeks |
+| DTMONTH | INTEGER | Date duration in months |
+| TSECOND | INTEGER | Time duration in seconds |
+| TMINUTE | INTEGER | Time duration in minutes |
+| CDAY | INTEGER | Calendar day |
+| STRUCTURE | STRUCT | Nested structure |
+| TABLE | LIST | Table parameter |
+
+---
+
+### Configuration Options
+
+#### erpl_rfc
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `erpl_telemetry_enabled` | BOOLEAN | `true` | Enable telemetry ([erpl.io/telemetry](https://erpl.io/telemetry)) |
+| `erpl_telemetry_key` | VARCHAR | *(built-in)* | Telemetry API key |
+| `erpl_trace_enabled` | BOOLEAN | `false` | Enable ERPL tracing |
+| `erpl_trace_level` | VARCHAR | `'INFO'` | Trace level: TRACE, DEBUG, INFO, WARN, ERROR, NONE |
+| `erpl_trace_output` | VARCHAR | `'console'` | Output: console, file, both |
+| `erpl_trace_file_path` | VARCHAR | `'trace'` | Trace file directory |
+| `erpl_trace_max_file_size` | BIGINT | 0 (unlimited) | Max trace file size in bytes |
+| `erpl_trace_rotation` | BOOLEAN | `false` | Enable trace file rotation |
+| `erpl_rfc_strict_type_check` | BOOLEAN | `false` | When true, throw an error on unsupported SAP RFC types instead of falling back to VARCHAR |
+
+```sql
+SET erpl_trace_enabled = TRUE;
+SET erpl_trace_level = 'DEBUG';
+SET erpl_trace_output = 'both';
+```
+
+#### erpl_bics
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `erpl_bics_trace` | BOOLEAN | `false` | Enable BICS trace logging |
+| `erpl_bics_trace_dir` | VARCHAR | `'./trace'` | BICS trace directory |
+
+#### erpl_tunnel
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `erpl_telemetry_enabled` | BOOLEAN | `true` | Enable telemetry |
+| `erpl_telemetry_key` | VARCHAR | *(built-in)* | Telemetry API key |
+
+---
+
+## Notes
+
+### Filter Pushdown
+
+`sap_read_table` supports both SAP-side and DuckDB-side filter pushdown:
+
+```sql
+-- SAP-side filter (via FILTER parameter, pushed to RFC_READ_TABLE)
+SELECT * FROM sap_read_table('SFLIGHT', FILTER='CARRID = ''LH''');
+
+-- DuckDB-side filter pushdown (automatically pushed to SAP when possible)
+SELECT * FROM sap_read_table('SFLIGHT') WHERE CARRID = 'LH';
+```
+
+### Parallel Reads
+
+Use the `THREADS` parameter on `sap_read_table` and `sap_odp_read_full` for large tables:
+
+```sql
+SELECT * FROM sap_read_table('LARGE_TABLE', THREADS=8);
+```
+
+### SSH Tunnel + SAP Connection
+
+Complete workflow for connecting through an SSH jump host:
+
+```sql
+-- 1. Create SSH tunnel secret
+CREATE SECRET my_ssh (TYPE ssh_tunnel, ssh_host 'jump.example.com', ssh_user 'user', password 'pw');
+
+-- 2. Create tunnel
+PRAGMA tunnel_create(secret='my_ssh', remote_host='sap.internal', remote_port=3300, local_port=13300);
+
+-- 3. Create SAP connection pointing to local tunnel port
+CREATE SECRET my_sap (TYPE sap_rfc, ASHOST 'localhost', SYSNR '00', CLIENT '100', USER 'sap', PASSWD 'pw');
+
+-- 4. Query through tunnel
+SELECT * FROM sap_read_table('SFLIGHT');
+
+-- 5. Cleanup
+PRAGMA tunnel_close_all;
+```
+
+---
+
+**Last Updated:** 2026-02-11

--- a/rfc/src/erpl_rfc_extension.cpp
+++ b/rfc/src/erpl_rfc_extension.cpp
@@ -20,6 +20,7 @@
 
 #include "telemetry.hpp"
 #include "sap_connection.hpp"
+#include "sap_function.hpp"
 #include "sap_secret.hpp"
 #include "sap_storage.hpp"
 #include "erpl_tracing.hpp"
@@ -134,6 +135,10 @@ namespace duckdb {
         erpl::ErplTracer::Instance().SetRotation(parameter.GetValue<bool>());
     }
 
+    static void OnStrictTypeCheck(ClientContext &, SetScope, Value &parameter) {
+        SetRfcStrictTypeCheck(parameter.GetValue<bool>());
+    }
+
     static void RegisterConfiguration(ExtensionLoader &loader)
     {
         auto &instance = loader.GetDatabaseInstance();
@@ -155,6 +160,13 @@ namespace duckdb {
                                   LogicalType::BIGINT, Value::BIGINT(0), OnTraceMaxFileSize);
         config.AddExtensionOption("erpl_trace_rotation", "Enable ERPL RFC trace file rotation", LogicalType::BOOLEAN,
                                   Value(false), OnTraceRotation);
+
+        config.AddExtensionOption(
+            "erpl_rfc_strict_type_check",
+            "When true, throw an error on unsupported SAP RFC types instead of falling back to VARCHAR",
+            LogicalType::BOOLEAN,
+            Value(false),
+            OnStrictTypeCheck);
 
         auto provider = make_uniq<RfcEnvironmentCredentialsProvider>(config);
         provider->SetAll();

--- a/rfc/src/include/sap_function.hpp
+++ b/rfc/src/include/sap_function.hpp
@@ -8,6 +8,9 @@
 
 namespace duckdb {
 
+void SetRfcStrictTypeCheck(bool strict);
+bool GetRfcStrictTypeCheck();
+
     class IConvertToSqlLiteral
     {
         public:

--- a/rfc/src/include/sap_function.hpp
+++ b/rfc/src/include/sap_function.hpp
@@ -302,6 +302,11 @@ bool GetRfcStrictTypeCheck();
 
         std::shared_ptr<RfcInvocation> invocation;
         std::shared_ptr<RfcResultSet> result_set;
+        // When the called RFC has no export/changing/table parameters
+        // (e.g. RFC_PING), we synthesize a single boolean 'ok' column.
+        // `ok_only` flags that mode; `ok_only_emitted` tracks the one row.
+        bool ok_only = false;
+        bool ok_only_emitted = false;
 
         std::vector<std::string> GetFieldNames();
         std::vector<std::string> GetResultNames();

--- a/rfc/src/include/sap_rfc.hpp
+++ b/rfc/src/include/sap_rfc.hpp
@@ -139,7 +139,6 @@ namespace duckdb
 			duckdb::unique_ptr<RfcReadColumnTask> CreateTaskForNextStep(duckdb::TaskExecutor &executor, duckdb::Vector &column_output);
 			unsigned int GetRfcColumnIndex();
 			unsigned int GetProjectedColumnIndex();
-			std::shared_ptr<RfcConnection> GetConnection();
 			bool IsRowIdColumnId();
 			void SetRowIdColumnId();
 			unsigned int GetCardinality();
@@ -163,7 +162,6 @@ namespace duckdb
 			RfcReadTableBindData *bind_data;
 			ReadTableStates current_state = ReadTableStates::INIT;
 			std::shared_ptr<RfcResultSet> current_result_data = nullptr;
-			std::shared_ptr<RfcConnection> current_connection = nullptr;
 
 			std::mutex thread_lock;
 	};

--- a/rfc/src/include/sap_type_conversion.hpp
+++ b/rfc/src/include/sap_type_conversion.hpp
@@ -26,6 +26,13 @@ namespace duckdb
     void ltrim(std::string &s);
     Value bcd2duck(std::string &bcd_str, unsigned int length, unsigned int decimals);
 
+    // SAP UTCLONG/UTCSECOND/UTCMINUTE <-> DuckDB TIMESTAMP.
+    // SAP-side format: "YYYYMMDDHHMMSS,sssssss" (UTCLONG, comma decimal
+    // separator), or shorter forms for UTCSECOND/UTCMINUTE. Empty input
+    // (or an all-zero "00000000000000" zero-timestamp) maps to NULL.
+    Value sap_utc2timestamp(std::string &utc_str);
+    std::string timestamp2sap_utc(const Value &timestamp_value);
+
     Value rfc2duck(RFC_DATE &rfc_date);
     Value rfc2duck(const RFC_DATE &rfc_date);
     Value rfc2duck(RFC_TIME &rfc_time);

--- a/rfc/src/include/scanner_describe_function.hpp
+++ b/rfc/src/include/scanner_describe_function.hpp
@@ -18,10 +18,15 @@ public:
         : _function(function), _RPY_FUNCTIONMODULE_READ(RPY_FUNCTIONMODULE_READ), _done(false)
     { }
 
-    static std::unique_ptr<RfcDescribeFunctionBindData> FromFunctionHandleAndResultSet(std::shared_ptr<RfcFunction> function, 
-                                                                                       std::shared_ptr<RfcResultSet> result_set) 
+    static std::unique_ptr<RfcDescribeFunctionBindData> FromFunctionHandleAndResultSet(std::shared_ptr<RfcFunction> function,
+                                                                                       std::shared_ptr<RfcResultSet> result_set)
     {
-        auto result_value = std::make_shared<Value>(result_set->GetResultValue());
+        // result_set may be null when RPY_FUNCTIONMODULE_READ couldn't be
+        // called (e.g. FL180 "Source wider than 72 char"); in that case the
+        // metadata fields fall back to NULL/empty.
+        auto result_value = result_set != nullptr
+            ? std::make_shared<Value>(result_set->GetResultValue())
+            : std::shared_ptr<Value>();
         return std::make_unique<RfcDescribeFunctionBindData>(function, result_value);
     }
 
@@ -119,7 +124,12 @@ private:
     std::shared_ptr<Value> _RPY_FUNCTIONMODULE_READ;
     bool _done;
 
-    ValueHelper Helper() 
+    bool HasRpyMetadata() const
+    {
+        return _RPY_FUNCTIONMODULE_READ != nullptr;
+    }
+
+    ValueHelper Helper()
     {
         return ValueHelper(*_RPY_FUNCTIONMODULE_READ);
     }
@@ -173,15 +183,18 @@ private:
         return Value::STRUCT(param_value);
     }
 
-    Value ShortText() { return Helper()["SHORT_TEXT"]; }
-    Value RemoteCall() { return Helper()["REMOTE_CALL"]; }
-    Value FunctionPool() { return Helper()["FUNCTION_POOL"]; }
-    Value Source() 
+    Value ShortText()    { return HasRpyMetadata() ? Helper()["SHORT_TEXT"]    : Value(LogicalType::VARCHAR); }
+    Value RemoteCall()   { return HasRpyMetadata() ? Helper()["REMOTE_CALL"]   : Value(LogicalType::VARCHAR); }
+    Value FunctionPool() { return HasRpyMetadata() ? Helper()["FUNCTION_POOL"] : Value(LogicalType::VARCHAR); }
+    Value Source()
     {
+        if (!HasRpyMetadata()) {
+            return Value(LogicalType::VARCHAR);
+        }
         std::stringstream ss;
 
         auto source_lines = ListValue::GetChildren(Helper()["SOURCE"]);
-        for (auto &line : source_lines) 
+        for (auto &line : source_lines)
         {
             ss << ValueHelper(line)["LINE"].ToString() << std::endl;
         }

--- a/rfc/src/sap_function.cpp
+++ b/rfc/src/sap_function.cpp
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <set>
 #include <stdexcept>
 
@@ -6,7 +7,12 @@
 #include "duckdb_argument_helper.hpp"
 #include "sap_function.hpp"
 
+static std::atomic<bool> g_rfc_strict_type_check{false};
+
 namespace duckdb {
+
+void SetRfcStrictTypeCheck(bool strict) { g_rfc_strict_type_check.store(strict, std::memory_order_relaxed); }
+bool GetRfcStrictTypeCheck()            { return g_rfc_strict_type_check.load(std::memory_order_relaxed); }
 RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_desc)
     { 
         _type = std::make_shared<RfcType>(sap_desc.type, sap_desc.typeDescHandle, GetLength(), GetDecimals());
@@ -197,8 +203,8 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
             case RFCTYPE_INT2:
                 return LogicalType::SMALLINT;
                 break;
-            case RFCTYPE_INT8: 
-                return LogicalType::INTEGER;
+            case RFCTYPE_INT8:
+                return LogicalType::BIGINT;
                 break;
             case RFCTYPE_FLOAT:
                 return LogicalType::DOUBLE;
@@ -255,8 +261,10 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
                 break;
             }
             default:
-                throw std::runtime_error(StringUtil::Format("Unknown RFC type: %d", _rfc_type));
-                break;
+                if (GetRfcStrictTypeCheck()) {
+                    throw InvalidInputException("Unknown SAP RFC type: %d — set erpl_rfc_strict_type_check=false to fall back to VARCHAR", _rfc_type);
+                }
+                return LogicalType::VARCHAR;
         }
     }
 
@@ -365,7 +373,9 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
             }
             case RFCTYPE_XSTRING:
             {
-                throw std::logic_error("XSTRING type is not supported yet");
+                if (GetRfcStrictTypeCheck()) {
+                    throw InvalidInputException("XSTRING input is not supported — set erpl_rfc_strict_type_check=false to skip");
+                }
                 break;
             }
             // Binary types
@@ -403,9 +413,9 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
             }
             case RFCTYPE_UTCLONG:
             {
-                throw std::logic_error("UTCLONG type is not supported yet");
-                auto string_value = std2uc(arg_value.GetValue<std::string>());
-                rc = RfcSetString(container_handle, sap_arg_name.get(), string_value.get(), strlenU(string_value.get()), &error_info);
+                if (GetRfcStrictTypeCheck()) {
+                    throw InvalidInputException("UTCLONG input is not supported — set erpl_rfc_strict_type_check=false to skip");
+                }
                 break;
             }
             // Complex types
@@ -435,7 +445,10 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
             }
             default:
             {
-                throw std::runtime_error(StringUtil::Format("RFC type %s for argument %s is not supported", rfctype2std(_rfc_type), arg_name));
+                if (GetRfcStrictTypeCheck()) {
+                    throw InvalidInputException("SAP RFC type %s for argument %s is not supported as input — set erpl_rfc_strict_type_check=false to skip", rfctype2std(_rfc_type), arg_name);
+                }
+                break;
             }
 
             if (rc != RFC_OK) {
@@ -698,15 +711,64 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
                 rc = RfcGetTable(function_handle, std2uc(field_name).get(), &table_handle, &error_info);
                 if (rc != RFC_OK)
                 {
-                    throw std::runtime_error(StringUtil::Format("Failed to get table %s: %s: %s", 
+                    throw std::runtime_error(StringUtil::Format("Failed to get table %s: %s: %s",
                                                                 rfcrc2std(error_info.code), uc2std(error_info.message)));
                 }
 
                 return ConvertRfcTable(table_handle);
             }
+            case RFCTYPE_INT8:
+            {
+                RFC_INT8 int8_value;
+                rc = RfcGetInt8(function_handle, rfc_name.get(), &int8_value, &error_info);
+                if (rc != RFC_OK) { break; }
+                return rfc2duck(int8_value);
+            }
+            case RFCTYPE_DECF16:
+            case RFCTYPE_DECF34:
+            {
+                unsigned int result_len = 0;
+                unsigned int str_len = (_rfc_type == RFCTYPE_DECF16) ? 25u : 43u;
+                SAP_UC *string_value = (RFC_CHAR *)mallocU(str_len + 1);
+                rc = RfcGetString(function_handle, rfc_name.get(), string_value, str_len + 1, &result_len, &error_info);
+                if (rc == RFC_BUFFER_TOO_SMALL) {
+                    free(string_value);
+                    str_len = result_len;
+                    string_value = (RFC_CHAR *)mallocU(str_len + 1);
+                    rc = RfcGetString(function_handle, rfc_name.get(), string_value, str_len + 1, &result_len, &error_info);
+                }
+                if (rc != RFC_OK) { free(string_value); break; }
+                auto dec_str = uc2std(string_value, str_len);
+                free(string_value);
+                return bcd2duck(dec_str, GetLength() * 2 - 1, GetDecimals());
+            }
+            case RFCTYPE_DTDAY:
+            case RFCTYPE_DTWEEK:
+            case RFCTYPE_DTMONTH:
+            case RFCTYPE_TSECOND:
+            case RFCTYPE_TMINUTE:
+            case RFCTYPE_CDAY:
+            {
+                RFC_INT int_value;
+                rc = RfcGetInt(function_handle, rfc_name.get(), &int_value, &error_info);
+                if (rc != RFC_OK) { break; }
+                return rfc2duck(int_value);
+            }
+            case RFCTYPE_UTCLONG:
+            case RFCTYPE_UTCSECOND:
+            case RFCTYPE_UTCMINUTE:
+                return Value(LogicalType::TIMESTAMP);
+            case RFCTYPE_NULL:
+                return Value(LogicalType::SQLNULL);
+            case RFCTYPE_XMLDATA:
+            case RFCTYPE_ABAPOBJECT:
+                return Value("");
             default:
             {
-                throw std::runtime_error(StringUtil::Format("Conversion of RFC type %s is not supported yet", rfctype2std(_rfc_type)));
+                if (GetRfcStrictTypeCheck()) {
+                    throw InvalidInputException("Conversion of SAP RFC type %s is not supported — set erpl_rfc_strict_type_check=false to fall back to VARCHAR", rfctype2std(_rfc_type));
+                }
+                return Value("");
             }
         }
 

--- a/rfc/src/sap_function.cpp
+++ b/rfc/src/sap_function.cpp
@@ -209,19 +209,41 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
             case RFCTYPE_FLOAT:
                 return LogicalType::DOUBLE;
                 break;
-            case RFCTYPE_BCD:
+            case RFCTYPE_BCD: {
+                // BCD: GetLength returns the byte count of the packed-decimal
+                // storage (ceil((digits+1)/2)). 2*N-1 recovers the digit count.
+                // Cap at DuckDB's DECIMAL precision limit (38) to avoid asserts
+                // on rare DEC(>=20,*) DDIC fields.
+                auto precision = std::min<unsigned int>(GetLength() * 2 - 1, 38);
+                auto scale = std::min<unsigned int>(GetDecimals(), precision);
+                return LogicalType::DECIMAL(precision, scale);
+            }
             case RFCTYPE_DECF16:
-            case RFCTYPE_DECF34:
-                return LogicalType::DECIMAL(GetLength() * 2 - 1, GetDecimals());
-                //return LogicalType::DECIMAL(GetLength(), GetDecimals());
-                break;
+            case RFCTYPE_DECF34: {
+                // DECFLOAT16/34 are IEEE 754-2008 decimal floats with fixed
+                // significand precision (16 / 34 digits). GetLength returns
+                // different things depending on the source:
+                //   - SDK introspection (RfcGetParameterDesc) -> storage byte
+                //     count (8 for DECF16, 16 for DECF34).
+                //   - DDIC introspection (DFIES_TAB) -> DDIC LENG, which can
+                //     be up to 31 for D34D.
+                // Both are *not* the digit count we need for DECIMAL(P, S).
+                // Hardcode the spec-defined precision instead.
+                unsigned int precision = (_rfc_type == RFCTYPE_DECF16) ? 16 : 34;
+                auto scale = std::min<unsigned int>(GetDecimals(), precision);
+                return LogicalType::DECIMAL(precision, scale);
+            }
             case RFCTYPE_CHAR:
             case RFCTYPE_STRING:
-            case RFCTYPE_XSTRING:
             case RFCTYPE_XMLDATA:
                 return LogicalType::VARCHAR;
                 break;
+            // RFCTYPE_XSTRING (variable-length raw bytes) and RFCTYPE_BYTE
+            // (fixed-length raw bytes) both carry binary payloads. The read
+            // path returns Value::BLOB; the schema must match or DuckDB
+            // catches it as a bind/value type mismatch.
             case RFCTYPE_BYTE:
+            case RFCTYPE_XSTRING:
                 return LogicalType::BLOB;
                 break;
             case RFCTYPE_TIME:
@@ -289,10 +311,19 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
         return LogicalType::STRUCT(child_types);
     }
 
-    bool RfcType::IsCompatibleType(const LogicalTypeId type) 
+    bool RfcType::IsCompatibleType(const LogicalTypeId type)
     {
         auto compatible_type = GetCompatibleDuckDbType();
-        return type == compatible_type;
+        if (type == compatible_type) {
+            return true;
+        }
+        // BYTE and XSTRING are raw bytes. Accept either VARCHAR or BLOB as the
+        // DuckDB input — both carry binary payloads, and the marshalling code
+        // pulls the bytes via StringValue::Get which works for both.
+        if (_rfc_type == RFCTYPE_XSTRING || _rfc_type == RFCTYPE_BYTE) {
+            return type == LogicalTypeId::VARCHAR || type == LogicalTypeId::BLOB;
+        }
+        return false;
     }
 
     void RfcType::AdaptValue(RfcInvocation &invocation, string &arg_name, Value &arg_value) 
@@ -373,19 +404,32 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
             }
             case RFCTYPE_XSTRING:
             {
-                if (GetRfcStrictTypeCheck()) {
-                    throw InvalidInputException("XSTRING input is not supported — set erpl_rfc_strict_type_check=false to skip");
+                // Variable-length raw bytes — take the bytes from a DuckDB BLOB (or VARCHAR for
+                // hex strings cast through ::BLOB) and push them as-is into the RFC XSTRING.
+                if (arg_value.IsNull()) {
+                    break;
                 }
+                auto bytes = StringValue::Get(arg_value);
+                rc = RfcSetXString(container_handle, sap_arg_name.get(),
+                                   reinterpret_cast<const SAP_RAW *>(bytes.data()),
+                                   static_cast<unsigned int>(bytes.size()),
+                                   &error_info);
                 break;
             }
             // Binary types
             case RFCTYPE_BYTE:
             {
-                unsigned int byte_value_len = 0;
-                SAP_RAW *byte_value = (SAP_RAW *)malloc(byte_value_len);
-
-                rc = RfcSetBytes(container_handle, sap_arg_name.get(), byte_value, byte_value_len, &error_info);
-                free(byte_value);
+                // Fixed-length raw bytes. SAP enforces the field length; we send what the user
+                // gave us. If the payload is shorter than the field width SAP will pad/truncate
+                // per its own convention — we don't second-guess it here.
+                if (arg_value.IsNull()) {
+                    break;
+                }
+                auto bytes = StringValue::Get(arg_value);
+                rc = RfcSetBytes(container_handle, sap_arg_name.get(),
+                                 reinterpret_cast<const SAP_RAW *>(bytes.data()),
+                                 static_cast<unsigned int>(bytes.size()),
+                                 &error_info);
                 break;
             }
             // Date types
@@ -412,10 +456,20 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
                 break;
             }
             case RFCTYPE_UTCLONG:
+            case RFCTYPE_UTCSECOND:
+            case RFCTYPE_UTCMINUTE:
             {
-                if (GetRfcStrictTypeCheck()) {
-                    throw InvalidInputException("UTCLONG input is not supported — set erpl_rfc_strict_type_check=false to skip");
+                // SAP UTCLONG/UTCSECOND/UTCMINUTE are 8-byte integers
+                // carrying a UTC timestamp; the SDK accepts/returns them as
+                // a normalized string via RfcSetString/RfcGetString. We
+                // convert a DuckDB TIMESTAMP to SAP's "YYYYMMDDHHMMSS,ssssss"
+                // form (comma decimal separator, ABAP convention).
+                if (arg_value.IsNull()) {
+                    break;
                 }
+                auto utc_str = std2uc(timestamp2sap_utc(arg_value));
+                rc = RfcSetString(container_handle, sap_arg_name.get(),
+                                  utc_str.get(), strlenU(utc_str.get()), &error_info);
                 break;
             }
             // Complex types
@@ -586,7 +640,10 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
                 auto bcd_str = uc2std(string_value, str_len);
                 free(string_value);
 
-                auto result_value = bcd2duck(bcd_str, GetLength() * 2 - 1, GetDecimals());
+                // Match CreateDuckDbType's precision cap so DECIMAL(P, S) is valid.
+                auto precision = std::min<unsigned int>(GetLength() * 2 - 1, 38);
+                auto scale = std::min<unsigned int>(GetDecimals(), precision);
+                auto result_value = bcd2duck(bcd_str, precision, scale);
                 return result_value;
             }
             // String types
@@ -740,7 +797,11 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
                 if (rc != RFC_OK) { free(string_value); break; }
                 auto dec_str = uc2std(string_value, str_len);
                 free(string_value);
-                return bcd2duck(dec_str, GetLength() * 2 - 1, GetDecimals());
+                // Same precision derivation as CreateDuckDbType — hardcoded
+                // per type, ignoring GetLength's byte-vs-digit ambiguity.
+                unsigned int precision = (_rfc_type == RFCTYPE_DECF16) ? 16 : 34;
+                auto scale = std::min<unsigned int>(GetDecimals(), precision);
+                return bcd2duck(dec_str, precision, scale);
             }
             case RFCTYPE_DTDAY:
             case RFCTYPE_DTWEEK:
@@ -757,7 +818,24 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
             case RFCTYPE_UTCLONG:
             case RFCTYPE_UTCSECOND:
             case RFCTYPE_UTCMINUTE:
-                return Value(LogicalType::TIMESTAMP);
+            {
+                // SDK normalizes to a 25-char "YYYYMMDDHHMMSS,sssssss" form
+                // (UTCLONG); UTCSECOND is shorter (no fractional) and
+                // UTCMINUTE shorter still. Allocate generously.
+                unsigned int result_len = 0, str_len = 30;
+                SAP_UC *str_buf = (RFC_CHAR *)mallocU(str_len + 1);
+                rc = RfcGetString(function_handle, rfc_name.get(), str_buf, str_len + 1, &result_len, &error_info);
+                if (rc == RFC_BUFFER_TOO_SMALL) {
+                    free(str_buf);
+                    str_len = result_len;
+                    str_buf = (RFC_CHAR *)mallocU(str_len + 1);
+                    rc = RfcGetString(function_handle, rfc_name.get(), str_buf, str_len + 1, &result_len, &error_info);
+                }
+                if (rc != RFC_OK) { free(str_buf); break; }
+                auto utc_str = uc2std(str_buf, str_len);
+                free(str_buf);
+                return sap_utc2timestamp(utc_str);
+            }
             case RFCTYPE_NULL:
                 return Value(LogicalType::SQLNULL);
             case RFCTYPE_XMLDATA:
@@ -892,10 +970,28 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
             {"CUKY",        RFCTYPE_CHAR},
             {"DATS",        RFCTYPE_DATE},
             {"DEC",         RFCTYPE_BCD},
+            // DECFLOAT16 / DECFLOAT34 variants (S/4HANA et al.):
+            //   D16D / D34D — "DECFLOAT for date"
+            //   D16N / D34N — "DECFLOAT normalized"
+            //   D16R / D34R — "DECFLOAT raw"
+            //   D16S / D34S — "DECFLOAT scaled"
+            // All represent IEEE 754-2008 decimal floats and round-trip through
+            // RFCTYPE_DECF16 / RFCTYPE_DECF34 -> DuckDB DECIMAL.
+            {"D16D",        RFCTYPE_DECF16},
+            {"D16N",        RFCTYPE_DECF16},
+            {"D16R",        RFCTYPE_DECF16},
+            {"D16S",        RFCTYPE_DECF16},
+            {"DECF16",      RFCTYPE_DECF16},
+            {"D34D",        RFCTYPE_DECF34},
+            {"D34N",        RFCTYPE_DECF34},
+            {"D34R",        RFCTYPE_DECF34},
+            {"D34S",        RFCTYPE_DECF34},
+            {"DECF34",      RFCTYPE_DECF34},
             {"FLTP",        RFCTYPE_FLOAT},
             {"INT1",        RFCTYPE_INT1},
             {"INT2",        RFCTYPE_INT2},
             {"INT4",        RFCTYPE_INT},
+            {"INT8",        RFCTYPE_INT8},
             {"LANG",        RFCTYPE_CHAR},
             {"LCHR",        RFCTYPE_STRING},
             {"LRAW",        RFCTYPE_BYTE},
@@ -904,11 +1000,22 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
             {"QUAN",        RFCTYPE_BCD},
             {"RAW",         RFCTYPE_BYTE},
             {"RAWSTRING",   RFCTYPE_XSTRING},
-            {"RSTR",        RFCTYPE_STRING},
+            // RSTR is the DDIC short name for RAWSTRING — variable-length
+            // raw bytes, not a character string. Mapping it to RFCTYPE_STRING
+            // (the previous behaviour) made the column schema VARCHAR while
+            // the actual values came back as BLOB, causing schema/value type
+            // clashes (e.g. /DMO/AGENCY.ATTACHMENT).
+            {"RSTR",        RFCTYPE_XSTRING},
             {"STRING",      RFCTYPE_STRING},
             {"STRG",        RFCTYPE_STRING},
             {"SSTR",        RFCTYPE_STRING},
             {"TIMS",        RFCTYPE_TIME},
+            // UTC long timestamp (NW 7.50+): UTCL/UTCLONG = high-precision UTC
+            // timestamp; UTCS = UTC second; UTCM = UTC minute. Map to TIMESTAMP.
+            {"UTCL",        RFCTYPE_UTCLONG},
+            {"UTCLONG",     RFCTYPE_UTCLONG},
+            {"UTCS",        RFCTYPE_UTCSECOND},
+            {"UTCM",        RFCTYPE_UTCMINUTE},
             {"UNIT",        RFCTYPE_CHAR}
         };
 
@@ -1264,13 +1371,52 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
         : RfcInvocationAdapter(invocation) 
     { }
 
-    void RfcInvocationPositionalAdapter::Adapt(std::vector<RfcFunctionParameterDesc> parameter_infos, std::vector<Value> &arguments) 
+    void RfcInvocationPositionalAdapter::Adapt(std::vector<RfcFunctionParameterDesc> parameter_infos, std::vector<Value> &arguments)
     {
         if (arguments.size() == 0) {
             return;
         }
 
-        throw std::logic_error("Positional adapter not implemented");
+        // Match positional args to the function's settable parameters
+        // (IMPORT + CHANGING + TABLES, in DDIC declaration order). EXPORT
+        // params are skipped because the caller can't set them.
+        std::vector<RfcFunctionParameterDesc> settable;
+        std::copy_if(parameter_infos.begin(), parameter_infos.end(), std::back_inserter(settable),
+                     [](RfcFunctionParameterDesc &p) { return p.GetDirection() != RFC_EXPORT; });
+
+        if (arguments.size() > settable.size()) {
+            throw std::runtime_error(StringUtil::Format(
+                "Too many positional arguments: function has %u settable parameters but got %u",
+                static_cast<unsigned int>(settable.size()), static_cast<unsigned int>(arguments.size())));
+        }
+
+        for (std::size_t i = 0; i < arguments.size(); i++) {
+            auto &param = settable[i];
+            auto param_name = param.GetName();
+            auto &arg_value = arguments[i];
+
+            // NULL is universally compatible — mirror the named adapter rule.
+            if (arg_value.IsNull()) {
+                continue;
+            }
+
+            auto param_type = param.GetRfcType();
+            auto arg_type_id = arg_value.type().id();
+            if (!param_type->IsCompatibleType(arg_type_id)) {
+                throw std::runtime_error(StringUtil::Format(
+                    "Positional argument %u (parameter '%s') is of type '%s' (RFC) but value is of type '%s' (DuckDB)",
+                    static_cast<unsigned int>(i + 1), param_name,
+                    param_type->GetName(), arg_value.type().ToString()));
+            }
+
+            try {
+                param_type->AdaptValue(_invocation, param_name, arg_value);
+            } catch (std::exception &ex) {
+                throw std::runtime_error(StringUtil::Format(
+                    "Failed to adapt positional argument %u ('%s'): %s",
+                    static_cast<unsigned int>(i + 1), param_name, ex.what()));
+            }
+        }
     }
 
 
@@ -1316,8 +1462,16 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
             auto child_type = child_value.type().id();
             auto param_type = parameter_info.GetRfcType();
 
+            // NULL is universally compatible: leave the RFC field at its default.
+            // This also lets callers write `{'X': NULL}` without an explicit cast
+            // (DuckDB infers a bare NULL as INTEGER, which would otherwise fail
+            // the strict IsCompatibleType check below).
+            if (child_value.IsNull()) {
+                return;
+            }
+
             if (! param_type->IsCompatibleType(child_type)) {
-                throw std::runtime_error(StringUtil::Format("Parameter '%s' is of type '%s' (RFC) but argument is of type '%s' (DuckDB)", 
+                throw std::runtime_error(StringUtil::Format("Parameter '%s' is of type '%s' (RFC) but argument is of type '%s' (DuckDB)",
                                                             child_name, param_type->GetName(), child_value.type().ToString()));
             }
 
@@ -1561,11 +1715,28 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
 
             if (field_it == field_infos.end()) {
                 auto available_names = StringUtil::Join(ExtractResultNames(field_infos), ", ");
-                throw std::runtime_error(StringUtil::Format("Field '%s' from path '%s' not found, available names are '%s'", 
+                throw std::runtime_error(StringUtil::Format("Field '%s' from path '%s' not found, available names are '%s'",
                                                             *token_it, path, available_names));
             }
 
-            field_infos = (*field_it).GetRfcType()->GetFieldInfos();
+            auto field_type = field_it->GetRfcType();
+            // A path that lands on a scalar (non-container) leaf is valid when
+            // it's the final token: return a single-column schema named after
+            // the leaf. This lets callers write
+            //   sap_rfc_invoke('RFC_SYSTEM_INFO', path := '/RFCSI_EXPORT/RFCSYSID')
+            // instead of the (RFCSI_EXPORT).RFCSYSID dot syntax.
+            if (!field_type->IsComplexType()) {
+                if (std::next(token_it) != tokens.end()) {
+                    throw std::runtime_error(StringUtil::Format(
+                        "Field '%s' from path '%s' is a scalar — cannot descend further",
+                        *token_it, path));
+                }
+                return std::make_pair(
+                    std::vector<std::string>{field_it->GetName()},
+                    std::vector<LogicalType>{field_type->CreateDuckDbType()});
+            }
+
+            field_infos = field_type->GetFieldInfos();
         }
 
         return std::make_pair(ExtractResultNames(field_infos), ExtractResultTypes(field_infos));
@@ -1662,14 +1833,20 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
                 if (child_name == *token_it) {
                     auto child_value = child_values[i];
                     auto child_type = child_value.type().id();
-                    switch(child_type) 
+                    switch(child_type)
                     {
                         case LogicalTypeId::STRUCT:
                             return ConvertValuesFromStruct(child_value, vector<string>(token_it + 1, tokens.end()));
                         case LogicalTypeId::LIST:
                             return ConvertValuesFromList(child_value, vector<string>(token_it + 1, tokens.end()));
                         default:
-                            throw std::runtime_error(StringUtil::Format("Field '%s' is not a container type", *token_it));
+                            // Scalar leaf: only valid if this is the last token.
+                            if (std::next(token_it) == tokens.end()) {
+                                _total_rows = 1;
+                                return {child_value};
+                            }
+                            throw std::runtime_error(StringUtil::Format(
+                                "Field '%s' is a scalar — cannot descend further", *token_it));
                     };
                 }
             }

--- a/rfc/src/sap_rfc.cpp
+++ b/rfc/src/sap_rfc.cpp
@@ -425,6 +425,17 @@ namespace duckdb
         });
         if (needs_string_support) {
             ResolveReadTableFunctionForStringTypes(connection);
+            // Eagerly resolve the et_data switch availability on this function
+            // module so parallel column tasks don't race on it at execute
+            // time. The function signature is stable across the session, so
+            // probing once during bind is equivalent to the lazy path.
+            if (read_table_function == "RFC_READ_TABLE" && !read_table_supports_et_data_switch.has_value()) {
+                try {
+                    read_table_supports_et_data_switch = ReadTableSupportsEtDataSwitch(connection, read_table_function);
+                } catch (std::exception &) {
+                    // leave unset; execute-time path will surface the error.
+                }
+            }
         }
 
         ResolveReadTableImportParams(connection);
@@ -666,33 +677,53 @@ namespace duckdb
         return false;
     }
 
-    void RfcReadTableBindData::Step(ClientContext &context, DataChunk &output) 
+    void RfcReadTableBindData::Step(ClientContext &context, DataChunk &output)
     {
         auto &scheduler = TaskScheduler::GetScheduler(context);
-        auto executor = TaskExecutor(scheduler);
-        if (max_threads > 0) {
-            unsigned int db_num_threads = context.db->NumberOfThreads();
-            max_threads = std::min(max_threads, db_num_threads);
-            scheduler.SetThreads(max_threads, 1);
-        }
-        
+
+        // Snapshot the active state machines so we can throttle scheduling
+        // without iterating column_state_machines twice.
+        std::vector<RfcReadColumnStateMachine *> active;
+        active.reserve(column_state_machines.size());
         for (auto &sm : column_state_machines) {
-            if (! sm.Active()) {
-                continue;
+            if (sm.Active()) {
+                active.push_back(&sm);
             }
-            auto task = sm.CreateTaskForNextStep(executor, output.data[sm.GetProjectedColumnIndex()]);
-            executor.ScheduleTask(std::move(task));
         }
 
-        //auto n_active = NActiveStateMachines();
-        //scheduler.ExecuteTasks(n_active);
+        // When max_threads > 0, the user wants at most that many concurrent
+        // RFC calls. Enforce by scheduling tasks in batches. Each batch is
+        // one full TaskExecutor cycle: schedule, WorkOnTasks (which blocks
+        // until all batch tasks finish), repeat.
+        //
+        // We deliberately do NOT call scheduler.SetThreads(): that mutates
+        // the global TaskScheduler::requested_thread_count, which gets
+        // applied at end-of-query via ClientContext::CleanupInternal ->
+        // RelaunchThreads, leaking the per-query setting into the rest of
+        // the session.
+        idx_t batch_size = active.size();
+        if (max_threads > 0 && max_threads < batch_size) {
+            batch_size = max_threads;
+        }
+        if (batch_size == 0) {
+            batch_size = 1;
+        }
 
-        executor.WorkOnTasks();
-        
+        for (idx_t start = 0; start < active.size(); start += batch_size) {
+            TaskExecutor executor(scheduler);
+            idx_t end = std::min<idx_t>(start + batch_size, active.size());
+            for (idx_t i = start; i < end; i++) {
+                auto &sm = *active[i];
+                auto task = sm.CreateTaskForNextStep(executor, output.data[sm.GetProjectedColumnIndex()]);
+                executor.ScheduleTask(std::move(task));
+            }
+            executor.WorkOnTasks();
+        }
+
         if (! AreActiveStateMachineCaridnalitiesEqual()) {
             throw std::runtime_error("Cardinality of column state machines is not the same. This should not happen.");
         }
-        
+
         auto cardinality = FirstActiveStateMachineCardinality();
         output.SetCardinality(cardinality);
     }
@@ -844,15 +875,7 @@ namespace duckdb
         return projected_column_idx;
     }
 
-    std::shared_ptr<RfcConnection> RfcReadColumnStateMachine::GetConnection() 
-    {
-        if (current_connection == nullptr) {
-            current_connection = bind_data->OpenNewConnection();
-        }
-        return current_connection;
-    }
-
-    bool RfcReadColumnStateMachine::IsRowIdColumnId() 
+    bool RfcReadColumnStateMachine::IsRowIdColumnId()
     {
         std::lock_guard<mutex> t(thread_lock);
         return row_id_column_id;
@@ -1010,6 +1033,38 @@ namespace duckdb
                 auto func_args = CreateFunctionArguments(read_table_delimiter, use_et_data);
                 auto invocation = func->BeginInvocation(func_args);
                 current_result_data = invocation->Invoke(data_path);
+
+                // /SAPDS/RFC_READ_TABLE2 and /BODS/RFC_READ_TABLE2 distribute
+                // rows across multiple TBLOUTxxxx output tables based on the
+                // projected row width — the SMALLEST TBLOUTxxxx that fits
+                // gets populated, the others stay empty.
+                // ResolveReadTableResultPath picks one path at bind time, but
+                // the right size depends on the actual columns in this batch
+                // (which can differ per column-parallel task). If our chosen
+                // path is empty, walk the other TBLOUTxxxx on the SAME RFC
+                // invocation (no extra round-trip — RfcResultSet just walks
+                // the SDK handle) and use whichever has data.
+                if (current_result_data->TotalRows() == 0 &&
+                    data_path.rfind("/TBLOUT", 0) == 0) {
+                    static const std::vector<std::string> alt_paths = {
+                        "/TBLOUT128", "/TBLOUT512", "/TBLOUT2048", "/TBLOUT8192", "/TBLOUT30000"
+                    };
+                    for (auto &alt : alt_paths) {
+                        if (alt == data_path) {
+                            continue;
+                        }
+                        try {
+                            auto alt_result = std::make_shared<RfcResultSet>(invocation, alt);
+                            if (alt_result->TotalRows() > 0) {
+                                current_result_data = alt_result;
+                                break;
+                            }
+                        } catch (std::exception &) {
+                            // Path not present on this function module variant; skip.
+                        }
+                    }
+                }
+
                 connection->Close();
                 return current_result_data->TotalRows();
             }

--- a/rfc/src/sap_type_conversion.cpp
+++ b/rfc/src/sap_type_conversion.cpp
@@ -112,7 +112,10 @@ namespace duckdb
             case RFCTYPE_INT: return LogicalTypeId::INTEGER;
             case RFCTYPE_INT1: return LogicalTypeId::TINYINT;
             case RFCTYPE_INT2: return LogicalTypeId::SMALLINT;
-            case RFCTYPE_INT8: return LogicalTypeId::INTEGER;
+            // RFC_INT8 is an 8-byte signed integer. The natural DuckDB
+            // equivalent is BIGINT (also 8 bytes); INTEGER would lose half
+            // the range and force callers to add an explicit ::BIGINT cast.
+            case RFCTYPE_INT8: return LogicalTypeId::BIGINT;
             case RFCTYPE_FLOAT: return LogicalTypeId::DOUBLE;
             case RFCTYPE_BCD: return LogicalTypeId::DECIMAL;
             case RFCTYPE_DECF16: return LogicalTypeId::DECIMAL;
@@ -120,7 +123,9 @@ namespace duckdb
             // Character types
             case RFCTYPE_CHAR: return LogicalTypeId::VARCHAR;
             case RFCTYPE_STRING: return LogicalTypeId::VARCHAR;
-            case RFCTYPE_XSTRING: return LogicalTypeId::VARCHAR;
+            // RAW byte sequences: read path returns Value::BLOB, so the
+            // compatible DuckDB logical type is BLOB (not VARCHAR).
+            case RFCTYPE_XSTRING: return LogicalTypeId::BLOB;
             case RFCTYPE_XMLDATA: return LogicalTypeId::VARCHAR;
             // Binary types
             case RFCTYPE_BYTE: return LogicalTypeId::BLOB;
@@ -330,6 +335,82 @@ namespace duckdb
         s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
             return !std::isspace(ch);
         }));
+    }
+
+    // SAP-side UTCLONG/UTCSECOND/UTCMINUTE serialization.
+    //   UTCLONG:   "YYYYMMDDHHMMSS,sssssss"  (14 digits + ',' + 7 digits)
+    //   UTCSECOND: "YYYYMMDDHHMMSS"          (14 digits, no fractional)
+    //   UTCMINUTE: "YYYYMMDDHHMM"            (12 digits)
+    // The SDK normalizes via RfcGetString to one of these. An all-zero
+    // string represents an uninitialized timestamp -> NULL.
+    Value sap_utc2timestamp(std::string &utc_str)
+    {
+        // Trim trailing whitespace/null bytes the SDK may leave behind.
+        while (!utc_str.empty() && (utc_str.back() == ' ' || utc_str.back() == '\0')) {
+            utc_str.pop_back();
+        }
+        if (utc_str.empty()) {
+            return Value(LogicalType::TIMESTAMP);
+        }
+        // ABAP initial value for UTCLONG is all zeros; treat as NULL.
+        if (utc_str.find_first_not_of('0') == std::string::npos) {
+            return Value(LogicalType::TIMESTAMP);
+        }
+        // Build ISO "YYYY-MM-DD HH:MM:SS[.fffffff]" from compact SAP form.
+        if (utc_str.size() < 8) {
+            return Value(LogicalType::TIMESTAMP);
+        }
+        std::string iso;
+        iso.reserve(30);
+        iso += utc_str.substr(0, 4);
+        iso += '-';
+        iso += utc_str.substr(4, 2);
+        iso += '-';
+        iso += utc_str.substr(6, 2);
+        if (utc_str.size() >= 10) {
+            iso += ' ';
+            iso += utc_str.substr(8, 2);
+            iso += ':';
+            iso += (utc_str.size() >= 12) ? utc_str.substr(10, 2) : std::string("00");
+            iso += ':';
+            iso += (utc_str.size() >= 14) ? utc_str.substr(12, 2) : std::string("00");
+        }
+        if (utc_str.size() > 14) {
+            // Skip the SAP separator ('.' or ',') and append fractional digits.
+            std::string frac = utc_str.substr(14);
+            if (!frac.empty() && (frac[0] == ',' || frac[0] == '.')) {
+                frac[0] = '.';
+            } else {
+                frac.insert(frac.begin(), '.');
+            }
+            iso += frac;
+        }
+        try {
+            return Value(iso).DefaultCastAs(LogicalType::TIMESTAMP);
+        } catch (...) {
+            return Value(LogicalType::TIMESTAMP);
+        }
+    }
+
+    std::string timestamp2sap_utc(const Value &timestamp_value)
+    {
+        if (timestamp_value.IsNull()) {
+            return std::string();
+        }
+        // DuckDB Timestamp::ToString format: "YYYY-MM-DD HH:MM:SS[.fffffff]".
+        // Convert to SAP compact form "YYYYMMDDHHMMSS,sssssss".
+        auto cast_value = timestamp_value.type().id() == LogicalTypeId::TIMESTAMP
+            ? timestamp_value
+            : timestamp_value.DefaultCastAs(LogicalType::TIMESTAMP);
+        auto iso = cast_value.ToString();
+        std::string sap;
+        sap.reserve(iso.size());
+        for (char c : iso) {
+            if (c == '-' || c == ' ' || c == ':') continue;
+            if (c == '.') { sap += ','; continue; }   // SAP decimal separator
+            sap += c;
+        }
+        return sap;
     }
 
     Value bcd2duck(std::string &bcd_str, unsigned int length, unsigned int decimals)

--- a/rfc/src/scanner_describe_function.cpp
+++ b/rfc/src/scanner_describe_function.cpp
@@ -1,7 +1,8 @@
 #include "scanner_describe_function.hpp"
 #include "telemetry.hpp"
+#include "erpl_tracing.hpp"
 
-namespace duckdb 
+namespace duckdb
 {
 
 static std::vector<Value> CreateFunctionArguments(std::string &func_name)
@@ -11,29 +12,45 @@ static std::vector<Value> CreateFunctionArguments(std::string &func_name)
         .BuildArgList();
 }
 
-static unique_ptr<FunctionData> RfcDescribeFunctionBind(ClientContext &context, 
-                                                        TableFunctionBindInput &input, 
-                                                        vector<LogicalType> &return_types, 
+static unique_ptr<FunctionData> RfcDescribeFunctionBind(ClientContext &context,
+                                                        TableFunctionBindInput &input,
+                                                        vector<LogicalType> &return_types,
                                                         vector<string> &names)
 {
     PostHogTelemetry::Instance().CaptureFunctionExecution("sap_rfc_describe_function");
 
     auto &inputs = input.inputs;
-    
+
     // Connect to the SAP system
     auto connection = RfcAuthParams::FromContext(context).Connect();
 
-    // Create the function
+    // Create the function — gives us the SDK-side parameter introspection
+    // (param names, types, directions). This works for every callable RFC.
     auto func_name = inputs[0].ToString();
     auto func_handle = std::make_shared<RfcFunction>(connection, func_name);
 
-    auto func_args = CreateFunctionArguments(func_name);
-    auto result_set = RfcResultSet::InvokeFunction(connection, "RPY_FUNCTIONMODULE_READ", func_args);
+    // Reading the ABAP source/short text/function pool requires
+    // RPY_FUNCTIONMODULE_READ, which fails with FL180 ("Source wider than
+    // 72 char") on a small number of older modules (e.g. SXPG_COMMAND_EXECUTE,
+    // IDOC_INBOUND_ASYNCHRONOUS, STFC_RETURN_DATA). When that happens we
+    // gracefully degrade: keep the SDK-side parameter info and leave the
+    // RPY-sourced metadata fields (text, function_group, remote_callable,
+    // source) empty rather than failing the whole describe call.
+    std::shared_ptr<RfcResultSet> result_set;
+    try {
+        auto func_args = CreateFunctionArguments(func_name);
+        result_set = RfcResultSet::InvokeFunction(connection, "RPY_FUNCTIONMODULE_READ", func_args);
+    } catch (std::exception &ex) {
+        ERPL_TRACE_WARN_DATA("sap_rfc_describe_function",
+                             "RPY_FUNCTIONMODULE_READ failed; falling back to SDK-only describe",
+                             ex.what());
+        result_set = nullptr;
+    }
 
     auto bind_data = RfcDescribeFunctionBindData::FromFunctionHandleAndResultSet(func_handle, result_set);
     names = bind_data->GetResultNames();
     return_types = bind_data->GetResultTypes();
-    
+
     return std::move(bind_data);
 }
 

--- a/rfc/src/scanner_invoke.cpp
+++ b/rfc/src/scanner_invoke.cpp
@@ -37,9 +37,18 @@ namespace duckdb
         names = result_set->GetResultNames();
         return_types = result_set->GetResultTypes();
 
-        // Make this invocation available to the bind data
+        // DuckDB requires every table function to expose at least one column.
+        // RFC modules like RFC_PING have no export/changing/table parameters,
+        // so the natural schema is empty. Inject a synthetic BOOLEAN 'ok'
+        // column so the call is still usable as `SELECT * FROM sap_rfc_invoke(...)`.
+        // The invocation itself has already succeeded if we reached this line.
         auto bind_data = make_uniq<RfcFunctionBindData>();
         bind_data->result_set = result_set;
+        bind_data->ok_only = return_types.empty();
+        if (bind_data->ok_only) {
+            names.push_back("ok");
+            return_types.push_back(LogicalType::BOOLEAN);
+        }
 
         return std::move(bind_data);
     }
@@ -47,17 +56,29 @@ namespace duckdb
     /**
      * @brief (Step 2) Scans the function and returns the next chunk of data.
     */
-    static void RfcInvokeScan(ClientContext &context, 
-                              TableFunctionInput &data, 
-                              DataChunk &output) 
+    static void RfcInvokeScan(ClientContext &context,
+                              TableFunctionInput &data,
+                              DataChunk &output)
     {
-	    auto &bind_data = data.bind_data->Cast<RfcFunctionBindData>();
+	    auto &bind_data = data.bind_data->CastNoConst<RfcFunctionBindData>();
         auto result_set = bind_data.result_set;
+
+        if (bind_data.ok_only) {
+            // Synthetic single-row 'ok=true' for functions with no real
+            // result params. Emit once, then signal end-of-stream.
+            if (bind_data.ok_only_emitted) {
+                return;
+            }
+            bind_data.ok_only_emitted = true;
+            output.SetCardinality(1);
+            output.SetValue(0, 0, Value::BOOLEAN(true));
+            return;
+        }
 
         if (! result_set->HasMoreResults()) {
             return;
         }
-        
+
         result_set->FetchNextResult(output);
     }
 

--- a/rfc/test/parallel/README.md
+++ b/rfc/test/parallel/README.md
@@ -1,0 +1,38 @@
+# sap_read_table Parallelism Harness
+
+Verifies the column-parallel scan path of `sap_read_table` against a running ABAP
+Cloud Developer Trial container.
+
+## Prerequisites
+
+- `a4h` container running (`scripts/start-sap.sh`).
+- Debug build present: `GEN=ninja make debug`.
+- `.adt.creds` JSON at the repo root.
+- Python tooling: `uv` (the project standard).
+
+## Run
+
+```bash
+cd /home/jr/Projects/datazoo/erpl
+uv run pytest rfc/test/parallel -v
+```
+
+Targeted runs:
+
+```bash
+uv run pytest rfc/test/parallel/test_alignment.py::test_b8_sapds_get_sorted -v
+uv run pytest rfc/test/parallel/test_perf_ddic.py -v --capture=no
+```
+
+## What lives where
+
+- `conftest.py` — credential loading, DuckDB CLI wrapper, fixture wiring.
+- `oracles.py` — single-shot, full-row, single-transaction RFC oracle builder.
+- `test_alignment.py` — scenarios B1–B8 (row-order alignment under parallelism).
+- `test_breadth.py` — broad coverage across tables, views, CDS views.
+- `test_perf_ddic.py` — DDIC-table throughput sweep across THREADS values.
+- `test_connection_pressure.py` — concurrent multiprocess load.
+- `test_global_scheduler.py` — proves/disproves the `SetThreads` session leak.
+- `tsan_scenarios.sh` — TSAN re-run of every scenario.
+
+Artifacts land under `../../../artifacts/` and oracles under `../../../build/oracle/`.

--- a/rfc/test/parallel/conftest.py
+++ b/rfc/test/parallel/conftest.py
@@ -1,0 +1,133 @@
+"""Pytest fixtures for the sap_read_table parallelism harness.
+
+Loads ABAP Trial credentials and exposes a fresh DuckDB connection
+to every test. The debug build statically links the ERPL extensions
+so no LOAD is required.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+
+import duckdb
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+DUCKDB_BINARY = REPO_ROOT / "build" / "debug" / "duckdb"
+NWRFC_LIB = REPO_ROOT / "nwrfcsdk" / "linux" / "lib"
+ARTIFACTS = REPO_ROOT / "artifacts"
+ORACLE_DIR = REPO_ROOT / "build" / "oracle"
+ADT_CREDS = REPO_ROOT / ".adt.creds"
+
+
+def _load_credentials() -> dict[str, str]:
+    """Load SAP creds from .adt.creds JSON (ADT port) and derive RFC env vars.
+
+    The A4H container exposes the gateway on the host as port 3300 (sapgw00),
+    which is SYSNR=00. ASHOST=localhost. The HTTP port in .adt.creds (50000)
+    is for ADT, not RFC, but the user/password/client are shared.
+    """
+    creds = json.loads(ADT_CREDS.read_text())
+    return {
+        "ERPL_SAP_ASHOST": creds.get("host", "localhost"),
+        "ERPL_SAP_SYSNR": "00",
+        "ERPL_SAP_CLIENT": creds.get("client", "001"),
+        "ERPL_SAP_USER": creds.get("user", "DEVELOPER"),
+        "ERPL_SAP_PASSWORD": creds.get("password", ""),
+        "ERPL_SAP_LANG": "EN",
+    }
+
+
+@pytest.fixture(scope="session")
+def sap_env() -> dict[str, str]:
+    env = _load_credentials()
+    for k, v in env.items():
+        os.environ.setdefault(k, v)
+    # Inject the SAP shared libs so the static-linked extension can resolve them.
+    nwrfc = str(NWRFC_LIB)
+    current = os.environ.get("LD_LIBRARY_PATH", "")
+    if nwrfc not in current.split(":"):
+        os.environ["LD_LIBRARY_PATH"] = nwrfc + (":" + current if current else "")
+    return env
+
+
+@pytest.fixture
+def con(sap_env: dict[str, str]):
+    """In-process DuckDB connection with the debug-build extensions loaded."""
+    # The python duckdb module loads its own DuckDB; it cannot use the
+    # statically-linked debug binary. We use the CLI binary via subprocess for
+    # SAP-side calls (see `cli` fixture) and the python module only for
+    # local-only operations (parquet IO, hashing oracles).
+    c = duckdb.connect(":memory:", config={"allow_unsigned_extensions": True})
+    yield c
+    c.close()
+
+
+@pytest.fixture(scope="session")
+def cli_run(sap_env: dict[str, str]):
+    """Run a SQL script through the debug duckdb CLI and return stdout.
+
+    The CLI is the only way to get the statically-linked ERPL extension. The
+    secret is created inline so each invocation is self-contained.
+    """
+    secret_sql = f"""
+CREATE OR REPLACE SECRET abap_trial (
+    TYPE sap_rfc,
+    ASHOST '{sap_env["ERPL_SAP_ASHOST"]}',
+    SYSNR '{sap_env["ERPL_SAP_SYSNR"]}',
+    CLIENT '{sap_env["ERPL_SAP_CLIENT"]}',
+    USER '{sap_env["ERPL_SAP_USER"]}',
+    PASSWD '{sap_env["ERPL_SAP_PASSWORD"]}',
+    LANG '{sap_env["ERPL_SAP_LANG"]}'
+);
+"""
+
+    # Suppress the ASan/LSan noise from libsapnwrfc.so static init.
+    env_extra = {
+        "LSAN_OPTIONS": f"suppressions={REPO_ROOT / 'scripts' / 'lsan_suppress.txt'}:print_suppressions=0",
+        "ASAN_OPTIONS": "detect_odr_violation=0:detect_leaks=0",
+    }
+
+    def _run(sql: str, *, timeout: int = 600, retries: int = 2) -> str:
+        full = secret_sql + sql
+        last_err = ""
+        for attempt in range(retries + 1):
+            proc = subprocess.run(
+                [str(DUCKDB_BINARY), "-csv", "-c", full],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                env={**os.environ, **env_extra},
+            )
+            if proc.returncode == 0:
+                return proc.stdout
+            stderr = proc.stderr or ""
+            transient = (
+                "RFC_COMMUNICATION_FAILURE" in stderr
+                or "Timeout while opening an RFC connection" in stderr
+            )
+            last_err = (
+                f"duckdb cli failed (rc={proc.returncode}, attempt {attempt + 1}/{retries + 1})\n"
+                f"--- stdout ---\n{proc.stdout}\n"
+                f"--- stderr ---\n{stderr}\n"
+                f"--- sql ---\n{full}"
+            )
+            if not transient or attempt == retries:
+                break
+        raise RuntimeError(last_err)
+
+    return _run
+
+
+@pytest.fixture(scope="session")
+def artifacts_dir() -> pathlib.Path:
+    ARTIFACTS.mkdir(parents=True, exist_ok=True)
+    return ARTIFACTS
+
+
+@pytest.fixture(scope="session")
+def oracle_dir() -> pathlib.Path:
+    ORACLE_DIR.mkdir(parents=True, exist_ok=True)
+    return ORACLE_DIR

--- a/rfc/test/parallel/fuzz_invoke.py
+++ b/rfc/test/parallel/fuzz_invoke.py
@@ -1,0 +1,323 @@
+"""Fuzz `sap_rfc_invoke` against a diverse set of real SAP RFC function modules
+to exercise different parameter shapes (scalars, structs, deep structs, tables,
+empty calls) and different result shapes.
+
+Run:
+    uv run python rfc/test/parallel/fuzz_invoke.py
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+DUCKDB = REPO_ROOT / "build" / "debug" / "duckdb"
+ADT_CREDS = REPO_ROOT / ".adt.creds"
+ARTIFACTS = REPO_ROOT / "artifacts" / "fuzz"
+
+
+def secret() -> str:
+    c = json.loads(ADT_CREDS.read_text())
+    return f"""CREATE OR REPLACE SECRET abap_trial (
+    TYPE sap_rfc, ASHOST '{c.get("host", "localhost")}', SYSNR '00',
+    CLIENT '{c.get("client", "001")}', USER '{c.get("user", "DEVELOPER")}',
+    PASSWD '{c.get("password", "")}', LANG 'EN'
+);
+"""
+
+
+def run_cli(sql: str, *, timeout: int = 120) -> tuple[int, str, str]:
+    env = {**os.environ}
+    env["LD_LIBRARY_PATH"] = f"{REPO_ROOT / 'nwrfcsdk' / 'linux' / 'lib'}:{env.get('LD_LIBRARY_PATH', '')}"
+    env["LSAN_OPTIONS"] = f"suppressions={REPO_ROOT / 'scripts' / 'lsan_suppress.txt'}:print_suppressions=0"
+    env["ASAN_OPTIONS"] = "detect_odr_violation=0:detect_leaks=0"
+    try:
+        proc = subprocess.run(
+            [str(DUCKDB), "-csv", "-c", secret() + sql],
+            capture_output=True, text=True, timeout=timeout, env=env,
+        )
+        return proc.returncode, proc.stdout, proc.stderr
+    except subprocess.TimeoutExpired:
+        return 124, "", f"TIMEOUT after {timeout}s"
+
+
+@dataclasses.dataclass
+class Case:
+    name: str            # Human-readable test name
+    sql: str             # The SELECT statement (just the sap_rfc_invoke + projection)
+    expects_rows: bool = True   # True → expect at least one row; False → OK if empty (e.g. SHOWUSERLIST output)
+    note: str = ""              # description of what this exercises
+
+
+# ----------------------------------------------------------------------
+# Hand-crafted test cases covering different RFC patterns
+# ----------------------------------------------------------------------
+CASES: list[Case] = [
+    # Pattern 1: zero-argument function returning a single struct
+    Case(
+        name="RFC_PING (no args, no return data)",
+        sql="SELECT COUNT(*) FROM sap_rfc_invoke('RFC_PING');",
+        note="Smoke test for the empty-args path",
+    ),
+
+    # Pattern 2: simple echo, single scalar input, two scalar outputs
+    Case(
+        name="STFC_CONNECTION (scalar in, two scalars out)",
+        sql=(
+            "SELECT ECHOTEXT, RESPTEXT FROM sap_rfc_invoke("
+            "  'STFC_CONNECTION', {'REQUTEXT': 'Hello SAP from DuckDB'}"
+            ");"
+        ),
+        note="Smoke test for the named-adapter scalar marshalling",
+    ),
+
+    # Pattern 3: zero-arg, struct return
+    Case(
+        name="RFC_SYSTEM_INFO (no args, struct return)",
+        sql=(
+            "SELECT (RFCSI_EXPORT).RFCDEST, (RFCSI_EXPORT).RFCSYSID, (RFCSI_EXPORT).RFCDBHOST "
+            "FROM sap_rfc_invoke('RFC_SYSTEM_INFO');"
+        ),
+        note="Tests path-less invocation returning a struct parameter",
+    ),
+
+    # Pattern 4: scalar input, table outputs (RFC_GET_FUNCTION_INTERFACE)
+    Case(
+        name="RFC_GET_FUNCTION_INTERFACE (scalar in, table out)",
+        sql=(
+            "SELECT COUNT(*) FROM sap_rfc_invoke("
+            "  'RFC_GET_FUNCTION_INTERFACE', {'FUNCNAME': 'STFC_CONNECTION'},"
+            "  path := '/PARAMS'"
+            ");"
+        ),
+        note="Tests result-set path navigation to a table parameter",
+    ),
+
+    # Pattern 5: input struct with embedded sub-struct (BAPI flight scenario)
+    Case(
+        name="BAPI_FLIGHT_GETLIST (nested struct input, table output)",
+        sql=(
+            "SELECT COUNT(*) FROM sap_rfc_invoke("
+            "  'BAPI_FLIGHT_GETLIST', "
+            "  {'AIRLINE': 'LH', 'DESTINATION_FROM': {'AIRPORTID': 'FRA'},"
+            "   'DESTINATION_TO': {'AIRPORTID': 'JFK'}},"
+            "  path := '/FLIGHT_LIST'"
+            ");"
+        ),
+        note="Tests AdaptStructure for nested struct args",
+    ),
+
+    # Pattern 6: function with table-typed input (DDIF_FIELDINFO_GET)
+    Case(
+        name="DDIF_FIELDINFO_GET (scalar in, multiple table outs)",
+        sql=(
+            "SELECT COUNT(*) FROM sap_rfc_invoke("
+            "  'DDIF_FIELDINFO_GET', {'TABNAME': 'SFLIGHT'},"
+            "  path := '/DFIES_TAB'"
+            ");"
+        ),
+        note="Common DDIC introspection function with table result",
+    ),
+
+    # Pattern 7: STFC_DEEP_STRUCTURE — deep nested struct (RFC test function)
+    # Note: param names use NO underscores on this trial container.
+    # IMPORTSTRUCT is of ABAP type STFCCPLXT with fields I (INT), C (CHAR),
+    # STR (STRING), XSTR (XSTRING).
+    Case(
+        name="STFC_DEEP_STRUCTURE (deep struct echo)",
+        sql=(
+            "SELECT (ECHOSTRUCT).I, (ECHOSTRUCT).C, (ECHOSTRUCT).STR "
+            "FROM sap_rfc_invoke("
+            "  'STFC_DEEP_STRUCTURE', "
+            "  {'IMPORTSTRUCT': {'I': 42, 'C': 'AB', 'STR': 'top', 'XSTR': ''}}"
+            ");"
+        ),
+        note="Tests AdaptStructure round-trip with mixed INT/CHAR/STRING/XSTRING fields",
+    ),
+
+    # Pattern 8: STFC_DEEP_TABLE — deep table input/output (echo)
+    Case(
+        name="STFC_DEEP_TABLE (table input round-trip)",
+        sql=(
+            "SELECT COUNT(*) FROM sap_rfc_invoke("
+            "  'STFC_DEEP_TABLE', "
+            "  {'IMPORT_TAB': [{'I': 1, 'C': 'AA', 'STR': 'a', 'XSTR': ''},"
+            "                  {'I': 2, 'C': 'BB', 'STR': 'b', 'XSTR': ''}]},"
+            "  path := '/EXPORT_TAB'"
+            ");"
+        ),
+        note="Tests AdaptTable: pushing list-of-struct from DuckDB into RFC table param",
+    ),
+
+    # Pattern 9: BAPI_USER_GETLIST — table out, optional filters
+    Case(
+        name="BAPI_USER_GETLIST (optional filters, table return)",
+        sql=(
+            "SELECT COUNT(*) FROM sap_rfc_invoke("
+            "  'BAPI_USER_GETLIST', {'MAX_ROWS': 5},"
+            "  path := '/USERLIST'"
+            ");"
+        ),
+        note="Tests integer scalar param",
+    ),
+
+    # Pattern 10: BAPI_USER_GET_DETAIL — string in, many structs+tables out
+    Case(
+        name="BAPI_USER_GET_DETAIL (string in, mixed struct+table out)",
+        sql=(
+            "SELECT (ADDRESS).FULLNAME, (LOGONDATA).USTYP "
+            "FROM sap_rfc_invoke("
+            "  'BAPI_USER_GET_DETAIL', {'USERNAME': 'DEVELOPER'}"
+            ");"
+        ),
+        note="Tests no-path invocation returning many output params",
+    ),
+
+    # Pattern 11: RFC_FUNCTION_SEARCH — multiple optional args + table out
+    Case(
+        name="RFC_FUNCTION_SEARCH (multiple scalar filters, table out)",
+        sql=(
+            "SELECT COUNT(*) FROM sap_rfc_invoke("
+            "  'RFC_FUNCTION_SEARCH', {'FUNCNAME': 'STFC*', 'GROUPNAME': '*'},"
+            "  path := '/FUNCTIONS'"
+            ");"
+        ),
+        note="Pattern-match arg",
+    ),
+
+    # Pattern 12: RFC_GET_LOCAL_DESTINATIONS — no args, table out (may be empty on trial)
+    Case(
+        name="RFC_GET_LOCAL_DESTINATIONS (no args, table out)",
+        sql=(
+            "SELECT COUNT(*) FROM sap_rfc_invoke("
+            "  'RFC_GET_LOCAL_DESTINATIONS',"
+            "  path := '/LOCALDEST'"
+            ");"
+        ),
+        expects_rows=True,
+        note="No-arg + path navigation (table name LOCALDEST, no underscore)",
+    ),
+
+    # Pattern 13: BAPI_HELPVALUES_GET — multiple scalar inputs
+    Case(
+        name="BAPI_HELPVALUES_GET (multiple scalars in)",
+        sql=(
+            "SELECT COUNT(*) FROM sap_rfc_invoke("
+            "  'BAPI_HELPVALUES_GET', "
+            "  {'OBJTYPE': 'BUS1006', 'METHOD': 'GETLIST', 'PARAMETER': 'COMPANYDATA',"
+            "   'FIELD': 'COMPANY'},"
+            "  path := '/HELPVALUES'"
+            ");"
+        ),
+        note="Multiple scalar args, table named HELPVALUES (no underscore)",
+    ),
+
+    # Pattern 14: STFC_PERFORMANCE — many scalar params with defaults
+    # The trial container exposes a slimmer interface: CHECKTAB, LGET0332, LGET1000, LGIT0332, LGIT1000.
+    # The LGET*/LGIT* params are RFCTYPE_NUM (zero-padded numeric strings).
+    Case(
+        name="STFC_PERFORMANCE (mixed-type scalar params)",
+        sql=(
+            "SELECT COUNT(*) > 0 FROM sap_rfc_invoke("
+            "  'STFC_PERFORMANCE', "
+            "  {'CHECKTAB': ' ', 'LGET0332': '0', 'LGET1000': '0',"
+            "                    'LGIT0332': '0', 'LGIT1000': '0'}"
+            ");"
+        ),
+        note="NUM-typed params must be passed as numeric strings, not integers",
+    ),
+
+    # Pattern 16: RFC_PING — truly no params, no returns (the synthetic-ok-column path)
+    Case(
+        name="RFC_PING (no params, no returns; synthetic ok column)",
+        sql="SELECT ok FROM sap_rfc_invoke('RFC_PING');",
+        note="Regression test: previously crashed bind with 'must return at least one column'",
+    ),
+
+    # Pattern 15: Edge case: missing required argument — should give a clean error
+    Case(
+        name="EDGE: BAPI_USER_GET_DETAIL without USERNAME (expected error)",
+        sql="SELECT * FROM sap_rfc_invoke('BAPI_USER_GET_DETAIL');",
+        expects_rows=False,  # this should error, not return rows
+        note="Validate clean error path when required arg missing",
+    ),
+]
+
+
+def classify(rc: int, stderr: str) -> str:
+    if rc == 0:
+        return "OK"
+    if "RFC_ABAP_EXCEPTION" in stderr or "RFC_ABAP_MESSAGE" in stderr:
+        return "ABAP_EXCEPTION"
+    if "RFC_COMMUNICATION_FAILURE" in stderr or "Timeout while opening" in stderr:
+        return "SAP_UNAVAILABLE"
+    if "Parameter " in stderr and "not found" in stderr:
+        return "PARAM_NOT_FOUND"
+    if "TIMEOUT after" in stderr:
+        return "TIMEOUT"
+    if "Invalid Error" in stderr or "Failed to invoke function" in stderr:
+        # SDK side hit something — could be ABAP exception or client bug
+        if "RFC_EXCEPTION" in stderr:
+            return "RFC_EXCEPTION"
+        return "INVOKE_FAILED"
+    return "OTHER_ERROR"
+
+
+def main() -> int:
+    ARTIFACTS.mkdir(parents=True, exist_ok=True)
+    report_path = ARTIFACTS / f"fuzz_{int(time.time())}.txt"
+    print(f"== Fuzz {len(CASES)} sap_rfc_invoke cases ==")
+    results = []
+    with report_path.open("w") as f:
+        for i, case in enumerate(CASES, 1):
+            t0 = time.perf_counter()
+            rc, out, err = run_cli(case.sql, timeout=120)
+            elapsed = time.perf_counter() - t0
+            cls = classify(rc, err)
+
+            # For "expects rows" cases, also check that we actually got non-zero
+            extra = ""
+            if case.expects_rows and cls == "OK":
+                last = out.strip().split("\n")[-1].strip().strip('"')
+                # Try parsing as int first; if non-numeric, just say "ok"
+                try:
+                    n = int(last.split(",")[0])
+                    if n == 0:
+                        extra = " (ZERO ROWS!)"
+                except ValueError:
+                    pass
+
+            outcome = f"[{cls}] {case.name} ({elapsed:.1f}s){extra}"
+            print(f"  {i:>2}. {outcome}")
+            results.append((cls, case.name, elapsed, extra, err[:500] if err else ""))
+            f.write(f"\n=== Case {i}: {case.name} ===\n")
+            f.write(f"NOTE: {case.note}\n")
+            f.write(f"SQL: {case.sql}\n")
+            f.write(f"OUTCOME: {cls}{extra}  ({elapsed:.1f}s)\n")
+            if rc != 0:
+                f.write(f"STDERR (first 500 chars):\n{err[:500]}\n")
+            else:
+                f.write(f"STDOUT (first 500 chars):\n{out[:500]}\n")
+
+    # Summary
+    print("\n=== Summary ===")
+    by_outcome: dict[str, int] = {}
+    for cls, *_ in results:
+        by_outcome[cls] = by_outcome.get(cls, 0) + 1
+    for cls, n in sorted(by_outcome.items()):
+        print(f"  {cls:20s} {n}")
+    print(f"\nReport: {report_path}")
+
+    # Exit non-zero only if there are client-side bugs (OK or known ABAP exceptions are fine)
+    suspicious = sum(n for cls, n in by_outcome.items()
+                     if cls in ("INVOKE_FAILED", "OTHER_ERROR", "TIMEOUT", "PARAM_NOT_FOUND"))
+    return 0 if suspicious == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rfc/test/parallel/oracles.py
+++ b/rfc/test/parallel/oracles.py
@@ -1,0 +1,89 @@
+"""Build single-transaction oracles for parallel-scan verification.
+
+The strongest oracle is a single RFC_READ_TABLE invocation in one transaction
+with ALL desired columns in FIELDS — that guarantees a self-consistent row
+order across the whole result. We use that for tables where rfc invoke can
+parse the result.
+
+For practical coverage we also support a "weak oracle" mode: a serialized
+single-thread sap_read_table run. With THREADS=1 column-parallelism is
+sequenced but rows still come from separate RFC calls — order alignment is
+only stable for quiescent tables in practice. We use it as a sanity check,
+not as proof.
+"""
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+import subprocess
+
+
+@dataclasses.dataclass
+class TableInfo:
+    name: str
+    pk_columns: list[str]
+    all_columns: list[str]
+    row_count: int | None
+
+
+def describe_fields(cli_run, table: str) -> tuple[list[str], list[str]]:
+    """Return (all_columns, pk_columns) for a SAP table/view."""
+    sql = (
+        f"SELECT field, is_key FROM sap_describe_fields('{table}') "
+        f"ORDER BY pos;"
+    )
+    out = cli_run(sql, timeout=120)
+    cols: list[str] = []
+    pks: list[str] = []
+    for line in out.strip().split("\n")[1:]:  # skip header
+        if not line.strip():
+            continue
+        parts = line.split(",")
+        if len(parts) < 2:
+            continue
+        name = parts[0].strip().strip('"')
+        is_key = parts[1].strip().strip('"').upper() in ("X", "TRUE", "1")
+        cols.append(name)
+        if is_key:
+            pks.append(name)
+    return cols, pks
+
+
+def count_rows(cli_run, table: str, *, timeout: int = 120) -> int | None:
+    sql = f"SELECT COUNT(*)::BIGINT AS c FROM sap_read_table('{table}', THREADS=1);"
+    try:
+        out = cli_run(sql, timeout=timeout)
+    except (subprocess.TimeoutExpired, RuntimeError):
+        return None
+    lines = [l for l in out.strip().split("\n") if l]
+    if len(lines) < 2:
+        return None
+    try:
+        return int(lines[-1].strip().strip('"'))
+    except ValueError:
+        return None
+
+
+def get_table_info(cli_run, table: str) -> TableInfo:
+    cols, pks = describe_fields(cli_run, table)
+    rows = count_rows(cli_run, table)
+    return TableInfo(name=table, pk_columns=pks, all_columns=cols, row_count=rows)
+
+
+def build_parquet_oracle(cli_run, oracle_dir: pathlib.Path, table: str,
+                         columns: list[str] | None = None,
+                         threads: int = 1) -> pathlib.Path:
+    """Materialize the table at THREADS=1 to a parquet file. Weak oracle."""
+    oracle_dir.mkdir(parents=True, exist_ok=True)
+    safe = table.replace("/", "_")
+    out_path = oracle_dir / f"{safe}.parquet"
+    col_clause = ""
+    if columns:
+        cols_str = ",".join(f"'{c}'" for c in columns)
+        col_clause = f", COLUMNS=[{cols_str}]"
+    sql = (
+        f"COPY (SELECT * FROM sap_read_table('{table}', THREADS={threads}{col_clause})) "
+        f"TO '{out_path}' (FORMAT 'parquet');"
+    )
+    cli_run(sql, timeout=900)
+    return out_path

--- a/rfc/test/parallel/perf_sweep.py
+++ b/rfc/test/parallel/perf_sweep.py
@@ -1,0 +1,105 @@
+"""DDIC perf sweep — record wall-clock for various THREADS on DD02L and T100.
+
+T100 has 615k rows, DD02L has 164k. TADIR (1.3M) is skipped to keep the run
+under 30 min. Writes CSV to artifacts/perf/ddic.csv.
+
+Reads only a single-column subset to keep per-row cost low (the test exercises
+SAP-side throughput, not DuckDB conversion).
+"""
+from __future__ import annotations
+
+import csv
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+DUCKDB = REPO_ROOT / "build" / "debug" / "duckdb"
+ADT_CREDS = REPO_ROOT / ".adt.creds"
+ARTIFACTS = REPO_ROOT / "artifacts" / "perf"
+
+TABLES = [
+    ("DD02L", 164656, ["TABNAME", "TABCLASS"]),    # 2-col scan
+    ("T100",  615666, ["SPRSL", "ARBGB", "MSGNR"]),  # 3-col scan
+]
+THREAD_VALUES = [1, 2, 4, 8]
+
+
+def secret() -> str:
+    c = json.loads(ADT_CREDS.read_text())
+    return f"""CREATE OR REPLACE SECRET abap_trial (
+    TYPE sap_rfc, ASHOST '{c.get("host", "localhost")}',
+    SYSNR '00', CLIENT '{c.get("client", "001")}',
+    USER '{c.get("user", "DEVELOPER")}', PASSWD '{c.get("password", "")}', LANG 'EN'
+);
+"""
+
+
+def run_timed(sql: str, *, timeout: int = 600) -> float:
+    env = {**os.environ}
+    env["LD_LIBRARY_PATH"] = f"{REPO_ROOT / 'nwrfcsdk' / 'linux' / 'lib'}:{env.get('LD_LIBRARY_PATH', '')}"
+    env["LSAN_OPTIONS"] = f"suppressions={REPO_ROOT / 'scripts' / 'lsan_suppress.txt'}:print_suppressions=0"
+    env["ASAN_OPTIONS"] = "detect_odr_violation=0:detect_leaks=0"
+    t0 = time.perf_counter()
+    proc = subprocess.run(
+        [str(DUCKDB), "-csv", "-c", secret() + sql],
+        capture_output=True, text=True, timeout=timeout, env=env,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"rc={proc.returncode}\nSTDERR: {proc.stderr[:500]}\nSTDOUT: {proc.stdout[:300]}")
+    return time.perf_counter() - t0
+
+
+def main() -> int:
+    ARTIFACTS.mkdir(parents=True, exist_ok=True)
+    csv_path = ARTIFACTS / "ddic.csv"
+    rows: list[list] = []
+    with csv_path.open("w", newline="") as fp:
+        writer = csv.writer(fp)
+        writer.writerow(["table", "row_count", "columns", "threads", "wall_seconds", "rows_per_sec"])
+        for table, row_count, columns in TABLES:
+            cols_list = "[" + ",".join(f"'{c}'" for c in columns) + "]"
+            for threads in THREAD_VALUES:
+                sql = (
+                    f"SELECT COUNT(*) FROM sap_read_table("
+                    f"'{table}', COLUMNS={cols_list}, THREADS={threads}"
+                    f");"
+                )
+                try:
+                    wall = run_timed(sql, timeout=900)
+                except Exception as e:
+                    print(f"  {table} threads={threads}: FAILED {str(e)[:150]}")
+                    writer.writerow([table, row_count, len(columns), threads, "ERROR", str(e)[:80]])
+                    continue
+                rps = row_count / wall if wall > 0 else 0
+                writer.writerow([table, row_count, len(columns), threads, f"{wall:.2f}", f"{rps:.0f}"])
+                rows.append([table, threads, wall, rps])
+                print(f"  {table:8s} rows={row_count:7d} cols={len(columns)} threads={threads:2d} "
+                      f"wall={wall:6.2f}s rps={rps:7.0f}")
+
+    print(f"\nCSV: {csv_path}")
+    # Quick speedup summary per table
+    print("\n=== Speedup vs THREADS=1 ===")
+    by_table: dict[str, list[tuple[int, float]]] = {}
+    for table, threads, wall, _rps in rows:
+        by_table.setdefault(table, []).append((threads, wall))
+    for table, runs in by_table.items():
+        runs.sort()
+        if not runs:
+            continue
+        baseline = next((w for t, w in runs if t == 1), None)
+        if not baseline:
+            continue
+        print(f"  {table}:")
+        for t, w in runs:
+            speedup = baseline / w if w > 0 else 0.0
+            print(f"    THREADS={t}: {w:6.2f}s  speedup={speedup:.2f}x")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rfc/test/parallel/probe.py
+++ b/rfc/test/parallel/probe.py
@@ -1,0 +1,140 @@
+"""Probe the running SAP system: function signatures and table row counts.
+
+Captures findings to artifacts/probe/. Run once before the rest of the harness:
+
+    uv run python rfc/test/parallel/probe.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+DUCKDB = REPO_ROOT / "build" / "debug" / "duckdb"
+ADT_CREDS = REPO_ROOT / ".adt.creds"
+ARTIFACTS = REPO_ROOT / "artifacts" / "probe"
+
+DDIC_CANDIDATES = ["T002", "T100", "DD02L", "DD03L", "DD04L", "DD07L", "TADIR", "E071"]
+TARGET_TABLES = ["/DMO/FLIGHT", "SFLIGHT", "SPFLI", "/DMO/TRAVEL", "/DMO/AGENCY"]
+TARGET_VIEWS = ["DD02V", "V_T100"]
+TARGET_CDS = ["/DMO/R_Booking_D", "/DMO/I_Carrier", "/DMO/I_Flight"]
+
+# Skip function-descriptor inspection — empirically slow on this container and
+# B8 will answer GET_SORTED behavior directly.
+FUNCS_TO_INSPECT: list[str] = []
+
+
+def load_creds() -> dict[str, str]:
+    c = json.loads(ADT_CREDS.read_text())
+    return {
+        "ASHOST": c.get("host", "localhost"),
+        "SYSNR": "00",
+        "CLIENT": c.get("client", "001"),
+        "USER": c.get("user", "DEVELOPER"),
+        "PASSWORD": c.get("password", ""),
+        "LANG": "EN",
+    }
+
+
+def secret_sql(creds: dict[str, str]) -> str:
+    return f"""CREATE OR REPLACE SECRET abap_trial (
+    TYPE sap_rfc,
+    ASHOST '{creds["ASHOST"]}',
+    SYSNR '{creds["SYSNR"]}',
+    CLIENT '{creds["CLIENT"]}',
+    USER '{creds["USER"]}',
+    PASSWD '{creds["PASSWORD"]}',
+    LANG '{creds["LANG"]}'
+);
+"""
+
+
+def run_cli(sql: str, *, timeout: int = 600) -> tuple[int, str, str]:
+    env = {**os.environ}
+    nwrfc = str(REPO_ROOT / "nwrfcsdk" / "linux" / "lib")
+    env["LD_LIBRARY_PATH"] = nwrfc + ":" + env.get("LD_LIBRARY_PATH", "")
+    # The debug build is ASan/LSan/UBSan instrumented and produces a wall of
+    # "leak" reports from libsapnwrfc.so static initialization on every exit.
+    # Use the existing suppression file plus odr suppression, and silence the
+    # leak channel during probing (we run TSAN/ASAN separately later).
+    env["LSAN_OPTIONS"] = f"suppressions={REPO_ROOT / 'scripts' / 'lsan_suppress.txt'}:print_suppressions=0"
+    env["ASAN_OPTIONS"] = "detect_odr_violation=0:detect_leaks=0"
+    proc = subprocess.run(
+        [str(DUCKDB), "-csv", "-c", sql],
+        capture_output=True, text=True, timeout=timeout, env=env,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def main() -> int:
+    ARTIFACTS.mkdir(parents=True, exist_ok=True)
+    creds = load_creds()
+    secret = secret_sql(creds)
+
+    # 1. Function signatures via the parameter table that sap_rfc_describe_function returns.
+    # The function returns a single row with fields {name, import[], export[], changing[], tables[]}.
+    print("== Function signatures ==")
+    sig_path = ARTIFACTS / "function_signatures.txt"
+    with sig_path.open("w") as f:
+        for fname in FUNCS_TO_INSPECT:
+            f.write(f"\n=== {fname} ===\n")
+            sql = secret + (
+                f"SELECT i.name AS pname FROM sap_rfc_describe_function('{fname}') d, "
+                f"unnest(d.import) AS t(i) "
+                f"UNION ALL SELECT t.name FROM sap_rfc_describe_function('{fname}') d, "
+                f"unnest(d.tables) AS t(t) "
+                f"ORDER BY pname;"
+            )
+            rc, out, err = run_cli(sql, timeout=60)
+            if rc != 0:
+                # Strip the long ASan/leak preamble for the printed line.
+                short_err = (err or "").strip().splitlines()
+                msg = next((l for l in short_err if l and "leak" not in l.lower() and "san" not in l.lower()), "")[:120]
+                f.write(f"[ERROR rc={rc}]\n{err}\n")
+                print(f"  {fname}: NOT AVAILABLE ({msg})")
+            else:
+                f.write(out)
+                has_sorted = "GET_SORTED" in out
+                has_et_data = "ET_DATA" in out
+                has_use_et = "USE_ET_DATA_4_RETURN" in out
+                print(f"  {fname}: ok GET_SORTED={has_sorted} ET_DATA={has_et_data} USE_ET_DATA_4_RETURN={has_use_et}")
+
+    # 2. Row counts for candidate tables / views / CDS
+    print("\n== Row counts ==")
+    counts_path = ARTIFACTS / "row_counts.csv"
+    with counts_path.open("w") as f:
+        f.write("kind,object_name,row_count,error\n")
+        for kind, names in (
+            ("table", DDIC_CANDIDATES + TARGET_TABLES),
+            ("view", TARGET_VIEWS),
+            ("cds", TARGET_CDS),
+        ):
+            for name in names:
+                # Use a single-column scan with a small THREADS to count fast.
+                # sap_describe_fields tells us a column name; fall back to *.
+                sql = secret + f"SELECT COUNT(*) AS c FROM sap_read_table('{name}', THREADS=1);"
+                try:
+                    rc, out, err = run_cli(sql, timeout=60)
+                except subprocess.TimeoutExpired:
+                    f.write(f"{kind},{name},,TIMEOUT\n")
+                    print(f"  {kind:5s} {name:30s} TIMEOUT (likely huge)")
+                    continue
+                if rc != 0:
+                    msg = err.strip().replace("\n", " | ")[:200]
+                    f.write(f"{kind},{name},,\"{msg}\"\n")
+                    print(f"  {kind:5s} {name:30s} ERROR ({msg[:60]})")
+                else:
+                    lines = [l for l in out.strip().split("\n") if l]
+                    count = lines[-1] if lines else ""
+                    f.write(f"{kind},{name},{count},\n")
+                    print(f"  {kind:5s} {name:30s} rows={count}")
+
+    print(f"\nArtifacts written to {ARTIFACTS}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rfc/test/parallel/run_baseline.py
+++ b/rfc/test/parallel/run_baseline.py
@@ -1,0 +1,289 @@
+"""Focused baseline runner — exercises the critical scenarios in one shot
+and produces a single report. Useful for quick pre/post-fix comparison.
+
+Run:
+    uv run python rfc/test/parallel/run_baseline.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+DUCKDB = REPO_ROOT / "build" / "debug" / "duckdb"
+ADT_CREDS = REPO_ROOT / ".adt.creds"
+ARTIFACTS = REPO_ROOT / "artifacts" / "baseline"
+
+
+def secret() -> str:
+    c = json.loads(ADT_CREDS.read_text())
+    return f"""CREATE OR REPLACE SECRET abap_trial (
+    TYPE sap_rfc,
+    ASHOST '{c.get("host", "localhost")}',
+    SYSNR '00',
+    CLIENT '{c.get("client", "001")}',
+    USER '{c.get("user", "DEVELOPER")}',
+    PASSWD '{c.get("password", "")}',
+    LANG 'EN'
+);
+"""
+
+
+def run(sql: str, *, timeout: int = 300, retries: int = 2) -> str:
+    env = {**os.environ}
+    env["LD_LIBRARY_PATH"] = f"{REPO_ROOT / 'nwrfcsdk' / 'linux' / 'lib'}:{env.get('LD_LIBRARY_PATH', '')}"
+    env["LSAN_OPTIONS"] = f"suppressions={REPO_ROOT / 'scripts' / 'lsan_suppress.txt'}:print_suppressions=0"
+    env["ASAN_OPTIONS"] = "detect_odr_violation=0:detect_leaks=0"
+    last = ""
+    for attempt in range(retries + 1):
+        try:
+            proc = subprocess.run(
+                [str(DUCKDB), "-csv", "-c", secret() + sql],
+                capture_output=True, text=True, timeout=timeout, env=env,
+            )
+        except subprocess.TimeoutExpired:
+            last = f"timeout after {timeout}s (attempt {attempt + 1})"
+            continue
+        if proc.returncode == 0:
+            return proc.stdout
+        last = f"rc={proc.returncode}\nSTDERR: {proc.stderr[:500]}\nSTDOUT: {proc.stdout[:500]}"
+        if "RFC_COMMUNICATION_FAILURE" not in (proc.stderr or "") and "Timeout while opening an RFC connection" not in (proc.stderr or ""):
+            break
+    raise RuntimeError(f"failed after {retries + 1} attempts: {last}\nSQL: {sql[:300]}")
+
+
+def last_value(out: str) -> str:
+    lines = [l for l in out.strip().split("\n") if l]
+    return lines[-1].strip().strip('"') if lines else ""
+
+
+class Result:
+    def __init__(self, name: str):
+        self.name = name
+        self.passed: bool | None = None
+        self.detail: str = ""
+        self.duration: float = 0.0
+
+    def record(self, ok: bool, detail: str = ""):
+        self.passed = ok
+        self.detail = detail
+
+    def __str__(self) -> str:
+        status = "PASS" if self.passed else ("FAIL" if self.passed is False else "SKIP")
+        return f"[{status}] {self.name} ({self.duration:.1f}s) — {self.detail}"
+
+
+def scenario_b1_multiset(name: str = "B1: THREADS=1 vs THREADS=4 multiset") -> Result:
+    r = Result(name); t0 = time.perf_counter()
+    sql = (
+        "SELECT md5(string_agg(j, '' ORDER BY j)) FROM ("
+        "  SELECT row_to_json(t)::VARCHAR AS j FROM ("
+        "    SELECT * FROM sap_read_table('/DMO/FLIGHT', THREADS={threads})"
+        "  ) AS t"
+        ") sub;"
+    )
+    h1 = last_value(run(sql.replace("{threads}", "1")))
+    h4 = last_value(run(sql.replace("{threads}", "4")))
+    r.record(h1 == h4, f"h1={h1} h4={h4}")
+    r.duration = time.perf_counter() - t0
+    return r
+
+
+def scenario_b2_stability(name: str = "B2: 10-run hash stability THREADS=4") -> Result:
+    r = Result(name); t0 = time.perf_counter()
+    sql = (
+        "SELECT md5(string_agg(j, '' ORDER BY j)) FROM ("
+        "  SELECT row_to_json(t)::VARCHAR AS j FROM ("
+        "    SELECT * FROM sap_read_table('/DMO/FLIGHT', THREADS=4)"
+        "  ) AS t"
+        ") sub;"
+    )
+    hashes = [last_value(run(sql)) for _ in range(10)]
+    r.record(len(set(hashes)) == 1, f"unique={len(set(hashes))} hashes={hashes[:3]}…")
+    r.duration = time.perf_counter() - t0
+    return r
+
+
+def scenario_b2_pk_pivot(name: str = "B2: PK-pivot /DMO/FLIGHT no corruption") -> Result:
+    r = Result(name); t0 = time.perf_counter()
+    sql = """
+    WITH t1 AS (SELECT * FROM sap_read_table('/DMO/FLIGHT', THREADS=1)),
+         tn AS (SELECT * FROM sap_read_table('/DMO/FLIGHT', THREADS=4))
+    SELECT COUNT(*) AS mismatches
+    FROM t1 JOIN tn USING (CARRIER_ID, CONNECTION_ID, FLIGHT_DATE)
+    WHERE t1.PRICE IS DISTINCT FROM tn.PRICE
+       OR t1.CURRENCY_CODE IS DISTINCT FROM tn.CURRENCY_CODE
+       OR t1.PLANE_TYPE_ID IS DISTINCT FROM tn.PLANE_TYPE_ID
+       OR t1.SEATS_MAX IS DISTINCT FROM tn.SEATS_MAX
+       OR t1.SEATS_OCCUPIED IS DISTINCT FROM tn.SEATS_OCCUPIED;
+    """
+    v = last_value(run(sql))
+    r.record(v == "0", f"mismatches={v}")
+    r.duration = time.perf_counter() - t0
+    return r
+
+
+def scenario_b3_string_cols(name: str = "B3: /DMO/TRAVEL string cols (ET_DATA) THREADS=4 multiset") -> Result:
+    r = Result(name); t0 = time.perf_counter()
+    sql = """
+    WITH t1 AS (SELECT * FROM sap_read_table('/DMO/TRAVEL', THREADS=1,
+                                              READ_TABLE_FUNCTION='RFC_READ_TABLE',
+                                              READ_TABLE_DELIMITER='~')),
+         tn AS (SELECT * FROM sap_read_table('/DMO/TRAVEL', THREADS=4,
+                                              READ_TABLE_FUNCTION='RFC_READ_TABLE',
+                                              READ_TABLE_DELIMITER='~'))
+    SELECT (SELECT COUNT(*) FROM ((SELECT * FROM t1) EXCEPT ALL (SELECT * FROM tn))) +
+           (SELECT COUNT(*) FROM ((SELECT * FROM tn) EXCEPT ALL (SELECT * FROM t1)));
+    """
+    v = last_value(run(sql))
+    r.record(v == "0", f"multiset diff={v}")
+    r.duration = time.perf_counter() - t0
+    return r
+
+
+def scenario_b5_filter(name: str = "B5: filter pushdown vs post-filter") -> Result:
+    r = Result(name); t0 = time.perf_counter()
+    a = last_value(run("SELECT COUNT(*) FROM sap_read_table('/DMO/FLIGHT', THREADS=4) WHERE CARRIER_ID = 'SQ';"))
+    b = last_value(run("SELECT COUNT(*) FROM (SELECT * FROM sap_read_table('/DMO/FLIGHT', THREADS=1)) WHERE CARRIER_ID = 'SQ';"))
+    r.record(a == b, f"pushed={a} post={b}")
+    r.duration = time.perf_counter() - t0
+    return r
+
+
+def scenario_b6_limit(name: str = "B6: LIMIT=17 THREADS=4 valid rows") -> Result:
+    r = Result(name); t0 = time.perf_counter()
+    sql = """
+    WITH oracle AS (SELECT * FROM sap_read_table('/DMO/FLIGHT', THREADS=1)),
+         candidate AS (SELECT * FROM sap_read_table('/DMO/FLIGHT', THREADS=4, MAX_ROWS=17))
+    SELECT COUNT(*)::VARCHAR || '|' ||
+           (SELECT COUNT(*) FROM ((SELECT * FROM candidate) EXCEPT ALL (SELECT * FROM oracle)))::VARCHAR
+    FROM candidate;
+    """
+    v = last_value(run(sql))
+    card, extras = v.split("|") if "|" in v else ("?", "?")
+    r.record(card == "17" and extras == "0", f"card={card} extras-not-in-oracle={extras}")
+    r.duration = time.perf_counter() - t0
+    return r
+
+
+def scenario_b8_sapds_misalign(name: str = "B8: /SAPDS/RFC_READ_TABLE2 misalignment killer") -> Result:
+    r = Result(name); t0 = time.perf_counter()
+    sql = """
+    WITH oracle AS (SELECT * FROM sap_read_table('/DMO/FLIGHT', THREADS=1)),
+         candidate AS (SELECT * FROM sap_read_table('/DMO/FLIGHT',
+                                                     THREADS=4,
+                                                     READ_TABLE_FUNCTION='/SAPDS/RFC_READ_TABLE2',
+                                                     READ_TABLE_DELIMITER='~'))
+    SELECT
+      (SELECT COUNT(*) FROM ((SELECT * FROM candidate) EXCEPT ALL (SELECT * FROM oracle)))::VARCHAR
+      || '|' ||
+      (SELECT COUNT(*) FROM ((SELECT * FROM oracle) EXCEPT ALL (SELECT * FROM candidate)))::VARCHAR;
+    """
+    v = last_value(run(sql))
+    extras, missing = v.split("|") if "|" in v else ("?", "?")
+    r.record(extras == "0" and missing == "0", f"synthetic={extras} missing={missing}")
+    r.duration = time.perf_counter() - t0
+    return r
+
+
+def scenario_scheduler_leak(name: str = "Scheduler: thread count stable across THREADS=2") -> Result:
+    """Confirm sap_read_table(THREADS=N) does not leak its setting into the
+    rest of the DuckDB session. We read the threads setting before and after,
+    via current_setting('threads').
+    """
+    r = Result(name); t0 = time.perf_counter()
+    out_before = last_value(run("SELECT current_setting('threads');"))
+    last_value(run("SELECT COUNT(*) FROM sap_read_table('/DMO/FLIGHT', THREADS=2);"))
+    out_after = last_value(run("SELECT current_setting('threads');"))
+    # current_setting returns the requested thread count; if that's mutated
+    # by sap_read_table, after != before.
+    r.record(out_before == out_after, f"before={out_before} after={out_after}")
+    r.duration = time.perf_counter() - t0
+    return r
+
+
+def scenario_scheduler_leak_same_session(name: str = "Scheduler: same-session thread setting stable") -> Result:
+    """The leak is per-DB-instance, but each `run()` here spawns a fresh CLI
+    process. To test the actual leak we need a single-session scenario: read
+    threads, run sap_read_table(THREADS=2), read threads, all in one CLI
+    invocation.
+    """
+    r = Result(name); t0 = time.perf_counter()
+    sql = (
+        "SELECT current_setting('threads') AS t;"
+        "SELECT COUNT(*) FROM sap_read_table('/DMO/FLIGHT', THREADS=2);"
+        "SELECT current_setting('threads') AS t;"
+    )
+    out = run(sql)
+    lines = [l.strip().strip('"') for l in out.strip().split("\n") if l.strip()]
+    # CSV output groups stmt outputs: ["t","16","count_star()","40","t","2"] for example.
+    t_vals: list[str] = []
+    for i, l in enumerate(lines):
+        if l == "t" and i + 1 < len(lines):
+            t_vals.append(lines[i + 1])
+    if len(t_vals) != 2:
+        r.record(False, f"could not parse threads readings: {t_vals} from {lines}")
+    else:
+        r.record(t_vals[0] == t_vals[1], f"before={t_vals[0]} after={t_vals[1]}")
+    r.duration = time.perf_counter() - t0
+    return r
+
+
+def scenario_join_stability(name: str = "B7: SFLIGHT⋈SPFLI count stable across 5 runs") -> Result:
+    r = Result(name); t0 = time.perf_counter()
+    sql = """
+    SELECT COUNT(*)
+    FROM sap_read_table('SFLIGHT', THREADS=4) f
+    JOIN sap_read_table('SPFLI', THREADS=4) s
+        ON (f.MANDT = s.MANDT AND f.CARRID = s.CARRID AND f.CONNID = s.CONNID);
+    """
+    counts = [last_value(run(sql)) for _ in range(5)]
+    r.record(len(set(counts)) == 1, f"counts={counts}")
+    r.duration = time.perf_counter() - t0
+    return r
+
+
+SCENARIOS = [
+    scenario_b1_multiset,
+    scenario_b2_stability,
+    scenario_b2_pk_pivot,
+    scenario_b3_string_cols,
+    scenario_b5_filter,
+    scenario_b6_limit,
+    scenario_b8_sapds_misalign,
+    scenario_scheduler_leak,
+    scenario_scheduler_leak_same_session,
+    scenario_join_stability,
+]
+
+
+def main() -> int:
+    ARTIFACTS.mkdir(parents=True, exist_ok=True)
+    print("== Pre/Post-fix baseline ==")
+    results: list[Result] = []
+    for fn in SCENARIOS:
+        try:
+            r = fn()
+        except Exception as e:
+            r = Result(fn.__name__)
+            r.record(False, f"EXCEPTION: {str(e)[:300]}")
+        results.append(r)
+        print(" ", r)
+
+    summary_path = ARTIFACTS / f"summary_{int(time.time())}.txt"
+    with summary_path.open("w") as f:
+        f.write("# Baseline run\n\n")
+        for r in results:
+            f.write(str(r) + "\n")
+    print(f"\nSummary written to {summary_path}")
+
+    failed = [r for r in results if r.passed is False]
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rfc/test/parallel/test_alignment.py
+++ b/rfc/test/parallel/test_alignment.py
@@ -1,0 +1,191 @@
+"""Row-alignment verification for sap_read_table parallelism.
+
+The core risk being tested: each requested column issues its own RFC_READ_TABLE
+call. If SAP returns rows in different orders across the per-column calls,
+DuckDB stitches them by position and produces tuples that never existed in the
+source — silent data corruption.
+
+Detection strategy: build an oracle and compare candidate against it using
+multiset semantics (EXCEPT ALL). Any misaligned candidate row produces a
+synthetic tuple that does NOT appear in the oracle, so EXCEPT ALL surfaces it.
+
+We use two oracles:
+  - Strong: a single sap_rfc_invoke('RFC_READ_TABLE', FIELDS=[all]) call, parsed
+    into typed rows. One RFC transaction = one consistent row order.
+  - Weak: sap_read_table with THREADS=1. Column-parallel still happens (each
+    column gets its own RFC call), but they run serially. For quiescent tables
+    this is empirically stable but not guaranteed.
+
+The strong oracle is the gold standard. The weak oracle catches racing
+parallelism vs serial-but-still-column-parallel divergence.
+"""
+from __future__ import annotations
+
+import pytest
+
+from oracles import get_table_info
+
+
+# Tables that should fit in the trial container's demo data. Probed up-front
+# by the probe.py script; row counts here are upper bounds — tests use the
+# actual row count discovered at runtime.
+SMALL_TABLES = [
+    "/DMO/FLIGHT",
+    "SFLIGHT",
+    "SPFLI",
+    "/DMO/AGENCY",
+]
+STRING_TABLES = [
+    "/DMO/TRAVEL",     # has SSTR
+    "/DMO/AGENCY",     # has STRG
+]
+
+
+@pytest.mark.parametrize("table", SMALL_TABLES)
+def test_threads_n_matches_threads_one_multiset(cli_run, table):
+    """B1+B2: parallel result must be the same multiset as the threads=1 result.
+
+    Row order is not asserted; only that every row produced under THREADS=N
+    also appears under THREADS=1 and vice versa.
+    """
+    sql_for = lambda threads: (
+        f"SELECT md5(string_agg(row_to_json(t)::VARCHAR, '' ORDER BY row_to_json(t)::VARCHAR)) "
+        f"FROM (SELECT * FROM sap_read_table('{table}', THREADS={threads})) AS t;"
+    )
+    out1 = cli_run(sql_for(1)).strip().split("\n")[-1].strip('"')
+    out_n = cli_run(sql_for(4)).strip().split("\n")[-1].strip('"')
+    assert out1 == out_n, f"{table}: THREADS=1 ({out1}) != THREADS=4 ({out_n})"
+
+
+@pytest.mark.parametrize("table", SMALL_TABLES)
+def test_parallel_run_stability(cli_run, table):
+    """B2 inter-run stability: same query 10× must give identical hashes."""
+    sql = (
+        f"SELECT md5(string_agg(row_to_json(t)::VARCHAR, '' ORDER BY row_to_json(t)::VARCHAR)) "
+        f"FROM (SELECT * FROM sap_read_table('{table}', THREADS=4)) AS t;"
+    )
+    hashes = []
+    for _ in range(10):
+        out = cli_run(sql).strip().split("\n")[-1].strip('"')
+        hashes.append(out)
+    assert len(set(hashes)) == 1, f"{table}: hash drift across 10 runs: {hashes}"
+
+
+def test_pk_pivot_no_corruption(cli_run):
+    """B2 PK-pivot: for /DMO/FLIGHT, every (CARRIER_ID, CONNECTION_ID, FLIGHT_DATE)
+    row in the THREADS=4 result must have the SAME PRICE/CURRENCY/PLANE/SEATS
+    values as the same PK row in the THREADS=1 result. Misalignment would
+    produce different non-PK values for the same PK.
+    """
+    sql = """
+    WITH t1 AS (SELECT * FROM sap_read_table('/DMO/FLIGHT', THREADS=1)),
+         tn AS (SELECT * FROM sap_read_table('/DMO/FLIGHT', THREADS=4))
+    SELECT COUNT(*) AS mismatches
+    FROM t1 JOIN tn USING (CARRIER_ID, CONNECTION_ID, FLIGHT_DATE)
+    WHERE t1.PRICE IS DISTINCT FROM tn.PRICE
+       OR t1.CURRENCY_CODE IS DISTINCT FROM tn.CURRENCY_CODE
+       OR t1.PLANE_TYPE_ID IS DISTINCT FROM tn.PLANE_TYPE_ID
+       OR t1.SEATS_MAX IS DISTINCT FROM tn.SEATS_MAX
+       OR t1.SEATS_OCCUPIED IS DISTINCT FROM tn.SEATS_OCCUPIED;
+    """
+    out = cli_run(sql).strip().split("\n")[-1].strip('"')
+    assert out == "0", f"/DMO/FLIGHT: {out} rows with mismatched non-PK values between THREADS=1 and THREADS=4"
+
+
+def test_projection_subset_threads_4(cli_run):
+    """B4: a 3-of-N column projection must still align rows."""
+    sql = """
+    WITH t1 AS (SELECT CARRIER_ID, CONNECTION_ID, PRICE FROM sap_read_table('/DMO/FLIGHT', THREADS=1)),
+         tn AS (SELECT CARRIER_ID, CONNECTION_ID, PRICE FROM sap_read_table('/DMO/FLIGHT', THREADS=4))
+    SELECT (SELECT COUNT(*) FROM ((SELECT * FROM t1) EXCEPT ALL (SELECT * FROM tn))) +
+           (SELECT COUNT(*) FROM ((SELECT * FROM tn) EXCEPT ALL (SELECT * FROM t1)));
+    """
+    out = cli_run(sql).strip().split("\n")[-1].strip('"')
+    assert out == "0", f"projection multiset mismatch: {out}"
+
+
+def test_filter_pushdown_threads_4(cli_run):
+    """B5: filter pushdown must produce the same row count and content as filter applied post-scan."""
+    sql_pushed = "SELECT COUNT(*) FROM sap_read_table('/DMO/FLIGHT', THREADS=4) WHERE CARRIER_ID = 'SQ';"
+    sql_post   = "SELECT COUNT(*) FROM (SELECT * FROM sap_read_table('/DMO/FLIGHT', THREADS=1)) WHERE CARRIER_ID = 'SQ';"
+    a = cli_run(sql_pushed).strip().split("\n")[-1].strip('"')
+    b = cli_run(sql_post).strip().split("\n")[-1].strip('"')
+    assert a == b, f"filter pushdown: {a} != {b}"
+
+
+def test_limit_threads_4(cli_run):
+    """B6: LIMIT N over parallel scan returns exactly N rows, each a valid source row."""
+    sql = """
+    WITH oracle AS (SELECT * FROM sap_read_table('/DMO/FLIGHT', THREADS=1)),
+         candidate AS (SELECT * FROM sap_read_table('/DMO/FLIGHT', THREADS=4, MAX_ROWS=17))
+    SELECT COUNT(*) AS card,
+           (SELECT COUNT(*) FROM ((SELECT * FROM candidate) EXCEPT ALL (SELECT * FROM oracle))) AS extras
+    FROM candidate;
+    """
+    out = cli_run(sql).strip().split("\n")
+    # CSV: header then values
+    card, extras = out[-1].strip('"').split(",")
+    assert card == "17", f"LIMIT cardinality wrong: {card}"
+    assert extras == "0", f"LIMIT produced {extras} rows not in the oracle"
+
+
+@pytest.mark.parametrize("table", STRING_TABLES)
+def test_string_columns_threads_4(cli_run, table):
+    """B3: string-typed columns (SSTR/STRG via ET_DATA path) must align under parallelism."""
+    info = get_table_info(cli_run, table)
+    sql = f"""
+    WITH t1 AS (SELECT * FROM sap_read_table('{table}', THREADS=1,
+                                              READ_TABLE_FUNCTION='RFC_READ_TABLE',
+                                              READ_TABLE_DELIMITER='~')),
+         tn AS (SELECT * FROM sap_read_table('{table}', THREADS=4,
+                                              READ_TABLE_FUNCTION='RFC_READ_TABLE',
+                                              READ_TABLE_DELIMITER='~'))
+    SELECT (SELECT COUNT(*) FROM ((SELECT * FROM t1) EXCEPT ALL (SELECT * FROM tn))) +
+           (SELECT COUNT(*) FROM ((SELECT * FROM tn) EXCEPT ALL (SELECT * FROM t1)));
+    """
+    out = cli_run(sql).strip().split("\n")[-1].strip('"')
+    assert out == "0", f"{table} string-cols multiset mismatch: {out} (row count={info.row_count})"
+
+
+def test_sapds_get_sorted_misalignment(cli_run):
+    """B8: the misalignment killer.
+
+    With /SAPDS/RFC_READ_TABLE2, the code unconditionally sets GET_SORTED=X.
+    If GET_SORTED sorts by the FIELDS list (which differs per column under
+    column-parallel reads), rows come back in different orders per column and
+    DuckDB stitches them into corrupted tuples.
+
+    Pass: candidate multiset == oracle multiset.
+    Fail: candidate has rows that don't exist in the oracle → silent corruption.
+    """
+    sql = """
+    WITH oracle AS (SELECT * FROM sap_read_table('/DMO/FLIGHT', THREADS=1)),
+         candidate AS (SELECT * FROM sap_read_table('/DMO/FLIGHT',
+                                                     THREADS=4,
+                                                     READ_TABLE_FUNCTION='/SAPDS/RFC_READ_TABLE2',
+                                                     READ_TABLE_DELIMITER='~'))
+    SELECT (SELECT COUNT(*) FROM ((SELECT * FROM candidate) EXCEPT ALL (SELECT * FROM oracle))) AS extras,
+           (SELECT COUNT(*) FROM ((SELECT * FROM oracle) EXCEPT ALL (SELECT * FROM candidate))) AS missing;
+    """
+    out = cli_run(sql).strip().split("\n")
+    extras, missing = out[-1].strip('"').split(",")
+    assert extras == "0" and missing == "0", (
+        f"/SAPDS/RFC_READ_TABLE2 parallel scan corrupted rows: "
+        f"{extras} synthetic (not-in-source) rows, {missing} missing rows. "
+        f"This proves the GET_SORTED-with-per-column-FIELDS misalignment hypothesis."
+    )
+
+
+def test_join_two_parallel_reads_deterministic(cli_run):
+    """B7: a join of two parallel reads must return a stable count across repetitions."""
+    sql = """
+    SELECT COUNT(*)
+    FROM sap_read_table('SFLIGHT', THREADS=4) AS f
+    JOIN sap_read_table('SPFLI', THREADS=4) AS s
+        ON (f.MANDT = s.MANDT AND f.CARRID = s.CARRID AND f.CONNID = s.CONNID);
+    """
+    counts = []
+    for _ in range(5):
+        out = cli_run(sql).strip().split("\n")[-1].strip('"')
+        counts.append(out)
+    assert len(set(counts)) == 1, f"unstable join count across runs: {counts}"

--- a/rfc/test/parallel/test_breadth.py
+++ b/rfc/test/parallel/test_breadth.py
@@ -1,0 +1,33 @@
+"""Broad coverage across SAP object kinds: transparent tables, DDIC views,
+CDS views. Verifies that parallel scans work and produce stable hashes for
+each kind.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+OBJECTS = [
+    # (kind, name, threads-1 row count is expected to be small enough to run)
+    ("table", "/DMO/FLIGHT"),
+    ("table", "SFLIGHT"),
+    ("table", "SPFLI"),
+    ("table", "/DMO/TRAVEL"),
+    ("table", "/DMO/AGENCY"),
+    ("table", "T002"),
+    ("cds",   "/DMO/R_Booking_D"),
+    ("cds",   "/DMO/I_Carrier"),
+]
+
+
+@pytest.mark.parametrize("kind,name", OBJECTS, ids=[f"{k}:{n}" for k, n in OBJECTS])
+def test_parallel_scan_works_and_is_stable(cli_run, kind, name):
+    sql = f"""
+    SELECT md5(string_agg(row_to_json(t)::VARCHAR, '' ORDER BY row_to_json(t)::VARCHAR))
+    FROM (SELECT * FROM sap_read_table('{name}', THREADS=4)) AS t;
+    """
+    hashes = []
+    for _ in range(3):
+        out = cli_run(sql, timeout=300).strip().split("\n")[-1].strip('"')
+        hashes.append(out)
+    assert len(set(hashes)) == 1, f"{kind} {name}: hash drift across 3 runs: {hashes}"

--- a/rfc/test/parallel/test_global_scheduler.py
+++ b/rfc/test/parallel/test_global_scheduler.py
@@ -1,0 +1,37 @@
+"""Verify that sap_read_table(THREADS=N) does not leak the thread setting to
+the rest of the DuckDB session.
+
+Pre-fix: sap_rfc.cpp:676 calls scheduler.SetThreads(max_threads, 1), which
+mutates the global TaskScheduler's requested_thread_count. RelaunchThreads()
+applies it at the next CleanupInternal — so any subsequent query (or PRAGMA
+threads) is affected.
+
+Post-fix: max_threads is enforced by batching tasks in Step(), not by mutating
+the scheduler. PRAGMA threads should be unchanged before/after.
+"""
+from __future__ import annotations
+
+
+def test_pragma_threads_preserved(cli_run):
+    """Run a sap_read_table with THREADS=2, then check that the configured
+    thread setting is unchanged.
+
+    `PRAGMA threads` is not a query-style pragma in current DuckDB; use
+    `current_setting('threads')` instead.
+    """
+    sql = (
+        "SELECT current_setting('threads') AS t;"
+        "SELECT COUNT(*) FROM sap_read_table('/DMO/FLIGHT', THREADS=2);"
+        "SELECT current_setting('threads') AS t;"
+    )
+    out = cli_run(sql)
+    lines = [l.strip().strip('"') for l in out.strip().split("\n") if l.strip()]
+    # CSV output groups stmt results: ["t","32","count_star()","40","t","32"]
+    t_vals: list[str] = []
+    for i, l in enumerate(lines):
+        if l == "t" and i + 1 < len(lines):
+            t_vals.append(lines[i + 1])
+    assert len(t_vals) == 2, f"expected 2 thread readings, got: {t_vals} from {lines}"
+    assert t_vals[0] == t_vals[1], (
+        f"thread setting changed across sap_read_table: before={t_vals[0]} after={t_vals[1]}"
+    )

--- a/rfc/test/parallel/test_perf_ddic.py
+++ b/rfc/test/parallel/test_perf_ddic.py
@@ -1,0 +1,61 @@
+"""Performance characterization on DDIC tables.
+
+This is not a pass/fail test — it records timings for THREADS in {1,2,4,8,16}
+on the largest DDIC tables that the trial container has, writing CSV to
+artifacts/perf/ddic.csv.
+"""
+from __future__ import annotations
+
+import csv
+import pathlib
+import time
+
+import pytest
+
+
+DDIC_CANDIDATES = ["T002", "T100", "DD02L", "DD03L", "DD04L", "TADIR", "E071"]
+THREAD_VALUES = [1, 2, 4, 8, 16]
+
+
+@pytest.fixture(scope="module")
+def ddic_targets(cli_run):
+    """Probe row counts and pick the largest 3 tables that fit a 120s budget."""
+    candidates: list[tuple[str, int]] = []
+    for t in DDIC_CANDIDATES:
+        try:
+            out = cli_run(
+                f"SELECT COUNT(*)::BIGINT FROM sap_read_table('{t}', THREADS=1);",
+                timeout=120,
+            )
+            n = int(out.strip().split("\n")[-1].strip('"'))
+            candidates.append((t, n))
+        except Exception:
+            continue
+    # Largest first
+    candidates.sort(key=lambda x: -x[1])
+    return candidates[:3]
+
+
+def test_perf_sweep(cli_run, artifacts_dir: pathlib.Path, ddic_targets):
+    if not ddic_targets:
+        pytest.skip("no DDIC tables readable")
+    perf_dir = artifacts_dir / "perf"
+    perf_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = perf_dir / "ddic.csv"
+
+    with csv_path.open("w", newline="") as fp:
+        writer = csv.writer(fp)
+        writer.writerow(["table", "row_count", "threads", "wall_seconds", "rows_per_sec"])
+        for table, rows in ddic_targets:
+            for threads in THREAD_VALUES:
+                wall = _measure_one(cli_run, table, threads)
+                rps = (rows / wall) if wall > 0 else 0.0
+                writer.writerow([table, rows, threads, f"{wall:.2f}", f"{rps:.0f}"])
+                print(f"  {table:10s} rows={rows:9d} threads={threads:2d} wall={wall:.2f}s rps={rps:.0f}")
+
+
+def _measure_one(cli_run, table: str, threads: int) -> float:
+    sql = f"SELECT COUNT(*) FROM sap_read_table('{table}', THREADS={threads});"
+    t0 = time.perf_counter()
+    cli_run(sql, timeout=1800)
+    return time.perf_counter() - t0

--- a/rfc/test/sql/sap_read_table.test
+++ b/rfc/test/sql/sap_read_table.test
@@ -201,28 +201,31 @@ SELECT COUNT(*) > 0 FROM sap_read_table('T002', COLUMNS=['SPRAS']);
 1
 
 # ---------------------------------------------------------------------
-# Verify supported READ_TABLE_FUNCTION values
+# Verify supported READ_TABLE_FUNCTION values return the full 40 rows of /DMO/FLIGHT.
+# Previously these asserted `COUNT(*) >= 0` which passed trivially even when the
+# /SAPDS and /BODS variants silently returned 0 rows because rows landed in a
+# different TBLOUTxxxx output table than the one we read from.
 query I
-SELECT COUNT(*) >= 0 FROM sap_read_table('/DMO/FLIGHT', COLUMNS=['CARRIER_ID'], READ_TABLE_FUNCTION='RFC_READ_TABLE');
+SELECT COUNT(*) FROM sap_read_table('/DMO/FLIGHT', COLUMNS=['CARRIER_ID'], READ_TABLE_FUNCTION='RFC_READ_TABLE');
 ----
-1
+40
 
 query I
-SELECT COUNT(*) >= 0 FROM sap_read_table('/DMO/FLIGHT', COLUMNS=['CARRIER_ID'], READ_TABLE_FUNCTION='/BODS/RFC_READ_TABLE');
+SELECT COUNT(*) FROM sap_read_table('/DMO/FLIGHT', COLUMNS=['CARRIER_ID'], READ_TABLE_FUNCTION='/BODS/RFC_READ_TABLE');
 ----
-1
+40
 
 query I
-SELECT COUNT(*) >= 0 FROM sap_read_table('/DMO/FLIGHT', COLUMNS=['CARRIER_ID'], READ_TABLE_FUNCTION='/SAPDS/RFC_READ_TABLE');
+SELECT COUNT(*) FROM sap_read_table('/DMO/FLIGHT', COLUMNS=['CARRIER_ID'], READ_TABLE_FUNCTION='/SAPDS/RFC_READ_TABLE');
 ----
-1
+40
 
 query I
-SELECT COUNT(*) >= 0 FROM sap_read_table('/DMO/FLIGHT', COLUMNS=['CARRIER_ID'], READ_TABLE_FUNCTION='/BODS/RFC_READ_TABLE2', READ_TABLE_DELIMITER='~');
+SELECT COUNT(*) FROM sap_read_table('/DMO/FLIGHT', COLUMNS=['CARRIER_ID'], READ_TABLE_FUNCTION='/BODS/RFC_READ_TABLE2', READ_TABLE_DELIMITER='~');
 ----
-1
+40
 
 query I
-SELECT COUNT(*) >= 0 FROM sap_read_table('/DMO/FLIGHT', COLUMNS=['CARRIER_ID'], READ_TABLE_FUNCTION='/SAPDS/RFC_READ_TABLE2', READ_TABLE_DELIMITER='~');
+SELECT COUNT(*) FROM sap_read_table('/DMO/FLIGHT', COLUMNS=['CARRIER_ID'], READ_TABLE_FUNCTION='/SAPDS/RFC_READ_TABLE2', READ_TABLE_DELIMITER='~');
 ----
-1
+40

--- a/rfc/test/sql/sap_rfc_invoke_fuzz.test
+++ b/rfc/test/sql/sap_rfc_invoke_fuzz.test
@@ -1,0 +1,482 @@
+# name: test/sql/sap_rfc_invoke_fuzz.test
+# description: regression tests for sap_rfc_invoke across a diverse set of real
+#              SAP RFC function modules — covers no-arg, nested struct, deep
+#              table, multi-result, and synthetic-ok-column code paths.
+# group: [rfc]
+
+require erpl_rfc
+
+require-env ERPL_SAP_ASHOST
+
+require-env ERPL_SAP_SYSNR
+
+require-env ERPL_SAP_USER
+
+require-env ERPL_SAP_PASSWORD
+
+require-env ERPL_SAP_CLIENT
+
+require-env ERPL_SAP_LANG
+
+statement ok
+CREATE SECRET abap_trial (
+    TYPE sap_rfc,
+    ASHOST '${ERPL_SAP_ASHOST}',
+    SYSNR '${ERPL_SAP_SYSNR}',
+    CLIENT '${ERPL_SAP_CLIENT}',
+    USER '${ERPL_SAP_USER}',
+    PASSWD '${ERPL_SAP_PASSWORD}',
+    LANG '${ERPL_SAP_LANG}'
+);
+
+# ---------------------------------------------------------------------
+# RFC_PING — no params, no exports, no tables.
+# Regression: previously crashed bind with
+#   "Table function must return at least one column".
+# Now exposes a synthetic boolean 'ok' column.
+query I
+SELECT ok FROM sap_rfc_invoke('RFC_PING');
+----
+true
+
+# RFC_PING with star projection should also work
+query I
+SELECT COUNT(*) FROM sap_rfc_invoke('RFC_PING');
+----
+1
+
+# ---------------------------------------------------------------------
+# STFC_CONNECTION — simple scalar echo.
+query I
+SELECT ECHOTEXT FROM sap_rfc_invoke(
+    'STFC_CONNECTION', {'REQUTEXT': 'Hello SAP from DuckDB'}
+);
+----
+Hello SAP from DuckDB
+
+# ---------------------------------------------------------------------
+# RFC_SYSTEM_INFO — no args, struct return navigated by name
+query I
+SELECT (RFCSI_EXPORT).RFCSYSID FROM sap_rfc_invoke('RFC_SYSTEM_INFO');
+----
+A4H
+
+# ---------------------------------------------------------------------
+# RFC_GET_FUNCTION_INTERFACE — scalar in, table out via path navigation.
+query I
+SELECT COUNT(*) FROM sap_rfc_invoke(
+    'RFC_GET_FUNCTION_INTERFACE', {'FUNCNAME': 'STFC_CONNECTION'},
+    path := '/PARAMS'
+);
+----
+3
+
+# ---------------------------------------------------------------------
+# BAPI_FLIGHT_GETLIST — nested struct input + table output.
+query I
+SELECT COUNT(*) FROM sap_rfc_invoke('BAPI_FLIGHT_GETLIST', {
+    'AIRLINE': 'LH',
+    'DESTINATION_FROM': {'AIRPORTID': 'FRA'},
+    'DESTINATION_TO': {'AIRPORTID': 'JFK'}
+}, path := '/FLIGHT_LIST');
+----
+16
+
+# ---------------------------------------------------------------------
+# DDIF_FIELDINFO_GET — scalar in, multiple table outs; navigate to one.
+query I
+SELECT COUNT(*) FROM sap_rfc_invoke(
+    'DDIF_FIELDINFO_GET', {'TABNAME': 'SFLIGHT'},
+    path := '/DFIES_TAB'
+);
+----
+14
+
+# ---------------------------------------------------------------------
+# STFC_DEEP_STRUCTURE — round-trip a STFCCPLXT struct (INT + CHAR + STRING).
+query III
+SELECT (ECHOSTRUCT).I, (ECHOSTRUCT).C, (ECHOSTRUCT).STR
+FROM sap_rfc_invoke('STFC_DEEP_STRUCTURE', {
+    'IMPORTSTRUCT': {'I': 42, 'C': 'AB', 'STR': 'top', 'XSTR': ''}
+});
+----
+42	AB	top
+
+# ---------------------------------------------------------------------
+# STFC_DEEP_TABLE — push a list-of-struct into a table parameter, read it back.
+# STFC_DEEP_TABLE echoes IMPORT_TAB into EXPORT_TAB and may add one summary
+# row; assert that at least the two input rows came back.
+query I
+SELECT COUNT(*) >= 2 FROM sap_rfc_invoke('STFC_DEEP_TABLE', {
+    'IMPORT_TAB': [{'I': 1, 'C': 'AA', 'STR': 'a', 'XSTR': ''},
+                   {'I': 2, 'C': 'BB', 'STR': 'b', 'XSTR': ''}]
+}, path := '/EXPORT_TAB');
+----
+true
+
+# ---------------------------------------------------------------------
+# BAPI_USER_GETLIST — integer scalar param, table out
+query I
+SELECT COUNT(*) FROM sap_rfc_invoke(
+    'BAPI_USER_GETLIST', {'MAX_ROWS': 5},
+    path := '/USERLIST'
+);
+----
+5
+
+# ---------------------------------------------------------------------
+# BAPI_USER_GET_DETAIL — string in, struct return navigated by field name.
+query I
+SELECT (ADDRESS).FULLNAME FROM sap_rfc_invoke(
+    'BAPI_USER_GET_DETAIL', {'USERNAME': 'DEVELOPER'}
+);
+----
+John Doe
+
+# ---------------------------------------------------------------------
+# RFC_FUNCTION_SEARCH — pattern-match args returning a table.
+# (Just assert at least one STFC* function is found.)
+query I
+SELECT COUNT(*) > 0 FROM sap_rfc_invoke(
+    'RFC_FUNCTION_SEARCH', {'FUNCNAME': 'STFC*', 'GROUPNAME': '*'},
+    path := '/FUNCTIONS'
+);
+----
+1
+
+# ---------------------------------------------------------------------
+# RFC_GET_LOCAL_DESTINATIONS — no args, navigate to LOCALDEST table.
+query I
+SELECT COUNT(*) >= 0 FROM sap_rfc_invoke(
+    'RFC_GET_LOCAL_DESTINATIONS', path := '/LOCALDEST'
+);
+----
+1
+
+# ---------------------------------------------------------------------
+# STFC_PERFORMANCE — RFCTYPE_NUM params must be passed as numeric strings.
+# Validates that the named adapter accepts the string-coded representation.
+query I
+SELECT COUNT(*) > 0 FROM sap_rfc_invoke('STFC_PERFORMANCE', {
+    'CHECKTAB': ' ',
+    'LGET0332': '0', 'LGET1000': '0',
+    'LGIT0332': '0', 'LGIT1000': '0'
+});
+----
+1
+
+# ---------------------------------------------------------------------
+# STFC_STRUCTURE — every primitive RFC type in one struct.
+# Regression: RFCHEX3 (RFCTYPE_BYTE) was a stub that always sent zeros;
+# RFCTYPE_XSTRING write was also unimplemented. Both now round-trip.
+# Asserts each of DOUBLE/INT4/INT2/INT1/CHAR1/CHAR2/CHAR4/DATE/TIME/BYTE
+# is preserved through the SAP test echo.
+query IIIIIIIIII
+SELECT (ECHOSTRUCT).RFCFLOAT,
+       (ECHOSTRUCT).RFCINT4,
+       (ECHOSTRUCT).RFCINT2,
+       (ECHOSTRUCT).RFCINT1,
+       (ECHOSTRUCT).RFCCHAR1,
+       (ECHOSTRUCT).RFCCHAR2,
+       (ECHOSTRUCT).RFCCHAR4,
+       (ECHOSTRUCT).RFCDATE,
+       (ECHOSTRUCT).RFCTIME,
+       (ECHOSTRUCT).RFCHEX3
+FROM sap_rfc_invoke('STFC_STRUCTURE', {
+    'IMPORTSTRUCT': {
+        'RFCFLOAT':  3.14159,
+        'RFCINT4':   1234567,
+        'RFCINT2':   32000::SMALLINT,
+        'RFCINT1':   100::TINYINT,
+        'RFCCHAR1':  'A',
+        'RFCCHAR2':  'BC',
+        'RFCCHAR4':  'DUCK',
+        'RFCDATE':   '2026-05-16'::DATE,
+        'RFCTIME':   '12:34:56'::TIME,
+        'RFCHEX3':   '\xCA\xFE\xBA'::BLOB,
+        'RFCDATA1':  '',
+        'RFCDATA2':  ''
+    }
+});
+----
+3.14159	1234567	32000	100	A	BC	DUCK	2026-05-16	12:34:56	\xCA\xFE\xBA
+
+# ---------------------------------------------------------------------
+# STFC_DEEP_STRUCTURE — XSTRING (variable-length raw bytes) round-trip.
+# Regression: RFCTYPE_XSTRING was an unimplemented no-op (or a strict-mode
+# throw) before the byte-fix.
+query I
+SELECT (ECHOSTRUCT).XSTR FROM sap_rfc_invoke('STFC_DEEP_STRUCTURE', {
+    'IMPORTSTRUCT': {'I': 0, 'C': '', 'STR': '', 'XSTR': '\xDE\xAD\xBE\xEF'::BLOB}
+});
+----
+\xDE\xAD\xBE\xEF
+
+# ---------------------------------------------------------------------
+# BAPI_EXCHANGERATE_CREATE — nested struct with DATE and DECIMAL fields
+# (BAPI1093_0). Validates date and decimal marshalling end-to-end.
+# We expect a BAPIRET2 return; SAP will respond with a status message.
+# Just assert the call doesn't error and that we get a TYPE back.
+query I
+SELECT length((RETURN).TYPE) > 0
+FROM sap_rfc_invoke('BAPI_EXCHANGERATE_CREATE', {
+    'EXCH_RATE': {
+        'RATE_TYPE':     'M',
+        'FROM_CURR':     'USD',
+        'TO_CURRNCY':    'EUR',
+        'VALID_FROM':    '2026-05-16'::DATE,
+        'EXCH_RATE':     0.92::DECIMAL(9,5),
+        'FROM_FACTOR':   1::DECIMAL(9,0),
+        'TO_FACTOR':     1::DECIMAL(9,0),
+        'EXCH_RATE_V':   0::DECIMAL(9,5),
+        'FROM_FACTOR_V': 0::DECIMAL(9,0),
+        'TO_FACTOR_V':   0::DECIMAL(9,0)
+    },
+    'DEV_ALLOW': '00'
+});
+----
+true
+
+# ---------------------------------------------------------------------
+# NULL handling — both an explicit-typed NULL and a bare NULL should be
+# accepted and treated as "leave the RFC field at its default".
+# Regression: bare NULL was rejected because DuckDB infers it as INTEGER
+# and the strict IsCompatibleType check rejected the mismatch.
+query I
+SELECT ECHOTEXT FROM sap_rfc_invoke('STFC_CONNECTION', {'REQUTEXT': NULL::VARCHAR});
+----
+(empty)
+
+query I
+SELECT ECHOTEXT FROM sap_rfc_invoke('STFC_CONNECTION', {'REQUTEXT': NULL});
+----
+(empty)
+
+# ---------------------------------------------------------------------
+# UTF-8 multibyte input including emoji — exercises the SAP Unicode boundary.
+query I
+SELECT ECHOTEXT FROM sap_rfc_invoke('STFC_CONNECTION', {'REQUTEXT': 'Héllo 世界 🦆'});
+----
+Héllo 世界 🦆
+
+# ---------------------------------------------------------------------
+# STFC_STRUCTURE in a TABLE — push a list-of-RFCTEST and read it back.
+# Exercises AdaptTable with a struct of mixed types (FLOAT + INTs + CHAR
+# + DATE + TIME + BYTE).
+query I
+SELECT COUNT(*) >= 1
+FROM sap_rfc_invoke('STFC_STRUCTURE', {
+    'IMPORTSTRUCT': {
+        'RFCFLOAT': 1.0, 'RFCINT4': 1, 'RFCINT2': 1::SMALLINT, 'RFCINT1': 1::TINYINT,
+        'RFCCHAR1': 'X', 'RFCCHAR2': 'YY', 'RFCCHAR4': 'ZZZZ',
+        'RFCDATE': '2026-01-01'::DATE, 'RFCTIME': '00:00:00'::TIME,
+        'RFCHEX3': '\x01\x02\x03'::BLOB, 'RFCDATA1': '', 'RFCDATA2': ''
+    },
+    'RFCTABLE': [
+        {'RFCFLOAT': 2.0, 'RFCINT4': 2, 'RFCINT2': 2::SMALLINT, 'RFCINT1': 2::TINYINT,
+         'RFCCHAR1': 'A', 'RFCCHAR2': 'BB', 'RFCCHAR4': 'CCCC',
+         'RFCDATE': '2026-02-02'::DATE, 'RFCTIME': '01:01:01'::TIME,
+         'RFCHEX3': '\x04\x05\x06'::BLOB, 'RFCDATA1': 'r1', 'RFCDATA2': 'r1'}
+    ]
+}, path := '/RFCTABLE');
+----
+true
+
+# ---------------------------------------------------------------------
+# STFC_CHANGING — exercises an RFC_CHANGING parameter. COUNTER comes in,
+# the function modifies it in place and also returns it (along with RESULT
+# = START_VALUE + COUNTER_IN).
+query II
+SELECT COUNTER, RESULT FROM sap_rfc_invoke('STFC_CHANGING', {
+    'START_VALUE': 10,
+    'COUNTER':     5
+});
+----
+6	15
+
+# ---------------------------------------------------------------------
+# STFC_XSTRING — top-level RFCTYPE_XSTRING parameter taking a DuckDB BLOB.
+# Regression: IsCompatibleType used to reject BLOB→XSTRING (it required
+# VARCHAR), so the call failed before reaching AdaptValue. Now both
+# VARCHAR and BLOB are accepted as compatible payloads for raw-byte types.
+# Asserts only that the call succeeds and returns a non-null answer
+# (the function transforms the bytes, doesn't pure-echo).
+query I
+SELECT MYANSWER IS NOT NULL FROM sap_rfc_invoke(
+    'STFC_XSTRING', {'QUESTION': '\xDE\xAD\xBE\xEF\x00\x01\x02\x03'::BLOB}
+);
+----
+true
+
+# ---------------------------------------------------------------------
+# Path-to-scalar — navigate to a leaf field via the path parameter.
+# Regression: previously threw "Field 'X' is not a container type".
+# Now valid when the path ends at a scalar field; result has a single
+# column named after the leaf.
+query I
+SELECT RFCSYSID FROM sap_rfc_invoke('RFC_SYSTEM_INFO', path := '/RFCSI_EXPORT/RFCSYSID');
+----
+A4H
+
+# ---------------------------------------------------------------------
+# Path navigation into a STRUCT result parameter — children become columns.
+query III
+SELECT FIRSTNAME, LASTNAME, FULLNAME
+FROM sap_rfc_invoke('BAPI_USER_GET_DETAIL', {'USERNAME': 'DEVELOPER'},
+                    path := '/ADDRESS');
+----
+John	Doe	John Doe
+
+# ---------------------------------------------------------------------
+# Path navigation into a TABLE result parameter — rows stream through.
+query I
+SELECT USERNAME FROM sap_rfc_invoke(
+    'BAPI_USER_GETLIST', {'MAX_ROWS': 3}, path := '/USERLIST'
+) ORDER BY USERNAME LIMIT 1;
+----
+BWDEVELOPER
+
+# ---------------------------------------------------------------------
+# Negative integers across all integer widths must round-trip.
+query III
+SELECT (ECHOSTRUCT).RFCINT4, (ECHOSTRUCT).RFCINT2, (ECHOSTRUCT).RFCINT1
+FROM sap_rfc_invoke('STFC_STRUCTURE', {
+    'IMPORTSTRUCT': {
+        'RFCFLOAT': -3.14, 'RFCINT4': -42, 'RFCINT2': -100::SMALLINT, 'RFCINT1': -5::TINYINT,
+        'RFCCHAR1': 'N', 'RFCCHAR2': 'EG', 'RFCCHAR4': 'NEG ',
+        'RFCDATE': '1990-01-01'::DATE, 'RFCTIME': '23:59:59'::TIME,
+        'RFCHEX3': '\xFF\xFF\xFF'::BLOB, 'RFCDATA1': '', 'RFCDATA2': ''
+    }
+});
+----
+-42	-100	-5
+
+# ---------------------------------------------------------------------
+# Wrong-type argument should fail with a precise error pointing at the
+# offending parameter and types. Regression-pin the error path.
+statement error
+SELECT ECHOTEXT FROM sap_rfc_invoke('STFC_CONNECTION', {'REQUTEXT': {'x': 'y'}});
+----
+Parameter 'REQUTEXT' is of type 'RFCTYPE_CHAR' (RFC) but argument is of type 'STRUCT(x VARCHAR)' (DuckDB)
+
+# ---------------------------------------------------------------------
+# Unknown parameter should fail with the parameter name in the message.
+statement error
+SELECT ECHOTEXT FROM sap_rfc_invoke('STFC_CONNECTION', {'NO_SUCH_PARAM': 'oops'});
+----
+Parameter 'NO_SUCH_PARAM' not found
+
+# ---------------------------------------------------------------------
+# APCRFC_INT8_COMP_TEST — single-column TABLE of BIGINT (no struct wrapper).
+# Exercises a TABLE-typed import where the row element is a scalar INT8.
+# Regression-pins that BIGINT->RFCTYPE_INT8 round-trips without an
+# explicit cast (RFCTYPE_INT8 used to map to INTEGER in
+# rfctype2logicaltype, which would have rejected BIGINT for direct
+# top-level INT8 params).
+query I
+SELECT ok FROM sap_rfc_invoke('APCRFC_INT8_COMP_TEST', {
+    'IT_INT8': [1::BIGINT, 2::BIGINT, 9223372036854775807::BIGINT]
+});
+----
+true
+
+# ---------------------------------------------------------------------
+# /DMO/TRAVEL has DEC(21,7) timestamps (TIMESTAMPL) and CURR(15,2)
+# prices. Regression: the BCD precision derivation used to compute
+# DECIMAL(GetLength()*2 - 1, ...) which gave DECIMAL(41,7) for DEC(21,7)
+# in sap_rfc_invoke (Bug 7 in this round). The fix caps precision at 38.
+# Verifies the typeinfo is a valid DECIMAL and rows come back.
+query I
+SELECT COUNT(*) > 0 FROM sap_read_table('/DMO/TRAVEL',
+    COLUMNS=['TRAVEL_ID', 'CREATEDAT', 'LASTCHANGEDAT', 'TOTAL_PRICE'],
+    MAX_ROWS=3);
+----
+true
+
+# ---------------------------------------------------------------------
+# DECFLOAT34 DDIC type ('D34D', 'D34R', 'D34S') used to throw
+# "Unsupported SAP data type" because GetTypeMap omitted it. After fix,
+# the column types resolve to DECIMAL and sap_describe_fields recognises
+# the type. The actual /SAPQUERY/TA08 SELECT may still fail on the SAP
+# side, so we just assert that the schema lookup succeeds.
+query I
+SELECT COUNT(*) FROM sap_describe_fields('/SAPQUERY/TA08')
+WHERE field LIKE 'DF34%';
+----
+4
+
+# ---------------------------------------------------------------------
+# Path-to-scalar should also work on a struct field nested *one level*
+# below a top-level result struct (already covered above), and on a
+# leaf inside a list element doesn't make sense — but a leaf inside the
+# top-level struct does. This pins the path /BAPI_USER_GET_DETAIL → /ADDRESS/COUNTRY.
+query I
+SELECT COUNTRY FROM sap_rfc_invoke(
+    'BAPI_USER_GET_DETAIL', {'USERNAME': 'DEVELOPER'},
+    path := '/ADDRESS/COUNTRY'
+);
+----
+DE
+
+# ---------------------------------------------------------------------
+# Positional adapter — accept arguments by position, not just as a struct.
+# Regression: RfcInvocationPositionalAdapter used to throw
+#   "Positional adapter not implemented"
+# any time a non-struct arg was supplied; callers were forced to wrap
+# everything in a struct. Now the adapter matches positional args to the
+# function's settable parameters (IMPORT + CHANGING + TABLES) in DDIC
+# declaration order, with the same NULL-skip and IsCompatibleType rules
+# as the named adapter.
+query I
+SELECT ECHOTEXT FROM sap_rfc_invoke('STFC_CONNECTION', 'Hello positional');
+----
+Hello positional
+
+# Same positional form but with a list value (single-column TABLE param).
+query I
+SELECT ok FROM sap_rfc_invoke(
+    'APCRFC_INT8_COMP_TEST', [1::BIGINT, 2::BIGINT, 9223372036854775807::BIGINT]
+);
+----
+true
+
+# Too many positional args should fail cleanly with parameter count info.
+statement error
+SELECT MYANSWER FROM sap_rfc_invoke('STFC_STRING', 'Hello', 'extra');
+----
+Too many positional arguments: function has 1 settable parameters but got 2
+
+# ---------------------------------------------------------------------
+# describe_function fallback — RPY_FUNCTIONMODULE_READ trips
+# FL180 "Source wider than 72 char" on some older module bodies
+# (e.g. SXPG_COMMAND_EXECUTE, RFC_GET_ATTRIBUTES, IDOC_INBOUND_ASYNCHRONOUS).
+# Regression: previously the whole describe call failed. Now the bind
+# gracefully falls back to SDK-only introspection; the parameter list
+# is still complete, but the source/text/pool/remote_callable fields
+# are NULL.
+query I
+SELECT length(import) > 0
+FROM sap_rfc_describe_function('SXPG_COMMAND_EXECUTE');
+----
+true
+
+query I
+SELECT length(export) > 0
+FROM sap_rfc_describe_function('RFC_GET_ATTRIBUTES');
+----
+true
+
+# ---------------------------------------------------------------------
+# DECFLOAT16/34 precision — SDK introspection reports nucLength as the
+# storage byte count (8 / 16), DDIC introspection as the digit count
+# (up to 16 / 34). Either way the schema must report the spec-defined
+# significand width (16 / 34). Regression: previously the SDK path gave
+# DECIMAL(8,0) for DECFLOAT16 and DECIMAL(16,0) for DECFLOAT34 — losing
+# half the digits.
+query II
+SELECT
+    list_element(d.changing, list_position(list_transform(d.changing, p -> p.name), 'DECFLOAT16')).duckdb_type AS df16_type,
+    list_element(d.changing, list_position(list_transform(d.changing, p -> p.name), 'DECFLOAT34')).duckdb_type AS df34_type
+FROM sap_rfc_describe_function('S_APCRFC_ALLTYPES') d;
+----
+DECIMAL(16,0)	DECIMAL(34,0)

--- a/rfc/test/sql/sap_rfc_type_coverage.test
+++ b/rfc/test/sql/sap_rfc_type_coverage.test
@@ -1,0 +1,99 @@
+# name: test/sql/sap_rfc_type_coverage.test
+# description: Systematic DDIC type coverage for sap_read_table / RFC layer.
+#              Asserts every DDIC type observed in the trial /DMO/ schema maps
+#              to the correct DuckDB logical type via CreateDuckDbType().
+# group: [rfc]
+
+require erpl_rfc
+
+require-env ERPL_SAP_ASHOST
+
+require-env ERPL_SAP_SYSNR
+
+require-env ERPL_SAP_USER
+
+require-env ERPL_SAP_PASSWORD
+
+require-env ERPL_SAP_CLIENT
+
+require-env ERPL_SAP_LANG
+
+statement ok
+CREATE SECRET abap_trial (
+    TYPE sap_rfc,
+    ASHOST '${ERPL_SAP_ASHOST}',
+    SYSNR '${ERPL_SAP_SYSNR}',
+    CLIENT '${ERPL_SAP_CLIENT}',
+    USER '${ERPL_SAP_USER}',
+    PASSWD '${ERPL_SAP_PASSWORD}',
+    LANG '${ERPL_SAP_LANG}'
+);
+
+# -------------------------------------------------------------------------
+# /DMO/FLIGHT — common DDIC types: CLNT, CHAR, NUMC, DATS, CURR, CUKY, INT4
+# -------------------------------------------------------------------------
+query TTTTTTT
+SELECT
+    typeof(CLIENT),         -- CLNT(3)
+    typeof(CARRIER_ID),     -- CHAR(3)
+    typeof(CONNECTION_ID),  -- NUMC(4)
+    typeof(FLIGHT_DATE),    -- DATS
+    typeof(PRICE),          -- CURR(8,2)
+    typeof(CURRENCY_CODE),  -- CUKY(5)
+    typeof(SEATS_MAX)       -- INT4
+FROM sap_read_table('/DMO/FLIGHT', SECRET='abap_trial', MAX_ROWS=1)
+LIMIT 1;
+----
+VARCHAR	VARCHAR	VARCHAR	DATE	DECIMAL(15,2)	VARCHAR	BIGINT
+
+# -------------------------------------------------------------------------
+# /DMO/A_BOOKING_D — RAW(16) ABAP UUID must surface as DuckDB BLOB.
+# -------------------------------------------------------------------------
+query T
+SELECT typeof(BOOKING_UUID)
+FROM sap_read_table('/DMO/A_BOOKING_D', COLUMNS=['BOOKING_UUID'],
+                    SECRET='abap_trial', MAX_ROWS=1)
+LIMIT 1;
+----
+BLOB
+
+# -------------------------------------------------------------------------
+# /DMO/FSA_ROOT_A — FLTP → DOUBLE, QUAN → DECIMAL.
+# -------------------------------------------------------------------------
+query TT
+SELECT typeof(STARS_VALUE), typeof(FIELD_WITH_QUANTITY)
+FROM sap_read_table('/DMO/FSA_ROOT_A',
+                    COLUMNS=['STARS_VALUE','FIELD_WITH_QUANTITY'],
+                    SECRET='abap_trial', MAX_ROWS=1)
+LIMIT 1;
+----
+DOUBLE	DECIMAL(15,3)
+
+# -------------------------------------------------------------------------
+# /DMO/AGENCY — STRG (variable-length text) → VARCHAR;
+#               RSTR (RAWSTRING, variable-length bytes) → BLOB.
+#
+# Before the type-coverage fix RSTR mapped to VARCHAR which is wrong:
+# RAWSTRING carries arbitrary bytes (rfc2duck for SAP_RAW returns Value::BLOB)
+# but the column schema claimed VARCHAR, causing a bind-vs-value type clash.
+# -------------------------------------------------------------------------
+query TT
+SELECT typeof(EMAIL_ADDRESS), typeof(ATTACHMENT)
+FROM sap_read_table('/DMO/AGENCY',
+                    COLUMNS=['EMAIL_ADDRESS','ATTACHMENT'],
+                    SECRET='abap_trial', MAX_ROWS=1)
+LIMIT 1;
+----
+VARCHAR	BLOB
+
+# -------------------------------------------------------------------------
+# Round-trip: actually fetch a UUID row and verify it is a non-empty BLOB.
+# Confirms the value-conversion path agrees with the bind schema.
+# -------------------------------------------------------------------------
+query I
+SELECT (octet_length(BOOKING_UUID) > 0)::INTEGER
+FROM sap_read_table('/DMO/A_BOOKING_D', COLUMNS=['BOOKING_UUID'],
+                    SECRET='abap_trial', MAX_ROWS=1)
+LIMIT 1;
+----
+1

--- a/rfc/test/sql/sap_rfc_type_fallback.test
+++ b/rfc/test/sql/sap_rfc_type_fallback.test
@@ -1,0 +1,122 @@
+# name: test/sql/sap_rfc_type_fallback.test
+# description: lenient VARCHAR fallback for unsupported SAP RFC types (issue #53)
+# group: [rfc]
+
+require erpl_rfc
+
+require-env ERPL_SAP_ASHOST
+
+require-env ERPL_SAP_SYSNR
+
+require-env ERPL_SAP_USER
+
+require-env ERPL_SAP_PASSWORD
+
+require-env ERPL_SAP_CLIENT
+
+require-env ERPL_SAP_LANG
+
+statement ok
+CREATE SECRET abap_trial (
+    TYPE sap_rfc,
+    ASHOST '${ERPL_SAP_ASHOST}',
+    SYSNR '${ERPL_SAP_SYSNR}',
+    CLIENT '${ERPL_SAP_CLIENT}',
+    USER '${ERPL_SAP_USER}',
+    PASSWD '${ERPL_SAP_PASSWORD}',
+    LANG '${ERPL_SAP_LANG}'
+);
+
+# -----------------------------------------------------------------------
+# Part 1: Config option exists and defaults to false (lenient mode)
+# -----------------------------------------------------------------------
+
+query I
+SELECT current_setting('erpl_rfc_strict_type_check');
+----
+false
+
+statement ok
+SET erpl_rfc_strict_type_check = true;
+
+query I
+SELECT current_setting('erpl_rfc_strict_type_check');
+----
+true
+
+statement ok
+SET erpl_rfc_strict_type_check = false;
+
+query I
+SELECT current_setting('erpl_rfc_strict_type_check');
+----
+false
+
+# -----------------------------------------------------------------------
+# Part 2: Lenient mode (default) — functions with XSTRING fields succeed
+#
+# STFC_XSTRING returns an XSTRING export parameter MYANSWER.
+# XSTRING is handled in ConvertRfcValue so this exercises the full path.
+# Before issue #53 the AdaptValue XSTRING stub threw std::logic_error when
+# passing XSTRING input; in lenient mode that stub now silently skips.
+# -----------------------------------------------------------------------
+
+query I
+SELECT count(*) > 0 FROM sap_rfc_invoke('STFC_XSTRING', SECRET='abap_trial');
+----
+true
+
+# -----------------------------------------------------------------------
+# Part 3: INT8 schema type is BIGINT (regression check for type mapping bug)
+#
+# RFCTYPE_INT8 was incorrectly mapped to LogicalType::INTEGER (32-bit) in
+# CreateDuckDbType().  After the fix it maps to LogicalType::BIGINT (64-bit),
+# consistent with rfc2duck(RFC_INT8) which already returns Value::BIGINT().
+#
+# RFC_GET_SYSTEM_INFO returns CURRENT_RESOURCES as RFCTYPE_INT (4-byte),
+# FAST_SER_VERS as RFCTYPE_INT, and MAXIMAL_RESOURCES as RFCTYPE_INT.
+# We verify the existing INT types still work to guard against regressions.
+# -----------------------------------------------------------------------
+
+query I
+SELECT count(*) > 0 FROM sap_rfc_invoke('RFC_SYSTEM_INFO', SECRET='abap_trial');
+----
+true
+
+# -----------------------------------------------------------------------
+# Part 4: Strict mode — unhandled RFCTYPE in schema raises error
+#
+# Toggle strict mode on and back off to verify the flag round-trips.
+# The full strict-mode throw path is covered by unit tests since triggering
+# a truly unregistered RFCTYPE on the trial system requires a custom ABAP
+# function module (BOX/GENERIC_BOX types are SDK-internal and unreachable
+# from a standard trial installation).
+# -----------------------------------------------------------------------
+
+statement ok
+SET erpl_rfc_strict_type_check = true;
+
+query I
+SELECT current_setting('erpl_rfc_strict_type_check');
+----
+true
+
+# Normal functions must still succeed even in strict mode, because they
+# only use well-known types (CHAR, INT, DATE, etc.) that have explicit
+# switch cases — the strict default: branch is never reached for them.
+query I
+SELECT count(*) > 0 FROM sap_rfc_invoke('RFC_SYSTEM_INFO', SECRET='abap_trial');
+----
+true
+
+statement ok
+SET erpl_rfc_strict_type_check = false;
+
+# -----------------------------------------------------------------------
+# Part 5: sap_read_table still works with default lenient mode
+# -----------------------------------------------------------------------
+
+query I
+SELECT count(*) > 0 FROM sap_read_table('/DMO/FLIGHT', SECRET='abap_trial');
+----
+true


### PR DESCRIPTION
## Summary

Five-round fuzz/verification pass against the live ABAP Cloud Developer Trial system. Surfaced and fixed **12 distinct bugs** across the RFC scanner and `sap_rfc_invoke` marshalling, plus implemented two previously-stubbed code paths (UTCLONG I/O, positional adapter) and one missing fallback (describe_function FL180). 5 commits, ~720 insertions, 113 deletions, **57 + 14 + 7 + 17 = 95 new test assertions** across new and existing test files.

## Bug-fix list

### `sap_read_table` parallelism (commit 8c1eda4)
1. **Global scheduler leak** — `Step()` mutated DuckDB's `TaskScheduler::requested_thread_count` via `SetThreads(max_threads, 1)`, leaking the per-call `THREADS=` value to the rest of the session AND failing to constrain in-query parallelism (the relaunch happens at end-of-query, after the scan). Replaced with batched task scheduling.
2. **Data race** on `bind_data->read_table_supports_et_data_switch` between parallel column tasks. Now resolved at bind time (single-threaded).
3. **Dead code** — `RfcReadColumnStateMachine::GetConnection()` + `current_connection` never called; every batch opens a fresh connection.
4. **`/SAPDS/RFC_READ_TABLE2` returned 0 rows** — picked `TBLOUT30000` first while SAP populates the smallest fitting `TBLOUTxxxx`. Now falls back to other paths on the same invocation handle if the bound path is empty.

### `sap_rfc_invoke` (commit 23cd1d1)
5. **`RFC_PING` crashed bind** with `"Table function must return at least one column"`. Now synthesizes a single `BOOLEAN ok` column when the function has no result params.
6. **`RFCTYPE_BYTE` write was a stub** — silently sent zeros instead of the BLOB. Now uses `RfcSetBytes` with `StringValue::Get`.
7. **`RFCTYPE_XSTRING` write was a no-op** (or threw in strict mode). Now uses `RfcSetXString` symmetrically.
8. **Bare `NULL` rejected** by `IsCompatibleType` (DuckDB infers as INTEGER). NULL is now universally compatible.
9. **Top-level XSTRING/BYTE rejected BLOB inputs** — `IsCompatibleType` required exact VARCHAR/BLOB match. Byte types now accept either.
10. **Path-to-scalar threw** `"not a container type"` — `/RFCSI_EXPORT/RFCSYSID` and similar now return the leaf as a single-column row.
11. **Positional adapter was a stub** — `"Positional adapter not implemented"`. Now matches positional args to settable params in DDIC order; `sap_rfc_invoke('STFC_CONNECTION', 'x')` works alongside the struct form.
12. **`RFCTYPE_UTCLONG/UTCSECOND/UTCMINUTE` read returned empty TIMESTAMP, write was a no-op.** Implemented via `RfcGetString` / `RfcSetString` + `sap_utc2timestamp` / `timestamp2sap_utc` helpers.

### `sap_rfc_describe_function` (commit 1787d4b)
13. **FL180 "Source wider than 72 char"** killed describe for `SXPG_COMMAND_EXECUTE`, `IDOC_INBOUND_ASYNCHRONOUS`, `RFC_GET_ATTRIBUTES`, `RPY_FUNCTIONMODULE_READ` itself. Bind now tries `RPY_FUNCTIONMODULE_READ` inside try/catch; on failure drops the RPY-sourced fields (text, function_group, remote_callable, source) to NULL and keeps the SDK-derived parameter list.

### DDIC type coverage (rolled into earlier commits)
14. **Missing DDIC type aliases** — `D16D/N/R/S`, `D34D/N/R/S`, `DECF16`, `DECF34`, `INT8`, `UTCL`, `UTCLONG`, `UTCS`, `UTCM` all threw "Unsupported SAP data type". Added to `GetTypeMap`.
15. **DECF34 crashed DuckDB** with `DECIMAL(61, 0)` — the BCD formula `2*N-1` doesn't apply to DECFLOAT. Now hardcoded per type (DECF16=16 digits, DECF34=34).
16. **BCD overflow** for `DEC(>=20, *)` — capped at DuckDB's `DECIMAL(38)` max.
17. **`RFCTYPE_INT8` mapped to `INTEGER`** in `rfctype2logicaltype` (lossy — 8 bytes truncated to 4). Now BIGINT.
18. **`RSTR` (RAWSTRING) mapped to `RFCTYPE_STRING`** — but the read path returns BLOB → schema/value clash. Now correctly maps to `RFCTYPE_XSTRING`.
19. **`RFCTYPE_XSTRING` schema was VARCHAR but value was BLOB** — same kind of clash. Now BLOB throughout.

## Test plan

- [x] `make sql_tests_rfc` — **17/17 test files, 0 failures** (added `sap_rfc_invoke_fuzz.test`, `sap_rfc_type_coverage.test`)
- [x] `sap_rfc_invoke_fuzz.test` — **57 assertions** covering: empty signature, scalar/struct/table in&out, deep nested struct, NULL handling, UTF-8 multibyte, BLOB round-trip, BYTE/XSTRING write, path-to-scalar, path-into-struct, path-into-table, CHANGING params, positional adapter (incl. too-many-args error), DECF34 schema, BCD precision cap, INT8 BIGINT[] table, describe_function FL180 fallback, DECFLOAT16/34 spec-defined precision.
- [x] `sap_rfc_type_coverage.test` — **14/14** assertions (RSTR→BLOB, RAW(16) UUID round-trip, FLTP→DOUBLE, QUAN→DECIMAL).
- [x] `sap_odp_type_coverage.test` — **7/7** (shared type-map code path).
- [x] `sap_bics_type_coverage.test` — **17/17** (shared type-map code path).
- [x] `make sql_tests_tunnel` — **3/3**.
- [x] `make sql_tests_odp` — **8/8**.
- [x] Python parallelism harness (`rfc/test/parallel/`) — **26/26** pytest cases against the live trial system, including 50-rep stability for `/DMO/FLIGHT` and large-table multiset-equality for `DD02L` (164k rows, `THREADS=4`) and `T100` (615k rows, `THREADS=8`).

## Files

```
rfc/src/include/sap_function.hpp              |   5 +
rfc/src/include/sap_rfc.hpp                   |   2 -
rfc/src/include/sap_type_conversion.hpp       |   7 +
rfc/src/include/scanner_describe_function.hpp |  31 +-
rfc/src/sap_function.cpp                      | 240 +++++++++++++++++--
rfc/src/sap_rfc.cpp                           | 107 +++++++--
rfc/src/sap_type_conversion.cpp               |  85 ++++++-
rfc/src/scanner_describe_function.cpp         |  35 ++-
rfc/src/scanner_invoke.cpp                    |  33 ++-
rfc/test/sql/sap_read_table.test              |  25 +-
rfc/test/sql/sap_rfc_invoke_fuzz.test (new)   | 482 ++++++++++++++++++++++++++++++++++
rfc/test/sql/sap_rfc_type_coverage.test (new) |  99 ++++++++
rfc/test/parallel/ (new)                      | ~1700 lines harness/oracles/perf
```

## Things deliberately left out

- **TSAN sweep**: planned in Round 1 but deferred (TSAN and ASAN are mutually exclusive; existing builds use ASAN/UBSAN). Race I identified is fixed, but TSAN was never confirmed.
- **DECFLOAT precision lossiness**: DECF is floating-point; mapping to fixed `DECIMAL(P, S)` cannot perfectly round-trip values whose actual scale exceeds the DDIC-declared one. Capped at spec-defined precision; documented inline.
- **UTCLONG end-to-end test on live system** — no DDIC field on the trial container uses UTCLONG/UTCSECOND/UTCMINUTE, so the implementation follows SDK documentation but isn't exercised through a real RFC. Verified compiles + helpers handle SAP's documented compact format both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)