### PR TITLE
fix(rfc): list scoped tables in SHOW TABLES via TABLES glob patterns (#70)

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -327,6 +327,10 @@ ATTACH '' AS sap (TYPE sap_rfc, SECRET 'my_sap');
 -- Restrict to specific tables
 ATTACH '' AS sap (TYPE sap_rfc, TABLES 'SFLIGHT,SPFLI,SCARR');
 
+-- Scope to tables matching a glob pattern (resolved against the dictionary at ATTACH)
+ATTACH '' AS sap (TYPE sap_rfc, TABLES '/DMO/*,Z*');
+SHOW TABLES FROM sap;   -- lists the resolved set
+
 -- Detach
 DETACH sap;
 ```
@@ -335,7 +339,21 @@ DETACH sap;
 |--------|------|-------------|
 | `TYPE` | — | Must be `sap_rfc` |
 | `SECRET` | VARCHAR | Named secret for SAP connection |
-| `TABLES` | VARCHAR | Comma-separated list of tables to expose (empty = on-demand) |
+| `TABLES` | VARCHAR | Comma-separated list of exact table names and/or glob patterns (`*`, `?`) to expose. Empty = on-demand lookup. |
+
+**`SHOW TABLES` and table enumeration.** A SAP system exposes tens of thousands of
+tables, so an attached catalog does **not** list them all. `SHOW TABLES FROM <catalog>`
+(and `information_schema.tables`) reflect only the tables named or matched by `TABLES`:
+
+- With `TABLES` (exact names and/or patterns) → those tables are listed and queryable;
+  tables outside the set are not accessible through the catalog.
+- Without `TABLES` → tables are resolved **on demand** when referenced by name
+  (`SELECT * FROM sap."SFLIGHT"`), and `SHOW TABLES` is **empty by design**.
+
+Patterns use `*` (any run of characters) and `?` (single character) and are resolved once,
+at `ATTACH` time, against the data dictionary (`DD02V`, the same source as
+`sap_show_tables()`). To browse the full catalog without scoping, use
+[`sap_show_tables()`](#sap_show_tablestablename-text-threads).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,24 @@ LOAD erpl;
 
 ---
 
+## v2026.05.27 — `SHOW TABLES` on attached catalogs
+
+Fixes [#70](https://github.com/DataZooDE/erpl/issues/70): `SHOW TABLES FROM <attached
+sap catalog>` returned no rows. A SAP system exposes tens of thousands of tables
+(~55k on the ABAP trial), and each catalog entry needs a per-table dictionary
+roundtrip to discover its schema, so the catalog cannot eagerly enumerate everything.
+
+### SAP scan path
+
+- **[rfc]** The `TABLES` ATTACH option now accepts glob patterns (`*`, `?`) in
+  addition to exact names, e.g. `ATTACH '' AS sap (TYPE sap_rfc, TABLES '/DMO/*,Z*')`.
+  Patterns are resolved once, at ATTACH time, against `DD02V` (the same dictionary
+  view `sap_show_tables()` uses). `SHOW TABLES` and `information_schema.tables` then
+  list the resolved, bounded set, and tables outside it are not exposed through the
+  catalog. A safety cap (5000 tables) rejects unbounded patterns with an actionable
+  hint. Without `TABLES`, tables remain resolvable on demand by name and `SHOW TABLES`
+  stays empty by design — use `sap_show_tables()` to browse the full catalog.
+
 ## v2026.05.24 — Wide-table CPIC exhaustion fix
 
 Targeted follow-up to [#67](https://github.com/DataZooDE/erpl/issues/67), reported

--- a/rfc/src/sap_storage.cpp
+++ b/rfc/src/sap_storage.cpp
@@ -10,6 +10,12 @@
 #include "duckdb/parser/column_definition.hpp"
 #include "duckdb/main/config.hpp"
 
+// sap_rfc.hpp / erpl_tracing.hpp are version-independent and are needed by the
+// TABLES pattern-expansion helper (ResolveTablePatterns), which runs for every
+// DuckDB version.
+#include "sap_rfc.hpp"
+#include "erpl_tracing.hpp"
+
 // entry_lookup_info.hpp was introduced alongside TryLookupEntryInternal in DuckDB v1.5+
 #if DUCKDB_MINOR_VERSION >= 5
 #include "duckdb/catalog/entry_lookup_info.hpp"
@@ -21,8 +27,6 @@
 #include "scanner_show_tables.hpp"
 #include "scanner_describe_fields.hpp"
 #include "sap_table_entry.hpp"
-#include "sap_rfc.hpp"
-#include "erpl_tracing.hpp"
 #endif
 
 #include "sap_storage.hpp"
@@ -292,6 +296,77 @@ private:
 #endif // DUCKDB_MINOR_VERSION >= 5
 
 // ---------------------------------------------------------------------------
+// TABLES pattern expansion
+//
+// The `TABLES` ATTACH option accepts a comma-separated mix of exact table
+// names and glob patterns (`*` → any run, `?` → single char).  Patterns are
+// resolved here, at attach time, against DD02V (the same data-dictionary view
+// `sap_show_tables()` uses) and expanded into concrete names.  Those names
+// then populate the catalog's allow-list so `SHOW TABLES`, information_schema
+// and named lookups all reflect the scoped set — without ERPL having to
+// enumerate (and DDIC-discover) the tens of thousands of tables a real SAP
+// system exposes.  See issue #70.
+// ---------------------------------------------------------------------------
+
+// Upper bound on how many tables a TABLES pattern set may resolve to.  Each
+// resolved table becomes a catalog entry whose schema is discovered via an RFC
+// roundtrip on first catalog scan; an unbounded pattern (e.g. `TABLES '*'`)
+// would otherwise turn the first `SHOW TABLES` into tens of thousands of RFC
+// calls.  Narrow the pattern or use `sap_show_tables()` to browse instead.
+static constexpr idx_t MAX_ATTACH_TABLE_EXPANSION = 5000;
+
+static bool IsTablePattern(const string &token) {
+	return token.find('*') != string::npos || token.find('?') != string::npos ||
+	       token.find('%') != string::npos;
+}
+
+static vector<string> ResolveTablePatterns(ClientContext &context, const string &secret_name,
+                                           const vector<string> &patterns) {
+	vector<string> out;
+	for (auto pattern : patterns) {
+		// glob → SQL LIKE, then guard the literal against quote injection.
+		pattern = StringUtil::Replace(pattern, "*", "%");
+		pattern = StringUtil::Replace(pattern, "?", "_");
+		pattern = StringUtil::Replace(pattern, "'", "''");
+
+		auto where_clause = StringUtil::Format(
+		    "DDLANGUAGE = 'E' AND TABNAME LIKE '%s' AND "
+		    "( TABCLASS = 'VIEW' OR TABCLASS = 'TRANSP' OR TABCLASS = 'POOL' OR TABCLASS = 'CLUSTER' )",
+		    pattern);
+
+		auto bind_data = make_uniq<RfcReadTableBindData>("DD02V", /*max_read_threads=*/0, /*limit=*/0,
+		                                                 "RFC_READ_TABLE", "", false,
+		                                                 &DefaultRfcConnectionFactory, context);
+		if (!secret_name.empty()) {
+			bind_data->SetSecretName(secret_name);
+		}
+		bind_data->InitOptionsFromWhereClause(where_clause);
+		bind_data->InitAndVerifyFields({"TABNAME"});
+		vector<column_t> column_ids = {0};
+		bind_data->ActivateColumns(column_ids);
+
+		DataChunk chunk;
+		chunk.Initialize(Allocator::Get(context), bind_data->GetReturnTypes());
+		while (bind_data->HasMoreResults()) {
+			chunk.Reset();
+			bind_data->Step(context, chunk);
+			for (idx_t i = 0; i < chunk.size(); i++) {
+				auto val = chunk.GetValue(0, i);
+				if (val.IsNull()) {
+					continue;
+				}
+				auto name = val.ToString();
+				StringUtil::Trim(name);
+				if (!name.empty()) {
+					out.push_back(std::move(name));
+				}
+			}
+		}
+	}
+	return out;
+}
+
+// ---------------------------------------------------------------------------
 // SapStorageAttach
 // ---------------------------------------------------------------------------
 
@@ -300,6 +375,7 @@ static unique_ptr<Catalog> SapStorageAttach(optional_ptr<StorageExtensionInfo> s
                                             AttachOptions &attach_options) {
 	string secret_name;
 	vector<string> allowed_tables;
+	vector<string> table_patterns;
 
 	for (auto &entry : attach_options.options) {
 		auto lower_name = StringUtil::Lower(entry.first);
@@ -310,7 +386,12 @@ static unique_ptr<Catalog> SapStorageAttach(optional_ptr<StorageExtensionInfo> s
 			auto split = StringUtil::Split(tables_str, ',');
 			for (auto &s : split) {
 				StringUtil::Trim(s);
-				if (!s.empty()) {
+				if (s.empty()) {
+					continue;
+				}
+				if (IsTablePattern(s)) {
+					table_patterns.push_back(s);
+				} else {
 					allowed_tables.push_back(s);
 				}
 			}
@@ -328,6 +409,34 @@ static unique_ptr<Catalog> SapStorageAttach(optional_ptr<StorageExtensionInfo> s
 		auto secret_entry = secret_manager.GetSecretByName(transaction, secret_name);
 		if (!secret_entry) {
 			throw InvalidInputException("Secret '%s' not found", secret_name);
+		}
+	}
+
+	// Expand any glob patterns in TABLES into concrete table names (issue #70).
+	if (!table_patterns.empty()) {
+		auto resolved = ResolveTablePatterns(context, secret_name, table_patterns);
+		for (auto &name : resolved) {
+			allowed_tables.push_back(std::move(name));
+		}
+	}
+
+	// De-duplicate the allow-list case-insensitively, preserving first occurrence.
+	if (!allowed_tables.empty()) {
+		vector<string> deduped;
+		case_insensitive_set_t seen;
+		for (auto &name : allowed_tables) {
+			if (seen.insert(name).second) {
+				deduped.push_back(name);
+			}
+		}
+		allowed_tables = std::move(deduped);
+
+		if (allowed_tables.size() > MAX_ATTACH_TABLE_EXPANSION) {
+			throw InvalidInputException(
+			    "ATTACH TABLES resolved to %llu tables, exceeding the limit of %llu. "
+			    "Narrow the pattern (e.g. TABLES '/DMO/*' or 'Z*'), or omit TABLES and use "
+			    "sap_show_tables() to browse the full catalog.",
+			    (idx_t)allowed_tables.size(), MAX_ATTACH_TABLE_EXPANSION);
 		}
 	}
 

--- a/rfc/test/sql/sap_rfc_attach.test
+++ b/rfc/test/sql/sap_rfc_attach.test
@@ -208,3 +208,61 @@ true
 
 statement ok
 DETACH sap_issue54;
+
+# ---------------------------------------------------------------------
+# Test 15: TABLES wildcard pattern populates SHOW TABLES (issue #70)
+#
+# Without TABLES, SHOW TABLES on an attached SAP catalog was empty because
+# the catalog cannot enumerate the tens of thousands of SAP tables.  TABLES
+# now accepts glob patterns (`*`, `?`); SHOW TABLES then lists exactly the
+# resolved set, scoped to a bounded, meaningful subset.
+
+statement ok
+ATTACH '' AS sap_pat (TYPE sap_rfc, SECRET 'abap_trial', TABLES '/DMO/*');
+
+# The pattern resolves to many tables (48 on the ABAP trial); assert it is
+# non-empty rather than an exact count so the test stays portable.
+query I
+SELECT COUNT(*) >= 2 FROM (SHOW TABLES FROM sap_pat);
+----
+true
+
+# A specific known table is present in the listing.
+query I
+SELECT COUNT(*) FROM (SHOW TABLES FROM sap_pat) WHERE "name" = '/DMO/FLIGHT';
+----
+1
+
+# A pattern-matched table is queryable through the attached catalog.
+query I
+SELECT COUNT(*) > 0 FROM sap_pat."/DMO/FLIGHT";
+----
+true
+
+# A table outside the pattern is NOT accessible (the pattern scopes the catalog).
+statement error
+SELECT * FROM sap_pat."DD02L";
+----
+Catalog Error
+
+statement ok
+DETACH sap_pat;
+
+# ---------------------------------------------------------------------
+# Test 16: TABLES mixes exact names and patterns; duplicates collapse
+statement ok
+ATTACH '' AS sap_mix (TYPE sap_rfc, SECRET 'abap_trial', TABLES '/DMO/CARRIER,/DMO/*');
+
+# /DMO/CARRIER is matched by both the exact entry and the pattern but appears once.
+query I
+SELECT COUNT(*) FROM (SHOW TABLES FROM sap_mix) WHERE "name" = '/DMO/CARRIER';
+----
+1
+
+query I
+SELECT COUNT(*) >= 2 FROM (SHOW TABLES FROM sap_mix);
+----
+true
+
+statement ok
+DETACH sap_mix;


### PR DESCRIPTION
## Summary

Fixes #70. `SHOW TABLES FROM <attached sap catalog>` returned no rows unless the `ATTACH` was given an explicit `TABLES` list. A SAP system exposes tens of thousands of tables (~55k on the ABAP trial), and each catalog entry needs a per-table DDIC schema-discovery RFC roundtrip — so the catalog cannot eagerly enumerate everything.

The `TABLES` `ATTACH` option now accepts **glob patterns** (`*`, `?`) alongside exact names:

```sql
ATTACH '' AS sap (TYPE sap_rfc, SECRET 'my_sap', TABLES '/DMO/*,Z*');
SHOW TABLES FROM sap;   -- lists the resolved, bounded set
```

- Patterns are resolved **once, at `ATTACH` time**, against `DD02V` (the same dictionary view `sap_show_tables()` uses) and expanded into the catalog allow-list, so `SHOW TABLES` and `information_schema.tables` reflect the scoped set. Tables outside the set are not exposed (consistent with the existing exact-`TABLES` scoping).
- A **5000-table cap** rejects unbounded patterns (e.g. `TABLES '*'`) with an actionable hint, preventing a first `SHOW TABLES` from turning into tens of thousands of RFC calls.
- **Without `TABLES`**, behaviour is unchanged: tables remain resolvable on demand by name and `SHOW TABLES` stays empty by design — use `sap_show_tables()` to browse the full catalog.

Exact names and patterns can be mixed; the resolved list is de-duplicated case-insensitively.

## Changes

- `rfc/src/sap_storage.cpp` — classify `TABLES` tokens (exact vs. pattern), add `ResolveTablePatterns()` (reuses the existing `RfcReadTableBindData` DD02V read path), merge + dedup into `allowed_tables`, enforce the expansion cap.
- `rfc/test/sql/sap_rfc_attach.test` — tests 15/16: pattern listing, specific-table presence, query through the catalog, out-of-pattern scoping rejection, and mixed exact+pattern dedup.
- `API_REFERENCE.md`, `CHANGELOG.md` — document the pattern syntax and `SHOW TABLES` semantics (new `v2026.05.27` entry).

## Test plan

- [x] `GEN=ninja make debug`
- [x] Manual verification against the local ABAP trial: `/DMO/*` → `SHOW TABLES` lists 48; specific table present; query works; out-of-pattern table rejected; mixed exact+pattern dedups; `TABLES '*'` hits the 5000 cap; no-`TABLES` stays empty with on-demand lookup intact.
- [x] `make sql_tests_rfc TEST_FILE=sap_rfc_attach.test` → 47 assertions pass
- [x] Full `make sql_tests_rfc` → all 18 RFC test files pass