### PR TITLE
feat: upgrade DuckDB to v1.5.3, update CI pipeline

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -36,22 +36,22 @@ jobs:
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
       deploy_versioned: ${{ !(startsWith(github.ref, 'refs/tags/v')) && !(github.ref == 'refs/heads/master') }}
 
-  duckdb-stable-build-v152:
-    name: Build v.1.5.2 extension binaries
+  duckdb-stable-build-v153:
+    name: Build v.1.5.3 extension binaries
     uses: ./.github/workflows/_extension_build.yml
     secrets: inherit
     with:
-      duckdb_version: v1.5.2
+      duckdb_version: v1.5.3
       extension_name: erpl
       exclude_archs: linux_arm64;windows_amd64_rtools;wasm_mvp;wasm_eh;wasm_threads;
 
-  duckdb-stable-deploy-v152:
+  duckdb-stable-deploy-v153:
     name: Deploy extension binaries
-    needs: duckdb-stable-build-v152
+    needs: duckdb-stable-build-v153
     uses: ./.github/workflows/_extension_deploy.yml
     secrets: inherit
     with:
-      duckdb_version: v1.5.2
+      duckdb_version: v1.5.3
       extension_name: erpl
       exclude_archs: linux_arm64;windows_amd64_rtools;wasm_mvp;wasm_eh;wasm_threads;
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
## Summary

- Bump `duckdb/` submodule gitlink to v1.5.3 (`14eca11`).
- Rename CI jobs `duckdb-stable-build-v152` / `…-deploy-v152` → `…-v153` and set `duckdb_version: v1.5.3` in `.github/workflows/MainDistributionPipeline.yml`.
- v1.4.4 LTS build/deploy matrix is left untouched — both tracks continue to ship.

## Notes

- `extension-ci-tools` submodule is intentionally **not** bumped, matching the precedent set by the v1.5.0 → v1.5.2 bump (commit `2e6b031`) which also kept it on `ef15a2a` (v1.5.1).
- No source changes required: existing `DUCKDB_MINOR_VERSION >= 5` guards in `rfc/src/sap_storage.cpp` already cover the 1.5.x line, and patch releases don't break the public API.
- Comment-only `v1.5.1` references in `Makefile` and `scripts/smoke-test*` are usage examples and were intentionally left as-is (matching prior bumps).

## Test plan

- [ ] CI `Build v.1.4.4 extension binaries` matrix passes (LTS regression guard).
- [ ] CI `Build v.1.5.3 extension binaries` matrix passes on all enabled archs.
- [ ] Post-build smoke test (`scripts/smoke-test.sh`) succeeds for v1.5.3.
- [ ] Deploy job uploads versioned artifacts for v1.5.3.

---
_Generated by [Claude Code](https://claude.ai/code/session_012vz4fCxMqctyvzovmcdA7p)_