### PR TITLE
fix(rfc): stream sap_read_table from the SDK handle + bound the result buffer on wide scans (#69)

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1128,6 +1128,9 @@ Notes:
 | `erpl_trace_max_file_size` | BIGINT | 0 (unlimited) | Max trace file size in bytes |
 | `erpl_trace_rotation` | BOOLEAN | `false` | Enable trace file rotation |
 | `erpl_rfc_strict_type_check` | BOOLEAN | `false` | When true, throw an error on unsupported SAP RFC types instead of falling back to VARCHAR |
+| `erpl_rfc_persistent_connections` | BOOLEAN | `true` | Cache one RFC connection + function descriptor per column for a `sap_read_table` scan instead of reopening per batch |
+| `erpl_rfc_max_persistent_connections` | UINTEGER | 16 | Upper bound on RFC connections a scan caches concurrently (issue #67); columns past the cap use per-batch open/close |
+| `erpl_rfc_read_table_batch_budget` | UINTEGER | 1310720 | Target max concurrent result rows (projected columns × per-column batch) for `sap_read_table`; bounds peak memory on wide tables (issue #69). Lower = less memory but more RFC round-trips; `0` disables the cap |
 
 ```sql
 SET erpl_trace_enabled = TRUE;

--- a/rfc/src/erpl_rfc_extension.cpp
+++ b/rfc/src/erpl_rfc_extension.cpp
@@ -148,6 +148,10 @@ namespace duckdb {
         SetRfcMaxPersistentConnections(parameter.GetValue<unsigned int>());
     }
 
+    static void OnReadTableBatchBudget(ClientContext &, SetScope, Value &parameter) {
+        SetRfcReadTableBatchBudget(parameter.GetValue<unsigned int>());
+    }
+
     static void RegisterConfiguration(ExtensionLoader &loader)
     {
         auto &instance = loader.GetDatabaseInstance();
@@ -200,6 +204,21 @@ namespace duckdb {
             LogicalType::UINTEGER,
             Value::UINTEGER(16),
             OnMaxPersistentConnections);
+
+        config.AddExtensionOption(
+            "erpl_rfc_read_table_batch_budget",
+            "Target upper bound on concurrent result rows (projected columns x "
+            "per-column batch size) held by a sap_read_table scan (issue #69).  "
+            "RFC_READ_TABLE materialises every row's fixed-width work area inside "
+            "the SAP SDK, and all projected columns read in parallel, so this "
+            "bounds peak memory on wide tables (BSEG, ACDOCA).  Lower it to cap "
+            "memory harder (at the cost of more RFC round-trips / slower wall "
+            "time); raise it for fewer round-trips on narrow tables.  The "
+            "per-column batch is clamped to [STANDARD_VECTOR_SIZE, 16x] and "
+            "warms up by power-of-two doubling.  0 disables the cap.",
+            LogicalType::UINTEGER,
+            Value::UINTEGER(RfcReadColumnStateMachine::DEFAULT_READ_TABLE_BATCH_BUDGET),
+            OnReadTableBatchBudget);
 
         auto provider = make_uniq<RfcEnvironmentCredentialsProvider>(config);
         provider->SetAll();

--- a/rfc/src/include/sap_function.hpp
+++ b/rfc/src/include/sap_function.hpp
@@ -68,8 +68,14 @@ bool GetRfcStrictTypeCheck();
             void AdaptValue(DATA_CONTAINER_HANDLE &container_handle, string &arg_name, Value &arg_value);
             Value ConvertRfcValue(RfcInvocation &invocation, string &field_name);
             Value ConvertRfcValue(std::shared_ptr<RfcInvocation> invocation, string &field_name);
+            // Reads `field_name` directly from an already-positioned SDK
+            // container (a structure/row handle), reusing the exact same
+            // per-type conversion as ConvertRfcValue.  Used by the read-table
+            // column scanner to stream rows straight from the SDK result
+            // table without materialising the whole batch as duckdb::Value.
+            Value ConvertRfcValueFromContainer(DATA_CONTAINER_HANDLE container_handle, const std::string &field_name);
             Value ConvertCsvValue(const Value &csv_value) const;
-            
+
             virtual std::string ToSqlLiteral();
 
         private:
@@ -200,6 +206,10 @@ bool GetRfcStrictTypeCheck();
             std::shared_ptr<RfcConnection> GetConnection() const;
             std::shared_ptr<RfcResultSet> Invoke(std::string path);
             std::shared_ptr<RfcResultSet> Invoke();
+            // Executes the RFC call (RfcInvoke) without materialising a
+            // RfcResultSet.  Callers that stream results straight from the
+            // SDK handles use this together with GetFunctionHandle().
+            void Execute();
 
             void DeactivateResult(std::string &param_name);
             void DeactivateResult(unsigned int col_idx);

--- a/rfc/src/include/sap_rfc.hpp
+++ b/rfc/src/include/sap_rfc.hpp
@@ -32,6 +32,12 @@ namespace duckdb
 	void SetRfcMaxPersistentConnections(unsigned int n);
 	unsigned int GetRfcMaxPersistentConnections();
 
+	// Concurrent-row budget for sap_read_table: caps (projected columns x
+	// batch_size) to bound the SAP SDK result buffer on wide scans (#69).
+	// Wired to the `erpl_rfc_read_table_batch_budget` extension option.
+	void SetRfcReadTableBatchBudget(unsigned int n);
+	unsigned int GetRfcReadTableBatchBudget();
+
 	//struct RfcReadTableGlobalState; // forward declaration
 	//struct RfcReadTableLocalState; // forward declaration
 	class RfcReadColumnStateMachine; // forward declaration
@@ -89,6 +95,13 @@ namespace duckdb
 			bool HasMoreResults();
 			void Step(ClientContext &context, DataChunk &output);
 
+			// Per-scan ceiling for the warm-up batch doubling, capped so that
+			// (projected columns x batch_size) stays within a fixed row budget
+			// — bounds the SAP SDK result buffer on wide scans (issue #69).
+			// Computed in Step() from the active column count; defaults to the
+			// absolute MAX_BATCH_SIZE for narrow scans.
+			unsigned int GetEffectiveMaxBatchSize() const { return effective_max_batch_size; }
+
 			std::string ToString();
 			double GetProgress();
 
@@ -125,6 +138,10 @@ namespace duckdb
 			std::vector<RfcType> column_types;
 			std::vector<RfcReadColumnStateMachine> column_state_machines;
 			std::atomic<unsigned int> persistent_slots_used{0};
+			// Defaults to RfcReadColumnStateMachine::MAX_BATCH_SIZE (that class
+			// is defined later in this header, so we can't name the constant
+			// here); Step() overwrites this with the column-count-aware cap.
+			unsigned int effective_max_batch_size = 16u * STANDARD_VECTOR_SIZE;
 
 			std::vector<RfcReadColumnStateMachine> CreateReadColumnStateMachines();
 			unsigned int NActiveStateMachines();
@@ -209,6 +226,14 @@ namespace duckdb
 			// is a power-of-two so the doubling sequence reaches it cleanly.
 			static constexpr unsigned int MAX_BATCH_SIZE = 16 * STANDARD_VECTOR_SIZE;
 
+			// Default concurrent-row budget for MaxBatchSizeForColumnCount: the
+			// target upper bound on (projected columns x batch_size), which
+			// bounds the SAP SDK result buffer on wide scans (issue #69).
+			// ~1.25M rows keeps a BSEG-shaped (~150 col) scan near an 8k batch
+			// — a balance between peak memory and RFC round-trip count.
+			// Overridable at runtime via erpl_rfc_read_table_batch_budget.
+			static constexpr unsigned int DEFAULT_READ_TABLE_BATCH_BUDGET = 1280u * 1024u;
+
 			// Pure helpers that encode the two ABAP-divisibility-preserving
 			// rules used inside the state machine.  Exposed so they can be
 			// tested without driving a live RFC scan.
@@ -224,8 +249,17 @@ namespace duckdb
 			//     produce an illegal (non-divisor) ROWCOUNT — in that case
 			//     we over-fetch and rely on LoadNextBatchToDuckDBColumn() to
 			//     clip the surplus client-side.
-			static unsigned int NextDesiredBatchSize(unsigned int current, unsigned int total_rows_after);
+			static unsigned int NextDesiredBatchSize(unsigned int current, unsigned int total_rows_after,
+			                                         unsigned int max_batch_size = MAX_BATCH_SIZE);
 			static unsigned int TrimmedActualBatchSize(unsigned int desired, unsigned int total_rows, unsigned int limit);
+
+			//   MaxBatchSizeForColumnCount: the per-scan warm-up ceiling that
+			//     keeps (projected columns x batch_size) within a fixed row
+			//     budget, bounding the SAP SDK result buffer on wide scans
+			//     (issue #69).  Returns a power of two in
+			//     [STANDARD_VECTOR_SIZE, MAX_BATCH_SIZE].
+			static unsigned int MaxBatchSizeForColumnCount(unsigned int num_columns,
+			                                               unsigned int concurrent_row_budget = DEFAULT_READ_TABLE_BATCH_BUDGET);
 
 		private:
 			bool active = true;
@@ -260,7 +294,21 @@ namespace duckdb
 
 			RfcReadTableBindData *bind_data;
 			ReadTableStates current_state = ReadTableStates::INIT;
-			std::shared_ptr<RfcResultSet> current_result_data = nullptr;
+
+			// Streaming read path (issue #69): instead of materialising the
+			// whole RFC batch as a duckdb::Value tree (RfcResultSet), we keep
+			// the live invocation — which owns the SDK function/result-table
+			// handle — and walk its rows straight into the output Vector one
+			// STANDARD_VECTOR_SIZE window at a time.  current_invocation must
+			// outlive every LoadNextBatchToDuckDBColumn call for the batch, so
+			// the SDK handle (and therefore current_table_handle) stays valid.
+			std::shared_ptr<RfcInvocation> current_invocation = nullptr;
+			RFC_TABLE_HANDLE current_table_handle = nullptr;
+			unsigned int current_batch_rows = 0;
+			// The single result-row field carrying the column's CSV payload
+			// (e.g. "WA"), resolved per batch from the result-table metadata.
+			std::shared_ptr<RfcType> wa_field_type = nullptr;
+			std::string wa_field_name;
 
 			std::mutex thread_lock;
 	};
@@ -274,6 +322,12 @@ namespace duckdb
 		private:
 			unsigned int ExecuteNextTableReadForColumn();
 			std::vector<Value> CreateFunctionArguments(const std::string &delimiter, bool use_et_data);
+
+			// Resolves the SDK result-table handle + its CSV-carrying field for
+			// the just-executed invocation, storing them on the state machine
+			// for streaming.  Returns the batch row count.  Handles the
+			// /TBLOUTxxxx size-bucket fallback used by /SAPDS RFC_READ_TABLE2.
+			unsigned int ResolveResultTable(std::shared_ptr<RfcInvocation> invocation, std::string data_path);
 
 			unsigned int LoadNextBatchToDuckDBColumn();
 			Value ParseCsvValue(const RfcType &rfc_type, const Value &orig) const;

--- a/rfc/src/sap_function.cpp
+++ b/rfc/src/sap_function.cpp
@@ -564,6 +564,16 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
         return ConvertRfcValue(function_handle, field_name);
     }
 
+    Value RfcType::ConvertRfcValueFromContainer(DATA_CONTAINER_HANDLE container_handle, const std::string &field_name)
+    {
+        // RFC_FUNCTION_HANDLE / RFC_STRUCTURE_HANDLE / DATA_CONTAINER_HANDLE
+        // are the same opaque SDK handle type; the per-type RfcGet* accessors
+        // work against any of them, so we reuse the function-handle overload.
+        RFC_FUNCTION_HANDLE handle = (RFC_FUNCTION_HANDLE)container_handle;
+        std::string name = field_name;
+        return ConvertRfcValue(handle, name);
+    }
+
     Value RfcType::ConvertRfcValue(RFC_FUNCTION_HANDLE &function_handle, string &field_name)
     {
         RFC_RC rc = RFC_OK;
@@ -1563,19 +1573,20 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
         return GetFunction()->GetConnection();
     }
 
-    std::shared_ptr<RfcResultSet> RfcInvocation::Invoke(std::string path) 
+    void RfcInvocation::Execute()
     {
         RFC_ERROR_INFO error_info;
-        RFC_RC rc = RFC_OK;
+        auto connection = GetFunction()->GetConnection();
 
-        auto function = GetFunction();
-        auto connection = function->GetConnection();
-
-        rc = RfcInvoke(connection->handle, _handle, &error_info);
+        RFC_RC rc = RfcInvoke(connection->handle, _handle, &error_info);
         if (rc != RFC_OK) {
             throw std::runtime_error(StringUtil::Format("Failed to invoke function:\n%s", rfcerrorinfo2std(error_info)));
         }
+    }
 
+    std::shared_ptr<RfcResultSet> RfcInvocation::Invoke(std::string path)
+    {
+        Execute();
         return std::make_shared<RfcResultSet>(shared_from_this(), path);
     }
     

--- a/rfc/src/sap_rfc.cpp
+++ b/rfc/src/sap_rfc.cpp
@@ -50,6 +50,12 @@ namespace duckdb
     void SetRfcMaxPersistentConnections(unsigned int n) { g_rfc_max_persistent_connections.store(n, std::memory_order_relaxed); }
     unsigned int GetRfcMaxPersistentConnections()       { return g_rfc_max_persistent_connections.load(std::memory_order_relaxed); }
 
+    // Concurrent-row budget that bounds the SAP SDK result buffer on wide
+    // sap_read_table scans (issue #69).  See MaxBatchSizeForColumnCount.
+    static std::atomic<unsigned int> g_rfc_read_table_batch_budget{RfcReadColumnStateMachine::DEFAULT_READ_TABLE_BATCH_BUDGET};
+    void SetRfcReadTableBatchBudget(unsigned int n) { g_rfc_read_table_batch_budget.store(n, std::memory_order_relaxed); }
+    unsigned int GetRfcReadTableBatchBudget()       { return g_rfc_read_table_batch_budget.load(std::memory_order_relaxed); }
+
     string RfcFunctionDesc(ClientContext &context, const FunctionParameters &parameters)
     {
         auto auth_params = RfcAuthParams::FromContext(context);
@@ -736,6 +742,13 @@ namespace duckdb
             }
         }
 
+        // Bound the SAP SDK result buffer on wide scans by capping the warm-up
+        // batch size to the active column count (issue #69).  Computed here —
+        // outside any per-state-machine lock — and read locklessly by the
+        // tasks scheduled below; the active set is fixed for the whole scan.
+        effective_max_batch_size = RfcReadColumnStateMachine::MaxBatchSizeForColumnCount(
+            (unsigned int)active.size(), GetRfcReadTableBatchBudget());
+
         // When max_threads > 0, the user wants at most that many concurrent
         // RFC calls. Enforce by scheduling tasks in batches. Each batch is
         // one full TaskExecutor cycle: schedule, WorkOnTasks (which blocks
@@ -957,16 +970,39 @@ namespace duckdb
     }
 
     unsigned int RfcReadColumnStateMachine::NextDesiredBatchSize(unsigned int current,
-                                                                 unsigned int total_rows_after)
+                                                                 unsigned int total_rows_after,
+                                                                 unsigned int max_batch_size)
     {
-        if (current >= MAX_BATCH_SIZE) {
+        if (current >= max_batch_size) {
             return current;
         }
         unsigned int next_size = current * 2u;
-        if (next_size > MAX_BATCH_SIZE) {
-            next_size = MAX_BATCH_SIZE;
+        if (next_size > max_batch_size) {
+            next_size = max_batch_size;
         }
         return (total_rows_after % next_size == 0) ? next_size : current;
+    }
+
+    unsigned int RfcReadColumnStateMachine::MaxBatchSizeForColumnCount(unsigned int num_columns,
+                                                                       unsigned int concurrent_row_budget)
+    {
+        // Cap the SAP SDK-side RFC_READ_TABLE result buffer (issue #69).  Each
+        // result row carries a fixed-width CHAR work area inside libsapnwrfc,
+        // and every projected column reads in parallel and holds its batch
+        // resident across all of its LOAD steps — so the peak SDK buffer
+        // scales as (columns x batch_size).  Keep that product within the
+        // concurrent-row budget, floored to a power of two in
+        // [STANDARD_VECTOR_SIZE, MAX_BATCH_SIZE] so the doubling warm-up still
+        // reaches the cap cleanly and ROWSKIPS % ROWCOUNT stays valid.
+        if (num_columns <= 1 || concurrent_row_budget == 0) {
+            return MAX_BATCH_SIZE;
+        }
+        unsigned int per_col = concurrent_row_budget / num_columns;
+        unsigned int cap = STANDARD_VECTOR_SIZE;
+        while (cap * 2u <= per_col && cap * 2u <= MAX_BATCH_SIZE) {
+            cap *= 2u;
+        }
+        return cap;
     }
 
     unsigned int RfcReadColumnStateMachine::TrimmedActualBatchSize(unsigned int desired,
@@ -1112,7 +1148,8 @@ namespace duckdb
                     // RfcReadColumnStateMachine::NextDesiredBatchSize for the rule.
                     if (limit == 0) {
                         desired_batch_size = RfcReadColumnStateMachine::NextDesiredBatchSize(
-                            desired_batch_size, total_rows + extracted_from_sap);
+                            desired_batch_size, total_rows + extracted_from_sap,
+                            owning_state_machine->bind_data->GetEffectiveMaxBatchSize());
                     }
                     break;
                 }
@@ -1144,6 +1181,12 @@ namespace duckdb
                         // the cached RFC connection so we don't hold a SAP work
                         // process reservation until query teardown.
                         owning_state_machine->InvalidateCachedConnection();
+                        // Drop the last batch's SDK function handle now so its
+                        // (potentially large) result-table buffer is freed at
+                        // end-of-column instead of at query teardown (#69).
+                        owning_state_machine->current_invocation.reset();
+                        owning_state_machine->current_table_handle = nullptr;
+                        owning_state_machine->current_batch_rows = 0;
                     }
 
                     return_control_to_duck = true;
@@ -1180,7 +1223,6 @@ namespace duckdb
             // resolves on first AcquireConnection() call.
             bool persistent_for_this_batch = false;
             try {
-                auto &current_result_data = owning_state_machine->current_result_data;
                 connection = owning_state_machine->AcquireConnection();
                 persistent_for_this_batch =
                     GetRfcPersistentConnections() &&
@@ -1209,46 +1251,24 @@ namespace duckdb
                 auto func = owning_state_machine->AcquireFunction(connection, read_table_function);
                 auto func_args = CreateFunctionArguments(read_table_delimiter, use_et_data);
                 auto invocation = func->BeginInvocation(func_args);
-                current_result_data = invocation->Invoke(data_path);
-
-                // /SAPDS/RFC_READ_TABLE2 and /BODS/RFC_READ_TABLE2 distribute
-                // rows across multiple TBLOUTxxxx output tables based on the
-                // projected row width — the SMALLEST TBLOUTxxxx that fits
-                // gets populated, the others stay empty.
-                // ResolveReadTableResultPath picks one path at bind time, but
-                // the right size depends on the actual columns in this batch
-                // (which can differ per column-parallel task). If our chosen
-                // path is empty, walk the other TBLOUTxxxx on the SAME RFC
-                // invocation (no extra round-trip — RfcResultSet just walks
-                // the SDK handle) and use whichever has data.
-                if (current_result_data->TotalRows() == 0 &&
-                    data_path.rfind("/TBLOUT", 0) == 0) {
-                    static const std::vector<std::string> alt_paths = {
-                        "/TBLOUT128", "/TBLOUT512", "/TBLOUT2048", "/TBLOUT8192", "/TBLOUT30000"
-                    };
-                    for (auto &alt : alt_paths) {
-                        if (alt == data_path) {
-                            continue;
-                        }
-                        try {
-                            auto alt_result = std::make_shared<RfcResultSet>(invocation, alt);
-                            if (alt_result->TotalRows() > 0) {
-                                current_result_data = alt_result;
-                                break;
-                            }
-                        } catch (std::exception &) {
-                            // Path not present on this function module variant; skip.
-                        }
-                    }
-                }
+                // Execute the RFC call but do NOT materialise the result as a
+                // duckdb::Value tree (issue #69 — that layer drove ~95% of all
+                // heap allocations).  Resolve the SDK result-table handle
+                // instead and stream rows straight into the output Vector
+                // during LoadNextBatchToDuckDBColumn.
+                invocation->Execute();
+                auto extracted = ResolveResultTable(invocation, data_path);
 
                 if (!persistent_for_this_batch) {
                     // Per-batch open/close — either the user disabled the
                     // cache, or this state machine didn't win a persistent
                     // slot from the bind-data budget (wide-table overflow).
+                    // Safe to close now: the response data lives in the
+                    // function handle (kept alive via current_invocation),
+                    // not the connection.
                     connection->Close();
                 }
-                return current_result_data->TotalRows();
+                return extracted;
             }
             catch (std::exception &e) {
                 // Drop the cached connection / function on any error so the
@@ -1341,42 +1361,144 @@ namespace duckdb
         return args.BuildArgList();
     }
 
-    unsigned int RfcReadColumnTask::LoadNextBatchToDuckDBColumn()
+    unsigned int RfcReadColumnTask::ResolveResultTable(std::shared_ptr<RfcInvocation> invocation, std::string data_path)
     {
-        auto &current_result_data = owning_state_machine->current_result_data;
-        auto &duck_count = owning_state_machine->duck_count;
-        auto &total_rows = owning_state_machine->total_rows;
-        auto &limit = owning_state_machine->limit;
+        auto sm = owning_state_machine;
+        // Keep the invocation alive: it owns the SDK function handle, and the
+        // result-table handle resolved below points into that handle's
+        // memory.  It must outlive every LoadNextBatchToDuckDBColumn call for
+        // this batch.
+        sm->current_invocation = invocation;
+        sm->current_table_handle = nullptr;
+        sm->current_batch_rows = 0;
 
-        if (current_result_data->TotalRows() == 0) {
+        auto func = invocation->GetFunction();
+        auto fh = invocation->GetFunctionHandle();
+        RFC_ERROR_INFO error_info;
+
+        auto strip_slash = [](const std::string &path) -> std::string {
+            auto pos = path.find_first_not_of('/');
+            return (pos == std::string::npos) ? std::string() : path.substr(pos);
+        };
+        auto resolve = [&](const std::string &path, RFC_TABLE_HANDLE &out_tbl, unsigned int &out_rows) -> bool {
+            auto param = strip_slash(path);
+            if (param.empty()) {
+                return false;
+            }
+            RFC_TABLE_HANDLE tbl = nullptr;
+            auto rc = RfcGetTable(fh, std2uc(param).get(), &tbl, &error_info);
+            if (rc != RFC_OK || tbl == nullptr) {
+                return false;
+            }
+            unsigned int rows = 0;
+            rc = RfcGetRowCount(tbl, &rows, &error_info);
+            if (rc != RFC_OK) {
+                return false;
+            }
+            out_tbl = tbl;
+            out_rows = rows;
+            return true;
+        };
+
+        std::string chosen_path = data_path;
+        RFC_TABLE_HANDLE tbl = nullptr;
+        unsigned int rows = 0;
+        if (!resolve(data_path, tbl, rows)) {
             return 0;
         }
 
-        // Hot loop: keep the LIST<VARCHAR> Value alive in this scope so we
-        // can bind the children vector by const ref instead of copying the
-        // whole batch on every LOAD step (LoadNextBatchToDuckDBColumn fires
-        // once per STANDARD_VECTOR_SIZE chunk, so for desired_batch_size =
-        // MAX_BATCH_SIZE this used to copy ~16x the same vector).  Also
-        // hoist the per-cell rfc_type lookup out of the loop and iterate in
-        // place to drop the second vector copy.
-        auto list_value = current_result_data->GetResultValue(0);
-        const auto &result_vec = ListValue::GetChildren(list_value);
+        // /SAPDS/RFC_READ_TABLE2 and /BODS/RFC_READ_TABLE2 distribute rows
+        // across multiple TBLOUTxxxx output tables based on the projected row
+        // width — the SMALLEST TBLOUTxxxx that fits gets populated, the others
+        // stay empty.  ResolveReadTableResultPath picks one path at bind time,
+        // but the right size depends on this batch's columns.  If our chosen
+        // path is empty, probe the other TBLOUTxxxx on the SAME function
+        // handle (no extra round-trip) and use whichever has rows.
+        if (rows == 0 && data_path.rfind("/TBLOUT", 0) == 0) {
+            static const std::vector<std::string> alt_paths = {
+                "/TBLOUT128", "/TBLOUT512", "/TBLOUT2048", "/TBLOUT8192", "/TBLOUT30000"
+            };
+            for (auto &alt : alt_paths) {
+                if (alt == data_path) {
+                    continue;
+                }
+                RFC_TABLE_HANDLE alt_tbl = nullptr;
+                unsigned int alt_rows = 0;
+                if (resolve(alt, alt_tbl, alt_rows) && alt_rows > 0) {
+                    chosen_path = alt;
+                    tbl = alt_tbl;
+                    rows = alt_rows;
+                    break;
+                }
+            }
+        }
 
-        auto batch_start = result_vec.begin() + duck_count * STANDARD_VECTOR_SIZE;
-        auto batch_end = batch_start + STANDARD_VECTOR_SIZE > result_vec.end()
-                            ? result_vec.end()
-                            : batch_start + STANDARD_VECTOR_SIZE;
-        if (limit > 0 && total_rows + batch_end - batch_start > limit) {
+        // The result row carries the requested column's CSV payload in a
+        // single field (e.g. "WA").  Resolve its name + SDK type once from the
+        // chosen table param's line structure so the per-row read in
+        // LoadNextBatchToDuckDBColumn reuses the exact same conversion the
+        // old RfcResultSet path applied.
+        auto result_info = func->GetResultInfo(strip_slash(chosen_path));
+        auto field_infos = result_info.GetRfcType()->GetFieldInfos();
+        if (field_infos.empty()) {
+            return 0;
+        }
+        sm->wa_field_name = field_infos[0].GetName();
+        sm->wa_field_type = field_infos[0].GetRfcType();
+        sm->current_table_handle = tbl;
+        sm->current_batch_rows = rows;
+        return rows;
+    }
+
+    unsigned int RfcReadColumnTask::LoadNextBatchToDuckDBColumn()
+    {
+        auto sm = owning_state_machine;
+        auto &duck_count = sm->duck_count;
+        auto &total_rows = sm->total_rows;
+        auto &limit = sm->limit;
+
+        auto table_handle = sm->current_table_handle;
+        auto batch_rows = sm->current_batch_rows;
+        if (batch_rows == 0 || table_handle == nullptr) {
+            return 0;
+        }
+
+        idx_t batch_start = (idx_t)duck_count * STANDARD_VECTOR_SIZE;
+        if (batch_start >= batch_rows) {
+            return 0;
+        }
+        idx_t batch_end = std::min<idx_t>(batch_start + STANDARD_VECTOR_SIZE, batch_rows);
+        if (limit > 0 && total_rows + (batch_end - batch_start) > limit) {
             batch_end = batch_start + (limit - total_rows);
         }
 
-        const auto &rfc_type = owning_state_machine->bind_data->GetColumnType(
-            owning_state_machine->column_idx);
+        // Hoist per-cell lookups out of the loop.  rfc_type is the column's
+        // real DDIC type (drives DATE/TIME/BCD parsing in ConvertCsvValue);
+        // wa_type/wa_name name the SDK result field carrying the CSV payload.
+        const auto rfc_type = sm->bind_data->GetColumnType(sm->column_idx);
+        auto wa_type = sm->wa_field_type;
+        const auto wa_name = sm->wa_field_name;
+        const bool is_row_id = sm->row_id_column_id;
 
+        RFC_ERROR_INFO error_info;
         idx_t row_idx = 0;
-        for (auto it = batch_start; it != batch_end; ++it, ++row_idx) {
-            auto val = ParseCsvValue(rfc_type, *it);
-            current_column_output.SetValue(row_idx, val);
+        for (idx_t i = batch_start; i < batch_end; ++i, ++row_idx) {
+            if (is_row_id) {
+                // Synthetic rowid column — no SAP payload to read.
+                current_column_output.SetValue(row_idx, Value::BIGINT(42));
+                continue;
+            }
+            auto rc = RfcMoveTo(table_handle, (unsigned int)i, &error_info);
+            if (rc != RFC_OK) {
+                throw std::runtime_error(StringUtil::Format("Failed to move to row %d: %s: %s",
+                                                            (int)i, rfcrc2std(error_info.code), uc2std(error_info.message)));
+            }
+            auto row_handle = RfcGetCurrentRow(table_handle, &error_info);
+            // Stream straight from the SDK handle: read the CSV field, parse
+            // it to the column's type, write into the output Vector.  No
+            // whole-batch duckdb::Value materialisation (issue #69).
+            auto wa_value = wa_type->ConvertRfcValueFromContainer(row_handle, wa_name);
+            current_column_output.SetValue(row_idx, ParseCsvValue(rfc_type, wa_value));
         }
         return row_idx;
     }

--- a/rfc/src/scanner_read_table.cpp
+++ b/rfc/src/scanner_read_table.cpp
@@ -1,4 +1,7 @@
 #include <regex>
+#ifdef __GLIBC__
+#include <malloc.h>
+#endif
 
 #include "duckdb/parallel/pipeline.hpp"
 #include "duckdb/parallel/event.hpp"
@@ -77,6 +80,13 @@ namespace duckdb
     {
         auto &bind_data = data.bind_data->CastNoConst<RfcReadTableBindData>();
         if (! bind_data.HasMoreResults()) {
+#ifdef __GLIBC__
+            // Scan finished: per-column SDK handles were released at FINISHED
+            // and the streaming reader holds no whole-batch buffers, so hand
+            // the emptied allocator arenas back to the OS instead of letting
+            // RSS linger as glibc free-list fragmentation (issue #69).
+            malloc_trim(0);
+#endif
             return;
         }
 

--- a/rfc/test/cpp/test_read_table_batching.cpp
+++ b/rfc/test/cpp/test_read_table_batching.cpp
@@ -78,6 +78,52 @@ TEST_CASE("NextDesiredBatchSize doubles geometrically while keeping ROWSKIPS val
 	REQUIRE(size == SM::MAX_BATCH_SIZE);
 }
 
+TEST_CASE("MaxBatchSizeForColumnCount bounds the SDK buffer on wide scans",
+          "[erpl_rfc][batching]") {
+	using SM = RfcReadColumnStateMachine;
+	// Use an explicit budget so the test is independent of the runtime default.
+	constexpr unsigned int BUDGET = 256u * 1024u;
+
+	// Narrow scans keep the full batch for throughput.
+	REQUIRE(SM::MaxBatchSizeForColumnCount(0, BUDGET) == SM::MAX_BATCH_SIZE);
+	REQUIRE(SM::MaxBatchSizeForColumnCount(1, BUDGET) == SM::MAX_BATCH_SIZE);
+	REQUIRE(SM::MaxBatchSizeForColumnCount(2, BUDGET) == SM::MAX_BATCH_SIZE);
+	// A zero budget disables the cap.
+	REQUIRE(SM::MaxBatchSizeForColumnCount(153, 0) == SM::MAX_BATCH_SIZE);
+
+	// Always a power of two within [STANDARD_VECTOR_SIZE, MAX_BATCH_SIZE], and
+	// monotonically non-increasing as the column count grows.
+	unsigned int prev = SM::MAX_BATCH_SIZE;
+	for (unsigned int cols = 1; cols <= 512; cols++) {
+		auto cap = SM::MaxBatchSizeForColumnCount(cols, BUDGET);
+		REQUIRE(cap >= (unsigned int)STANDARD_VECTOR_SIZE);
+		REQUIRE(cap <= SM::MAX_BATCH_SIZE);
+		REQUIRE((cap & (cap - 1)) == 0u); // power of two
+		REQUIRE(cap <= prev);
+		prev = cap;
+		// The whole point: keep columns x batch within the budget (with the
+		// STANDARD_VECTOR_SIZE floor as the only exception for very wide scans).
+		REQUIRE((cap == (unsigned int)STANDARD_VECTOR_SIZE ||
+		         (uint64_t)cols * cap <= (uint64_t)BUDGET));
+	}
+
+	// A BSEG-shaped wide scan collapses to the per-batch floor under a 256k
+	// budget.
+	REQUIRE(SM::MaxBatchSizeForColumnCount(153, BUDGET) == (unsigned int)STANDARD_VECTOR_SIZE);
+
+	// The warm-up doubling respects a lowered cap and never overshoots it.
+	unsigned int cap = SM::MaxBatchSizeForColumnCount(8, BUDGET);
+	unsigned int size = STANDARD_VECTOR_SIZE;
+	unsigned int total = 0;
+	for (int i = 0; i < 32; i++) {
+		REQUIRE(total % size == 0);
+		total += size;
+		size = SM::NextDesiredBatchSize(size, total, cap);
+		REQUIRE(size <= cap);
+	}
+	REQUIRE(size == cap);
+}
+
 TEST_CASE("TrimmedActualBatchSize preserves ROWSKIPS % ROWCOUNT == 0",
           "[erpl_rfc][batching]") {
 	using SM = RfcReadColumnStateMachine;

--- a/rfc/test/sql/sap_read_table.test
+++ b/rfc/test/sql/sap_read_table.test
@@ -259,3 +259,38 @@ SELECT
 FROM sap_read_table('USR02', COLUMNS=['TRDAT']);
 ----
 0	0	0
+
+# ---------------------------------------------------------------------
+# Issue #69: the erpl_rfc_read_table_batch_budget option bounds the SDK
+# result buffer on wide scans by capping the per-column batch size.  A
+# tiny budget forces the STANDARD_VECTOR_SIZE batch floor and many
+# round-trips; the result must stay identical to the default.
+statement ok
+SET erpl_rfc_read_table_batch_budget = 4096;
+
+query I
+SELECT COUNT(*) FROM sap_read_table('/DMO/FLIGHT');
+----
+40
+
+query II
+SELECT CARRIER_ID, CONNECTION_ID FROM sap_read_table('/DMO/FLIGHT') ORDER BY 1, 2 LIMIT 3;
+----
+AA
+0015
+AA
+0015
+AA
+0017
+
+# A zero budget disables the cap (full warm-up to MAX_BATCH_SIZE).
+statement ok
+SET erpl_rfc_read_table_batch_budget = 0;
+
+query I
+SELECT COUNT(*) FROM sap_read_table('/DMO/FLIGHT');
+----
+40
+
+statement ok
+RESET erpl_rfc_read_table_batch_budget;


### PR DESCRIPTION
Closes #69.

Continuation of #63. A full `SELECT *` on a wide table (BSEG, ACDOCA, ~75k+ rows × hundreds of columns) peaked at >8 GB, ran with heavy CPU, and RSS never released after the query. **Not a regression** — #63's warm-up batching / ROWCOUNT cap / persistent connections / LOAD copy-elision are all intact. This is a distinct layer.

## Root cause (heaptrack, 100k-row × 153-col scan, 8.2 GB peak)

| Layer | Peak | Allocations |
|---|---|---|
| SAP SDK result buffer (`RfcInvoke`→`RfcTable::resetWithCapacity`, CHAR(512) work area per row × columns in parallel) | **6.7 GB** | 14.9 M |
| Our `RfcResultSet` `duckdb::Value` materialization | 1.3 GB | **285 M (~95% of all allocs)** |

The SDK buffer dominates *peak bytes*; the Value churn dominates *allocation count* — the latter is what burned the CPU and fragmented the heap so RSS lingered.

## Fix (two complementary changes)

1. **Direct-to-vector streaming** — the read-table column scan keeps the live `RfcInvocation` + SDK `RFC_TABLE_HANDLE` and walks rows straight into the output `Vector`, dropping the per-batch `Value::LIST`/pivot materialization. Reuses the exact existing per-cell conversion (`RfcType::ConvertRfcValueFromContainer` + `RfcInvocation::Execute()`); `RfcResultSet` is unchanged and still used by `sap_rfc_invoke`. Adds `malloc_trim(0)` at scan teardown.
2. **`erpl_rfc_read_table_batch_budget`** (UINTEGER, default 1310720) — a column-adaptive cap on the per-column RFC batch size that bounds the SDK buffer. It's a *concurrent-row* budget, so wider tables automatically get smaller batches. Preserves the #63 `ROWSKIPS % ROWCOUNT == 0` invariant (power-of-two cap).

## Measured (100k × 153-col fixture)

| budget | batch | wall | peak RSS |
|---|---|---|---|
| baseline (master) | 32768 | 43 s | 8.2 GB |
| **1.28M (new default)** | 8192 | 69 s | **1.78 GB** |
| 640K | 4096 | 105 s | 0.97 GB |
| 256K | 2048 | 187 s | 0.55 GB |

A ~340-col BSEG auto-collapses to a ~2048 batch at the default (≈0.9 GB). Memory↔throughput is a fundamental tradeoff (smaller batch → more RFC round-trips, serialized by SAP's ~3-way concurrency cap), hence the runtime knob.

## Test plan

- [x] `erpl_rfc` C++ suite — 86 cases / 2939 assertions (incl. new `MaxBatchSizeForColumnCount` coverage)
- [x] SQL: `sap_read_table` (incl. new batch-budget cases), `sap_rfc_attach`, `sap_rfc_attach_limit`, `sap_rfc_invoke`
- [x] Full 100k × 153-col scan returns exact data (all distinct ids; DATE/TIME/CURR/NUMC/INT/CUKY/CHAR correct)
- [x] `API_REFERENCE.md` updated with the new option (+ the two previously-undocumented persistent-connection options)