### PR TITLE
fix(rfc): NULL DATS / TIMS handling in sap_read_table (#64)

### DIFF
--- a/rfc/src/sap_type_conversion.cpp
+++ b/rfc/src/sap_type_conversion.cpp
@@ -6,8 +6,10 @@
 #include "sap_type_conversion.hpp"
 
 
-namespace duckdb 
+namespace duckdb
 {
+    bool IsValidTime(const int32_t hour, const int32_t minute, const int32_t second);
+
     /**
      * @brief Converts a SAP_UC string to a std::string.
      * 
@@ -290,20 +292,37 @@ namespace duckdb
      * @note The SAP date is expected to be in the format YYYYMMDD.
      * @note If the date is invalid a default DuckDB date is returned.
     */
-    Value dats2duck(std::string &dats_str) 
+    Value dats2duck(std::string &dats_str)
     {
-        if (dats_str.empty()) {
-            return Value();
+        // Trim trailing whitespace/null bytes the SDK may leave behind.
+        auto trimmed = dats_str;
+        while (!trimmed.empty() && (trimmed.back() == ' ' || trimmed.back() == '\0')) {
+            trimmed.pop_back();
+        }
+        if (trimmed.empty()) {
+            return Value(LogicalType::DATE);
+        }
+        // ABAP initial value for DATS is all zeros; treat as NULL.
+        if (trimmed.find_first_not_of('0') == std::string::npos) {
+            return Value(LogicalType::DATE);
+        }
+        if (trimmed.size() < 8) {
+            return Value(LogicalType::DATE);
         }
 
-        int32_t year, month, day;
-
-        std::istringstream(dats_str.substr(0, 4)) >> year;
-        std::istringstream(dats_str.substr(4, 2)) >> month;
-        std::istringstream(dats_str.substr(6, 2)) >> day;
+        int32_t year = 0, month = 0, day = 0;
+        try {
+            year  = std::stoi(trimmed.substr(0, 4));
+            month = std::stoi(trimmed.substr(4, 2));
+            day   = std::stoi(trimmed.substr(6, 2));
+        } catch (...) {
+            return Value(LogicalType::DATE);
+        }
 
         date_t duck_date;
-        Date::TryFromDate(year, month, day, duck_date);
+        if (!Date::TryFromDate(year, month, day, duck_date)) {
+            return Value(LogicalType::DATE);
+        }
         return Value::CreateValue(duck_date);
     }
 
@@ -317,15 +336,33 @@ namespace duckdb
     */
     Value tims2duck(std::string &tims_str)
     {
-        if (tims_str.empty()) {
-            return Value();
+        // Trim trailing whitespace/null bytes the SDK may leave behind.
+        auto trimmed = tims_str;
+        while (!trimmed.empty() && (trimmed.back() == ' ' || trimmed.back() == '\0')) {
+            trimmed.pop_back();
+        }
+        if (trimmed.empty()) {
+            return Value(LogicalType::TIME);
+        }
+        // ABAP initial value for TIMS is all zeros; treat as NULL.
+        if (trimmed.find_first_not_of('0') == std::string::npos) {
+            return Value(LogicalType::TIME);
+        }
+        if (trimmed.size() < 6) {
+            return Value(LogicalType::TIME);
         }
 
-        int32_t hour, minute, second;
-
-        std::istringstream(tims_str.substr(0, 2)) >> hour;
-        std::istringstream(tims_str.substr(2, 2)) >> minute;
-        std::istringstream(tims_str.substr(4, 2)) >> second;
+        int32_t hour = 0, minute = 0, second = 0;
+        try {
+            hour   = std::stoi(trimmed.substr(0, 2));
+            minute = std::stoi(trimmed.substr(2, 2));
+            second = std::stoi(trimmed.substr(4, 2));
+        } catch (...) {
+            return Value(LogicalType::TIME);
+        }
+        if (!IsValidTime(hour, minute, second)) {
+            return Value(LogicalType::TIME);
+        }
 
         dtime_t duck_time = Time::FromTime(hour, minute, second, 0);
         return Value::CreateValue(duck_time);
@@ -474,21 +511,10 @@ namespace duckdb
      * @note The SAP time is expected to be in the format HHMMSS.
      * @note If the input time is invalid, a default time value is returned.
      */
-    Value rfc2duck(RFC_TIME &rfc_time) 
+    Value rfc2duck(RFC_TIME &rfc_time)
     {
         auto time_str = uc2std(rfc_time, SAP_TIME_LN);
-        int32_t hour, minute, second;
-
-        std::istringstream(time_str.substr(0, 2)) >> hour;
-        std::istringstream(time_str.substr(2, 2)) >> minute;
-        std::istringstream(time_str.substr(4, 2)) >> second;
-
-        if (!IsValidTime(hour, minute, second)) {
-            return Value::CreateValue((dtime_t()));
-        }
-
-        dtime_t duck_time = Time::FromTime(hour, minute, second, 0);
-        return Value::CreateValue(duck_time);
+        return tims2duck(time_str);
     }
 
     /**

--- a/rfc/test/cpp/test_type_conversion.cpp
+++ b/rfc/test/cpp/test_type_conversion.cpp
@@ -158,13 +158,29 @@ TEST_CASE("Test rfc2duck with RFC date", "[sap_type_conversion]") {
 TEST_CASE("Test rfc2duck with empty date", "[sap_type_conversion]") {
     RFC_DATE date = {'0', '0', '0', '0', '0', '0', '0', '0'};
     Value result = rfc2duck(date);
-    REQUIRE(DateValue::Get(result) == date_t());
+    REQUIRE(result.IsNull());
+    REQUIRE(result.type().id() == LogicalTypeId::DATE);
 }
 
-TEST_CASE("Test rfc2duck with invalid date", "[sap_type_conversion]") {
+TEST_CASE("Test dats2duck with all-spaces date returns NULL", "[sap_type_conversion]") {
+    std::string dats_str = "        ";
+    Value result = dats2duck(dats_str);
+    REQUIRE(result.IsNull());
+    REQUIRE(result.type().id() == LogicalTypeId::DATE);
+}
+
+TEST_CASE("Test dats2duck with empty string returns NULL", "[sap_type_conversion]") {
+    std::string dats_str = "";
+    Value result = dats2duck(dats_str);
+    REQUIRE(result.IsNull());
+    REQUIRE(result.type().id() == LogicalTypeId::DATE);
+}
+
+TEST_CASE("Test rfc2duck with invalid date returns NULL", "[sap_type_conversion]") {
     RFC_DATE date = {'2', '0', '2', '0', '1', '3', '6', '4'};
     Value result = rfc2duck(date);
-    REQUIRE(DateValue::Get(result) == date_t());
+    REQUIRE(result.IsNull());
+    REQUIRE(result.type().id() == LogicalTypeId::DATE);
 }
 
 TEST_CASE("TEST rfc2duck with RFC time", "[sap_type_conversion]") {
@@ -176,13 +192,29 @@ TEST_CASE("TEST rfc2duck with RFC time", "[sap_type_conversion]") {
 TEST_CASE("TEST rfc2duck with empty time", "[sap_type_conversion]") {
     RFC_TIME time = {'0', '0', '0', '0', '0', '0'};
     Value result = rfc2duck(time);
-    REQUIRE(TimeValue::Get(result) == dtime_t());
+    REQUIRE(result.IsNull());
+    REQUIRE(result.type().id() == LogicalTypeId::TIME);
+}
+
+TEST_CASE("Test tims2duck with all-spaces time returns NULL", "[sap_type_conversion]") {
+    std::string tims_str = "      ";
+    Value result = tims2duck(tims_str);
+    REQUIRE(result.IsNull());
+    REQUIRE(result.type().id() == LogicalTypeId::TIME);
+}
+
+TEST_CASE("Test tims2duck with empty string returns NULL", "[sap_type_conversion]") {
+    std::string tims_str = "";
+    Value result = tims2duck(tims_str);
+    REQUIRE(result.IsNull());
+    REQUIRE(result.type().id() == LogicalTypeId::TIME);
 }
 
 TEST_CASE("TEST rfc2duck with invalid time", "[sap_type_conversion]") {
     RFC_TIME time = {'2', '6', '0', '0', '0', '0'};
     Value result = rfc2duck(time);
-    REQUIRE(TimeValue::Get(result) == dtime_t());
+    REQUIRE(result.IsNull());
+    REQUIRE(result.type().id() == LogicalTypeId::TIME);
 }
 
 TEST_CASE("Test rfc2duck for float", "[sap_type_conversion]") {

--- a/rfc/test/sql/sap_read_table.test
+++ b/rfc/test/sql/sap_read_table.test
@@ -229,3 +229,33 @@ query I
 SELECT COUNT(*) FROM sap_read_table('/DMO/FLIGHT', COLUMNS=['CARRIER_ID'], READ_TABLE_FUNCTION='/SAPDS/RFC_READ_TABLE2', READ_TABLE_DELIMITER='~');
 ----
 40
+
+# ---------------------------------------------------------------------
+# Issue #64: NULL / initial DATS and TIMS columns must round-trip as
+# DuckDB NULL, not silently materialize as 1970-01-01 / 00:00:00 (the
+# all-zeros initial value) or wild garbage dates like 1439716-08-13
+# (the all-spaces RFC_READ_TABLE form). USR02 contains at least one
+# row whose TRDAT/LTIME are initial — the trial ships with the SAP*
+# user that never logged on. The fix in dats2duck/tims2duck must keep
+# those rows non-empty in the result set but report them as NULL.
+query II
+SELECT
+    SUM(CASE WHEN TRDAT IS NULL THEN 1 ELSE 0 END) > 0 AS has_null_dats,
+    SUM(CASE WHEN LTIME IS NULL THEN 1 ELSE 0 END) > 0 AS has_null_tims
+FROM sap_read_table('USR02', COLUMNS=['TRDAT','LTIME']);
+----
+true	true
+
+# The legacy buggy behaviour materialised initial DATS as 1970-01-01
+# (the all-zeros case) or wild garbage dates above year 9999 (the
+# all-spaces case). Aggregate over the full result so the predicates
+# stay client-side — pushing TRDAT = DATE '1970-01-01' down to SAP
+# fails because D(8,0) cannot represent that literal.
+query III
+SELECT
+    SUM(CASE WHEN TRDAT = DATE '1970-01-01' THEN 1 ELSE 0 END) AS epoch_dats_rows,
+    SUM(CASE WHEN extract(year FROM TRDAT) > 9999 THEN 1 ELSE 0 END) AS overflow_dats_rows,
+    SUM(CASE WHEN TRDAT IS NOT NULL AND extract(year FROM TRDAT) < 1900 THEN 1 ELSE 0 END) AS prehistoric_dats_rows
+FROM sap_read_table('USR02', COLUMNS=['TRDAT']);
+----
+0	0	0


### PR DESCRIPTION
## Summary

- Fixes #64. `dats2duck` / `tims2duck` previously turned SAP's initial / unset DATS and TIMS values into garbage instead of NULL:
  - `"00000000"` / `"000000"` (ABAP initial value) silently became `1970-01-01` / `00:00:00`.
  - `"        "` / `"      "` (what `RFC_READ_TABLE` actually sends for an unset column) made the `istringstream` extractions fail and leak uninitialized ints into `Date::TryFromDate`, producing wild dates like `1439716-08-13` from the bug report.
- Both helpers now mirror `sap_utc2timestamp`: trim trailing whitespace / nulls, short-circuit empty and all-zero inputs to a typed NULL (`Value(LogicalType::DATE/TIME)`), use `std::stoi` with try/catch instead of relying on uninitialized locals, and return NULL when `Date::TryFromDate` or the time range check rejects the parsed components.
- `rfc2duck(RFC_TIME&)` is folded onto `tims2duck` so direct RFC calls get the same NULL handling as the `sap_read_table` CSV path.

## Test plan

- [x] `./build/debug/extension/erpl_rfc/test/cpp/erpl_rfc_tests` — 233 assertions / 80 test cases, including new regression cases for empty / all-spaces / all-zeros / invalid DATS and TIMS.
- [x] `make sql_tests_rfc TEST_FILE=sap_read_table.test` — 60 assertions, including a new end-to-end check against `USR02` (whose `SAP*` row has unset `TRDAT` / `LTIME`) that asserts NULLs round-trip and no row materializes as `1970-01-01` or with year > 9999.
- [x] Negative control: temporarily reverting just `rfc/src/sap_type_conversion.cpp` to master and rebuilding makes the USR02 query show `1970-01-01 / 00:00:00`, and the new assertions fail.