### PR TITLE
feat(rfc): sap_rfc_authorizations() — document RFC modules per function (#71)

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -65,6 +65,7 @@ SELECT * FROM sap_bics_show_cubes();
 | `sap_rfc_invoke` | Call any RFC function | `SELECT * FROM sap_rfc_invoke('STFC_CONNECTION', {'REQUTEXT': 'Hi'})` |
 | `sap_show_tables` | Search SAP tables | `SELECT * FROM sap_show_tables(TABLENAME='*FLIGHT*')` |
 | `sap_describe_fields` | Get table field metadata | `SELECT * FROM sap_describe_fields('SFLIGHT')` |
+| `sap_rfc_authorizations` | List RFC modules each function uses (for S_RFC) | `SELECT * FROM sap_rfc_authorizations()` |
 | `sap_bics_show_cubes` | List BW cubes | `SELECT * FROM sap_bics_show_cubes()` |
 | `sap_bics_hierarchy` | Extract BW hierarchy | `SELECT * FROM sap_bics_hierarchy('MY_HIER')` |
 | `sap_bics_set_char_prop` | AO-style char property (Display/Sort/Totals) | `SELECT * FROM sap_bics_set_char_prop('q1', '0CNTRY', 'DISPLAY', 'TEXT')` |
@@ -222,6 +223,32 @@ Get detailed metadata about an RFC function module (parameters, types, structure
 
 ```sql
 SELECT * FROM sap_rfc_describe_function('STFC_CONNECTION');
+```
+
+---
+
+#### `sap_rfc_authorizations()`
+
+List which SAP RFC function modules each ERPL function invokes, so an SAP admin can scope the
+`S_RFC` authorization object for the ERPL service user to least privilege. This is a **static
+reference** — it needs no SAP connection (no secret required) and makes no RFC calls.
+
+**Returns:** `extension`, `duckdb_function`, `rfc_function_module`, `invocation`, `purpose`
+
+`invocation` is one of: `always` (called every time), `fallback` (one of a runtime-selected,
+capability-dependent chain — e.g. the `RFC_READ_TABLE` variants), `optional` (attempted, skipped
+gracefully on failure), `metadata` (a secondary DDIC/describe call), or `user-specified` (the FM is
+the one you pass to `sap_rfc_invoke`). Note: opening a connection and `sap_rfc_ping` use the SDK
+directly and invoke no function module.
+
+```sql
+-- All RFC modules to authorize for the whole ERPL suite
+SELECT DISTINCT rfc_function_module FROM sap_rfc_authorizations()
+WHERE rfc_function_module NOT IN ('<user-specified>', '<none>') ORDER BY 1;
+
+-- Just what sap_read_table needs
+SELECT rfc_function_module, invocation, purpose
+FROM sap_rfc_authorizations() WHERE duckdb_function = 'sap_read_table';
 ```
 
 ---

--- a/rfc/CMakeLists.txt
+++ b/rfc/CMakeLists.txt
@@ -71,6 +71,7 @@ set(EXTENSION_SOURCES
       src/scanner_show_tables.cpp
       src/scanner_describe_fields.cpp
       src/scanner_describe_references.cpp
+      src/scanner_rfc_authorizations.cpp
       src/scanner_read_table.cpp
       src/sap_storage.cpp
       src/sap_table_entry.cpp

--- a/rfc/src/erpl_rfc_extension.cpp
+++ b/rfc/src/erpl_rfc_extension.cpp
@@ -17,6 +17,7 @@
 #include "scanner_show_tables.hpp"
 #include "scanner_describe_fields.hpp"
 #include "scanner_read_table.hpp"
+#include "scanner_rfc_authorizations.hpp"
 #include "sap_rfc.hpp"
 
 #include "telemetry.hpp"
@@ -305,6 +306,18 @@ namespace duckdb {
             desc.examples    = {"SELECT * FROM sap_describe_fields('SFLIGHT')"};
             desc.categories  = {"sap"};
             desc.parameter_names = {"table_name"};
+            info.descriptions.push_back(std::move(desc));
+            loader.RegisterFunction(std::move(info));
+        }
+
+        {
+            CreateTableFunctionInfo info(CreateRfcAuthorizationsScanFunction());
+            FunctionDescription desc;
+            desc.description = "List which SAP RFC function modules each ERPL function invokes, so an admin can scope the S_RFC authorization object for the ERPL service user. Static reference; needs no SAP connection.";
+            desc.examples    = {"SELECT * FROM sap_rfc_authorizations()",
+                                "SELECT DISTINCT rfc_function_module FROM sap_rfc_authorizations() WHERE extension = 'erpl_rfc'"};
+            desc.categories  = {"sap"};
+            desc.parameter_names = {};
             info.descriptions.push_back(std::move(desc));
             loader.RegisterFunction(std::move(info));
         }

--- a/rfc/src/include/scanner_rfc_authorizations.hpp
+++ b/rfc/src/include/scanner_rfc_authorizations.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "duckdb.hpp"
+
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+
+namespace duckdb {
+    // sap_rfc_authorizations(): a static, connection-free reference of which SAP
+    // RFC function modules each ERPL DuckDB function invokes, so admins can scope
+    // the S_RFC authorization object for the ERPL service user (issue #71).
+    TableFunction CreateRfcAuthorizationsScanFunction();
+} // namespace duckdb

--- a/rfc/src/scanner_rfc_authorizations.cpp
+++ b/rfc/src/scanner_rfc_authorizations.cpp
@@ -1,0 +1,144 @@
+#include "duckdb.hpp"
+#include "scanner_rfc_authorizations.hpp"
+#include "telemetry.hpp"
+
+#include <algorithm>
+
+namespace duckdb
+{
+
+namespace
+{
+struct AuthRow {
+    const char *extension;
+    const char *duckdb_function;
+    const char *rfc_function_module;
+    const char *invocation;
+    const char *purpose;
+};
+
+// Which SAP RFC function modules each ERPL DuckDB function invokes — derived by
+// call-stack analysis of the rfc / bics / odp scanners (issue #71). `invocation`:
+//   always         — called on every execution
+//   fallback       — one of a runtime-selected chain (capability-dependent)
+//   optional       — attempted, gracefully skipped on failure
+//   metadata       — secondary DDIC/describe call enriching the result
+//   user-specified — the FM is supplied by the caller at runtime
+// Reads-table-backed functions may use any of the RFC_READ_TABLE fallback
+// variants documented under sap_read_table; they are listed once there.
+const AuthRow AUTH_ROWS[] = {
+    // ---- erpl_rfc ----------------------------------------------------------
+    {"erpl_rfc", "sap_read_table", "RFC_READ_TABLE", "always", "Primary table / CDS-view read (default reader)."},
+    {"erpl_rfc", "sap_read_table", "/SAPDS/RFC_READ_TABLE2", "fallback", "String-capable reader (ET_DATA); chosen at runtime if available."},
+    {"erpl_rfc", "sap_read_table", "/BODS/RFC_READ_TABLE2", "fallback", "String-capable reader (ET_DATA) variant."},
+    {"erpl_rfc", "sap_read_table", "/SAPDS/RFC_READ_TABLE", "fallback", "String-capable reader variant."},
+    {"erpl_rfc", "sap_read_table", "/BODS/RFC_READ_TABLE", "fallback", "String-capable reader variant."},
+    {"erpl_rfc", "sap_read_table", "DDIF_FIELDINFO_GET", "metadata", "Field names / types / lengths for the requested table at bind time."},
+    {"erpl_rfc", "sap_rfc_invoke", "<user-specified>", "user-specified", "Invokes the function module passed as the first argument; grant S_RFC for whatever you call."},
+    {"erpl_rfc", "sap_rfc_show_functions", "RFC_FUNCTION_SEARCH", "always", "Search RFC-enabled function modules by name/group pattern."},
+    {"erpl_rfc", "sap_rfc_show_groups", "RFC_GROUP_SEARCH", "always", "List SAP function groups."},
+    {"erpl_rfc", "sap_rfc_describe_function", "RPY_FUNCTIONMODULE_READ", "optional", "ABAP source / short text; skipped on FL180, falls back to SDK introspection."},
+    {"erpl_rfc", "sap_show_tables", "RFC_READ_TABLE", "always", "Resolves the table catalog from DDIC via RFC_READ_TABLE (see sap_read_table for variants)."},
+    {"erpl_rfc", "sap_show_tables", "DDIF_FIELDINFO_GET", "metadata", "Field metadata for listed tables."},
+    {"erpl_rfc", "sap_describe_fields", "DDIF_FIELDINFO_GET", "always", "Field metadata (names, ABAP types, lengths, texts) for a table/structure."},
+    {"erpl_rfc", "sap_rfc_ping", "<none>", "always", "Uses the SDK RfcPing() call — no RFC function module is invoked."},
+
+    // ---- erpl_bics: stateful query execution -------------------------------
+    {"erpl_bics", "sap_bics_begin", "BICS_CONS_CREATE_DATA_AREA", "always", "Create the BICS application data area on the BW server."},
+    {"erpl_bics", "sap_bics_begin", "BICS_PROV_OPEN", "always", "Open the data provider (cube or BEx query)."},
+    {"erpl_bics", "sap_bics_begin", "BICS_PROV_GET_INITIAL_STATE", "always", "Fetch the initial query state (axes, characteristics, measures)."},
+    {"erpl_bics", "sap_bics_begin", "BICS_PROV_VAR_GET_VARIABLES", "optional", "Read BEx variables when the query defines them."},
+    {"erpl_bics", "sap_bics_begin", "RFC_READ_TABLE", "metadata", "Probe RSRREPDIR to detect the BEx query type."},
+    {"erpl_bics", "sap_bics_columns", "BICS_PROV_SET_STATE", "always", "Submit column-axis changes."},
+    {"erpl_bics", "sap_bics_columns", "BICS_PROV_GET_RESULT_SET", "optional", "Fetch the updated result set when requested."},
+    {"erpl_bics", "sap_bics_rows", "BICS_PROV_SET_STATE", "always", "Submit row-axis changes."},
+    {"erpl_bics", "sap_bics_rows", "BICS_PROV_GET_RESULT_SET", "optional", "Fetch the updated result set when requested."},
+    {"erpl_bics", "sap_bics_filter", "BICS_PROV_SET_STATE", "always", "Submit filter / restriction changes."},
+    {"erpl_bics", "sap_bics_filter", "BICS_PROV_GET_RESULT_SET", "optional", "Fetch the updated result set when requested."},
+    {"erpl_bics", "sap_bics_set_char_prop", "BICS_PROV_SET_STATE", "always", "Submit characteristic display / sort / totals properties."},
+    {"erpl_bics", "sap_bics_result", "BICS_PROV_GET_RESULT_SET", "always", "Fetch the flattened result set (members + cells)."},
+    {"erpl_bics", "sap_bics_result", "BICS_PROV_CLOSE", "always", "Close the data provider when the session ends."},
+    {"erpl_bics", "sap_bics_describe", "BICS_PROV_GET_DESIGN_TIME_INFO", "always", "Design-time metadata (dimensions/measures) without executing the query."},
+    {"erpl_bics", "sap_bics_describe", "BAPI_IOBJ_GETDETAIL", "optional", "InfoObject attribute / hierarchy / text details."},
+    {"erpl_bics", "sap_bics_describe_infoobject", "BAPI_IOBJ_GETDETAIL", "always", "InfoObject type / length / decimals / conversion exit."},
+
+    // ---- erpl_bics: catalog / metadata / lineage (DDIC reads) --------------
+    {"erpl_bics", "sap_bics_show", "RSOBJS_GET_NODES", "always", "Browse InfoProviders / queries / InfoAreas."},
+    {"erpl_bics", "sap_bics_show_cubes", "RSOBJS_GET_NODES", "always", "List InfoCubes and MultiProviders."},
+    {"erpl_bics", "sap_bics_show_queries", "RSOBJS_GET_NODES", "always", "List BEx queries."},
+    {"erpl_bics", "sap_bics_show_hierarchies", "RFC_READ_TABLE", "always", "Read RSHIEDIR (hierarchy directory)."},
+    {"erpl_bics", "sap_bics_hierarchy", "RFC_READ_TABLE", "always", "Read RSHIEDIR hierarchy node structure."},
+    {"erpl_bics", "sap_bics_hierarchy", "RSNDI_SHIE_STRUCTURE_GET3", "optional", "Hierarchy structure with attributes (fallback)."},
+    {"erpl_bics", "sap_bics_meta_*", "RFC_READ_TABLE", "always", "All sap_bics_meta_* functions read BW dictionary tables (RSD*, RSO*, RSTRAN*, RSRREPDIR, RSZ*, ROOS*) via RFC_READ_TABLE."},
+    {"erpl_bics", "sap_bics_meta_*", "DDIF_FIELDINFO_GET", "metadata", "Field metadata for the BW dictionary tables read above."},
+    {"erpl_bics", "sap_bics_lineage_*", "RFC_READ_TABLE", "always", "All sap_bics_lineage_* functions trace lineage by reading RSTRAN/RSTRANFIELD/RSOOBJXREF via RFC_READ_TABLE."},
+
+    // ---- erpl_odp ----------------------------------------------------------
+    {"erpl_odp", "sap_odp_show_contexts", "RODPS_REPL_CONTEXT_GET_LIST", "always", "Enumerate ODP contexts (ABAP_CDS, BW, SAPI, ODQF)."},
+    {"erpl_odp", "sap_odp_show", "RODPS_REPL_ODP_GET_LIST", "always", "List ODP objects within a context."},
+    {"erpl_odp", "sap_odp_describe", "RODPS_REPL_ODP_GET_DETAIL", "always", "Field structure / metadata for an ODP object."},
+    {"erpl_odp", "sap_odp_preview", "RODPS_REPL_ODP_GET_DETAIL", "always", "Metadata for the preview."},
+    {"erpl_odp", "sap_odp_preview", "RODPS_REPL_ODP_READ_DIRECT_XML", "always", "Direct read of the first rows without a subscription."},
+    {"erpl_odp", "sap_odp_show_subscriptions", "RFC_READ_TABLE", "always", "Read the RODPS_REPL_SUBSC view of active subscriptions."},
+    {"erpl_odp", "sap_odp_show_subscriptions", "DDIF_FIELDINFO_GET", "metadata", "Schema of RODPS_REPL_SUBSC."},
+    {"erpl_odp", "sap_odp_show_cursors", "RODPS_REPL_CURSOR_GET_LIST", "always", "List delta extraction cursors and status."},
+    {"erpl_odp", "sap_odp_read_full", "RODPS_REPL_ODP_GET_DETAIL", "always", "Metadata before full extraction."},
+    {"erpl_odp", "sap_odp_read_full", "RODPS_REPL_ODP_OPEN", "always", "Open a full-extraction cursor."},
+    {"erpl_odp", "sap_odp_read_full", "RODPS_REPL_ODP_FETCH_XML", "always", "Fetch data packages."},
+    {"erpl_odp", "sap_odp_read_full", "RODPS_REPL_ODP_CLOSE", "always", "Close the full-extraction cursor when done."},
+    {"erpl_odp", "sap_odp_read_delta", "RODPS_REPL_ODP_GET_DETAIL", "always", "Metadata before delta extraction."},
+    {"erpl_odp", "sap_odp_read_delta", "RODPS_REPL_ODP_OPEN", "always", "Open a delta cursor (auto delta-init for a fresh subscriber)."},
+    {"erpl_odp", "sap_odp_read_delta", "RODPS_REPL_ODP_FETCH_XML", "always", "Fetch delta packages."},
+    {"erpl_odp", "sap_odp_get_last_modified", "RODPS_REPL_ODP_GET_LAST_MODIF", "always", "Probe the latest modification timestamp without opening a cursor."},
+    {"erpl_odp", "sap_odp_get_subscriptions", "RODPS_REPL_ODP_GET_SUBSCR", "always", "List all subscriptions for an ODP source."},
+    {"erpl_odp", "sap_odp_drop", "RODPS_REPL_ODP_RESET", "always", "Reset a subscription so a full extraction can re-initialize."},
+    {"erpl_odp", "sap_odp_close_delta_cursor", "RODPS_REPL_CURSOR_GET_LIST", "always", "Look up the cursor to close."},
+    {"erpl_odp", "sap_odp_close_delta_cursor", "RODPS_REPL_ODP_CLOSE", "always", "Gracefully close the delta cursor (idempotent)."},
+};
+
+struct RfcAuthorizationsBindData : public TableFunctionData {
+    idx_t offset = 0;
+};
+} // namespace
+
+static unique_ptr<FunctionData> RfcAuthorizationsBind(ClientContext &context,
+                                                      TableFunctionBindInput &input,
+                                                      vector<LogicalType> &return_types,
+                                                      vector<string> &names)
+{
+    PostHogTelemetry::Instance().CaptureFunctionExecution("sap_rfc_authorizations");
+
+    names = {"extension", "duckdb_function", "rfc_function_module", "invocation", "purpose"};
+    return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
+                    LogicalType::VARCHAR, LogicalType::VARCHAR};
+
+    return make_uniq<RfcAuthorizationsBindData>();
+}
+
+static void RfcAuthorizationsScan(ClientContext &context, TableFunctionInput &data, DataChunk &output)
+{
+    auto &bind_data = data.bind_data->CastNoConst<RfcAuthorizationsBindData>();
+    const idx_t total = sizeof(AUTH_ROWS) / sizeof(AUTH_ROWS[0]);
+    if (bind_data.offset >= total) {
+        return;
+    }
+
+    idx_t count = std::min<idx_t>(total - bind_data.offset, STANDARD_VECTOR_SIZE);
+    for (idx_t i = 0; i < count; i++) {
+        const auto &row = AUTH_ROWS[bind_data.offset + i];
+        output.SetValue(0, i, Value(row.extension));
+        output.SetValue(1, i, Value(row.duckdb_function));
+        output.SetValue(2, i, Value(row.rfc_function_module));
+        output.SetValue(3, i, Value(row.invocation));
+        output.SetValue(4, i, Value(row.purpose));
+    }
+    output.SetCardinality(count);
+    bind_data.offset += count;
+}
+
+TableFunction CreateRfcAuthorizationsScanFunction()
+{
+    return TableFunction("sap_rfc_authorizations", {}, RfcAuthorizationsScan, RfcAuthorizationsBind);
+}
+
+} // namespace duckdb

--- a/rfc/test/sql/sap_rfc_authorizations.test
+++ b/rfc/test/sql/sap_rfc_authorizations.test
@@ -1,0 +1,66 @@
+# name: test/sql/sap_rfc_authorizations.test
+# description: sap_rfc_authorizations() static RFC-usage reference (#71) — needs no SAP connection
+# group: [rfc]
+
+require erpl_rfc
+
+# Validates all five column names bind, and that the reference is non-empty.
+# No CREATE SECRET / require-env: this function is pure static documentation.
+query I
+SELECT count(*) > 0
+FROM (SELECT extension, duckdb_function, rfc_function_module, invocation, purpose
+      FROM sap_rfc_authorizations());
+----
+true
+
+# invocation is constrained to the documented vocabulary
+query I
+SELECT count(*)
+FROM sap_rfc_authorizations()
+WHERE invocation NOT IN ('always','fallback','optional','metadata','user-specified');
+----
+0
+
+# Spot-check representative rows across all three extensions
+query I
+SELECT count(*) FROM sap_rfc_authorizations()
+WHERE duckdb_function = 'sap_read_table' AND rfc_function_module = 'RFC_READ_TABLE' AND invocation = 'always';
+----
+1
+
+# The read-table fallback variants are documented
+query I
+SELECT count(*) FROM sap_rfc_authorizations()
+WHERE duckdb_function = 'sap_read_table' AND rfc_function_module LIKE '%RFC_READ_TABLE%' AND invocation = 'fallback';
+----
+4
+
+# sap_rfc_invoke is flagged as user-specified
+query I
+SELECT count(*) FROM sap_rfc_authorizations()
+WHERE duckdb_function = 'sap_rfc_invoke' AND rfc_function_module = '<user-specified>' AND invocation = 'user-specified';
+----
+1
+
+# BICS provider FMs present
+query I
+SELECT count(*) > 0 FROM sap_rfc_authorizations() WHERE rfc_function_module LIKE 'BICS_PROV_%';
+----
+true
+
+# ODP replication FMs present
+query I
+SELECT count(*) > 0 FROM sap_rfc_authorizations() WHERE rfc_function_module LIKE 'RODPS_REPL_%';
+----
+true
+
+# Completeness: every registered erpl_rfc sap_* function is documented here,
+# so a newly added RFC function can't silently miss the authorization reference.
+query I
+SELECT count(*) FROM (VALUES
+    ('sap_read_table'), ('sap_rfc_invoke'), ('sap_rfc_show_functions'),
+    ('sap_rfc_show_groups'), ('sap_rfc_describe_function'), ('sap_show_tables'),
+    ('sap_describe_fields'), ('sap_rfc_ping')) v(fn)
+WHERE fn NOT IN (SELECT duckdb_function FROM sap_rfc_authorizations() WHERE extension = 'erpl_rfc');
+----
+0


### PR DESCRIPTION
Closes #71.

The reporter asked for documentation of which SAP RFC function modules ERPL invokes, so an admin can grant the right `S_RFC` authorizations to the ERPL service user.

## What

A new static, connection-free table function **`sap_rfc_authorizations()`** returning one row per (DuckDB function × RFC function module):

| column | meaning |
|---|---|
| `extension` | `erpl_rfc` / `erpl_bics` / `erpl_odp` |
| `duckdb_function` | e.g. `sap_read_table` |
| `rfc_function_module` | e.g. `RFC_READ_TABLE` |
| `invocation` | `always` / `fallback` / `optional` / `metadata` / `user-specified` |
| `purpose` | one-line reason |

```sql
-- everything to authorize for the whole suite
SELECT DISTINCT rfc_function_module FROM sap_rfc_authorizations()
WHERE rfc_function_module NOT IN ('<user-specified>','<none>') ORDER BY 1;
```

It needs **no SAP connection** (no secret) and makes no RFC calls — it's pure static documentation. 60 rows, 35 functions, 33 distinct FMs.

## Why a table (not comment/tags)

The original idea was the function `comment`/`tags` metadata, but DuckDB v1.5.3's `FunctionEntry` drops `info.comment`/`info.tags` at registration, and `COMMENT ON FUNCTION` only targets macros — so neither is settable for C++ functions. A queryable reference table sidesteps that and **uniformly covers pragmas** too (which have no `FunctionDescription` API). The mapping was derived by agent call-stack analysis of the rfc/bics/odp scanners, which matters because several FMs are conditional (read-table's 5-FM capability fallback, `RPY_FUNCTIONMODULE_READ` optional/FL180, `sap_rfc_invoke`'s user-supplied FM, shared `DDIF_FIELDINFO_GET`).

## Test plan

- [x] Offline SQL test `rfc/test/sql/sap_rfc_authorizations.test` (no `require-env`/secret) — schema, invocation vocabulary, representative rows (read-table fallback chain, `sap_rfc_invoke` user-specified, a `BICS_PROV_*` and a `RODPS_REPL_*` row), and a **completeness check** that every registered `erpl_rfc` `sap_*` function is documented.
- [x] Full `erpl_rfc` C++ suite green (87 cases / 2942 assertions).
- [x] Smoke: `SELECT * FROM sap_rfc_authorizations()` returns 60 rows with no secret configured.
- [x] `API_REFERENCE.md` updated (Quick Reference + Discovery & Metadata entry).