### PR TITLE
fix(rfc): skip NULL scalar values in RfcType::AdaptValue (#72)

### DIFF
--- a/rfc/src/sap_function.cpp
+++ b/rfc/src/sap_function.cpp
@@ -338,7 +338,19 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
         RFC_ERROR_INFO error_info;
         auto sap_arg_name = std2uc(arg_name);
 
-        switch(_rfc_type) 
+        // A NULL DuckDB value means "leave this field at the SDK's initial
+        // value" — exactly what the CHAR/STRING/XSTRING/BYTE/UTC branches below
+        // already do explicitly.  Without this guard the scalar branches
+        // (DATE/TIME/NUM/INT*/BCD/FLOAT) call duck2rfc()/GetValue<>() on a NULL
+        // and throw "Calling GetValueInternal on a value that is NULL"
+        // (issue #72: a NULL HIERARCHY_DUEDATE in the BICS I_TH_CHARACTERISTICS
+        // table).  Containers (STRUCTURE/TABLE) are not scalars, so they still
+        // recurse — their child fields are guarded by this same check.
+        if (arg_value.IsNull() && _rfc_type != RFCTYPE_STRUCTURE && _rfc_type != RFCTYPE_TABLE) {
+            return;
+        }
+
+        switch(_rfc_type)
         {
             // Numeric types
             case RFCTYPE_NUM:

--- a/rfc/test/cpp/test_type_conversion.cpp
+++ b/rfc/test/cpp/test_type_conversion.cpp
@@ -293,6 +293,30 @@ TEST_CASE("Test duck2rfc for RFC_Time", "[sap_type_conversion]") {
     REQUIRE(rfc_time[5] == '0');
 }
 
+TEST_CASE("AdaptValue skips a NULL scalar instead of crashing (issue #72)", "[sap_type_conversion]") {
+    // Regression for #72: a NULL HIERARCHY_DUEDATE (DATE) in the BICS
+    // I_TH_CHARACTERISTICS table crashed sap_bics_result with
+    // "Calling GetValueInternal on a value that is NULL", because AdaptValue's
+    // DATE/TIME/numeric branches called duck2rfc()/GetValue<>() without a NULL
+    // guard (unlike CHAR/STRING/UTC). A NULL scalar must be left at the SDK's
+    // initial value. For a NULL scalar AdaptValue returns before touching the
+    // container handle, so a nullptr handle is safe here (no live SAP needed).
+    DATA_CONTAINER_HANDLE container = nullptr;
+    std::string field = "HIERARCHY_DUEDATE";
+
+    RfcType date_type(RFCTYPE_DATE, nullptr, 8, 0);
+    Value null_date(LogicalType::DATE);
+    REQUIRE_NOTHROW(date_type.AdaptValue(container, field, null_date));
+
+    RfcType time_type(RFCTYPE_TIME, nullptr, 6, 0);
+    Value null_time(LogicalType::TIME);
+    REQUIRE_NOTHROW(time_type.AdaptValue(container, field, null_time));
+
+    RfcType int_type(RFCTYPE_INT, nullptr, 4, 0);
+    Value null_int(LogicalType::INTEGER);
+    REQUIRE_NOTHROW(int_type.AdaptValue(container, field, null_int));
+}
+
 TEST_CASE("Test duck2rfc for RFC_Float", "[sap_type_conversion]") {
     auto value = Value::DOUBLE(42.5);
     RFC_FLOAT rfc_float;


### PR DESCRIPTION
Closes #72.

`sap_bics_result` crashed with `Calling GetValueInternal on a value that is NULL` while adapting the `I_TH_CHARACTERISTICS` table for `BICS_PROV_SET_STATE`.

## Root cause (shared marshalling, not BICS-specific)

SAP added a `HIERARCHY_DUEDATE` (DATE) field to the characteristics structure; it's NULL for non-hierarchy characteristics. When `sap_bics_result` round-trips that table back to SAP, `RfcType::AdaptValue` (`rfc/src/sap_function.cpp`) marshals each field — but its `DATE` / `TIME` / `NUM` / `INT*` / `BCD` / `FLOAT` branches called `duck2rfc()`/`GetValue<>()` **without a NULL guard**, unlike `CHAR`/`STRING`/`XSTRING`/`BYTE`/`UTC` which already skip NULLs. So a NULL date threw.

It surfaced now (regression) because recent BICS work (`6df542f` HIER_LEVEL columns, `e6679c1` AO char properties) started round-tripping more of the characteristics structure, so the NULL `HIERARCHY_DUEDATE` now reaches `SET_STATE`.

## Fix

One NULL guard at the top of `AdaptValue`: a NULL scalar is left at the SDK's initial value (matching the existing CHAR/STRING/UTC behavior); STRUCTURE/TABLE still recurse. Because it's in shared `erpl_rfc` code, it also hardens `sap_rfc_invoke` and `erpl_odp`.

## Test plan (red→green TDD)

- [x] **RED:** added an offline C++ test (`[sap_type_conversion]`) driving `AdaptValue` with a NULL DATE/TIME/INT — before the fix it failed with the exact #72 error (`Calling GetValueInternal on a value that is NULL`). No live SAP needed.
- [x] **GREEN:** after the guard, the test passes.
- [x] Full `erpl_rfc` C++ suite green (87 cases / 2942 assertions).
- [ ] **Live end-to-end confirmation pending** — the a4h trial `DEVELOPER` user is currently lock-out'd from earlier test logon failures (auto-unlocks next day, or unlock via SU01). Once available: `sap_rfc_describe_function('BICS_PROV_SET_STATE')` to confirm `HIERARCHY_DUEDATE` on the trial, and `make sql_tests_rfc` / `make sql_tests_bics`.

No `API_REFERENCE.md` change (no public surface change).