### PR TITLE
fix(rfc): don't throw from RFC connection/function destructors (#78)

### DIFF
--- a/rfc/src/include/sap_function.hpp
+++ b/rfc/src/include/sap_function.hpp
@@ -141,7 +141,7 @@ bool GetRfcStrictTypeCheck();
     {
         public:
             RfcFunction(std::shared_ptr<RfcConnection> &connection, std::string function_name);
-            ~RfcFunction() noexcept(false);
+            ~RfcFunction() noexcept;
 
             RFC_FUNCTION_DESC_HANDLE GetDescriptionHandle() const;
 
@@ -200,7 +200,7 @@ bool GetRfcStrictTypeCheck();
     {
         public:
             RfcInvocation(std::shared_ptr<RfcFunction> function, std::vector<Value> &arguments);
-            ~RfcInvocation() noexcept(false);
+            ~RfcInvocation() noexcept;
 
             std::shared_ptr<RfcFunction> GetFunction() const;
             std::shared_ptr<RfcConnection> GetConnection() const;

--- a/rfc/src/sap_connection.cpp
+++ b/rfc/src/sap_connection.cpp
@@ -195,22 +195,36 @@ namespace duckdb
 
     RfcConnection::~RfcConnection()
     {
-        Close();
+        // A destructor must never throw: an escaping exception calls
+        // std::terminate and aborts the host process (issue #78, where a
+        // stale/already-closed handle made Close() throw RFC_INVALID_HANDLE
+        // during teardown).
+        try {
+            Close();
+        } catch (...) {
+            // best-effort cleanup; swallow.
+        }
     }
-    
+
     void RfcConnection::Close()
     {
         if (handle == NULL)
             return;
-        
+
         RFC_RC rc = RFC_OK;
         RFC_ERROR_INFO error_info;
 
         rc = RfcCloseConnection(handle, &error_info);
-        if (rc != RFC_OK) {
+        // Regardless of the outcome the handle must not be reused: a second
+        // RfcCloseConnection on the same handle yields RFC_INVALID_HANDLE.
+        // Nulling here prevents the double-close path (issue #78).
+        handle = NULL;
+        // RFC_INVALID_HANDLE means the handle is already gone (the SAP gateway
+        // dropped the connection, or it was closed elsewhere) — nothing left
+        // to close, so treat it as benign rather than an error.
+        if (rc != RFC_OK && rc != RFC_INVALID_HANDLE) {
             throw IOException(StringUtil::Format("Error during SAP RFC connection closing: %s: %s",rfcrc2std(error_info.code), uc2std(error_info.message)));
         }
-        handle = NULL;
     }
 
     void RfcConnection::Ping()

--- a/rfc/src/sap_function.cpp
+++ b/rfc/src/sap_function.cpp
@@ -6,6 +6,7 @@
 #include "duckdb.hpp"
 #include "duckdb_argument_helper.hpp"
 #include "sap_function.hpp"
+#include "erpl_tracing.hpp"
 
 static std::atomic<bool> g_rfc_strict_type_check{false};
 
@@ -1206,7 +1207,7 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
         }
     }
 
-    RfcFunction::~RfcFunction() noexcept(false)
+    RfcFunction::~RfcFunction() noexcept
     {
         if (_desc_handle == NULL)
             return;
@@ -1519,7 +1520,7 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
         adapter->Adapt(function->GetParameterInfos(), arguments);
     }
 
-    RfcInvocation::~RfcInvocation() noexcept(false) 
+    RfcInvocation::~RfcInvocation() noexcept
     {
         if (_handle == NULL) {
             return;
@@ -1528,10 +1529,14 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
         RFC_RC rc = RFC_OK;
         RFC_ERROR_INFO error_info;
         rc = RfcDestroyFunction(_handle, &error_info);
+        // A destructor must never throw: an escaping exception calls
+        // std::terminate and aborts the host process (issue #78). On the rare
+        // RfcDestroyFunction failure, log and swallow instead of throwing.
         if (rc != RFC_OK) {
-            throw std::runtime_error(StringUtil::Format("Error destroying function: %s: %s "  
-                                                        "(This is indicates a serious error in the SAP NW RFC library.)",
-                                                        rfcrc2std(error_info.code), uc2std(error_info.message)));
+            ERPL_TRACE_ERROR("RfcInvocation",
+                             StringUtil::Format("Error destroying function: %s: %s "
+                                                "(indicates a serious error in the SAP NW RFC library.)",
+                                                rfcrc2std(error_info.code), uc2std(error_info.message)));
         }
         _handle = NULL;
     }

--- a/rfc/test/cpp/CMakeLists.txt
+++ b/rfc/test/cpp/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TEST_SOURCES
     test_table_wrapper.cpp
     test_telemetry.cpp
     test_read_table_batching.cpp
+    test_connection_close.cpp
     test_main.cpp
 )
 

--- a/rfc/test/cpp/test_connection_close.cpp
+++ b/rfc/test/cpp/test_connection_close.cpp
@@ -1,0 +1,63 @@
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "sapnwrfc.h"
+#include "sap_connection.hpp"
+
+#include <cstdlib>
+
+using namespace duckdb;
+
+// Issue #78: a stale / already-closed RFC_CONNECTION_HANDLE made
+// RfcConnection::Close() throw an IOException ("...RFC_INVALID_HANDLE: An
+// invalid handle 'RFC_CONNECTION_HANDLE' was passed to the API call").  Because
+// the throw escaped the (implicitly noexcept) destructor during connection
+// teardown, the host process aborted via std::terminate
+// ("terminate called after throwing an instance of 'duckdb::IOException'").
+//
+// This test reproduces the exact precondition against the live SAP system:
+// open a real connection, close its underlying handle out-of-band so the
+// wrapper still holds a now-invalid handle, then assert that neither Close()
+// nor the destructor throw.  It needs the same ERPL_SAP_* connection
+// parameters as the SQL tests and performs a single valid logon.
+TEST_CASE("RfcConnection::Close on an already-invalid handle does not throw",
+          "[erpl_rfc][connection]") {
+	const char *ashost = std::getenv("ERPL_SAP_ASHOST");
+	const char *sysnr  = std::getenv("ERPL_SAP_SYSNR");
+	const char *user   = std::getenv("ERPL_SAP_USER");
+	const char *passwd = std::getenv("ERPL_SAP_PASSWORD");
+	const char *client = std::getenv("ERPL_SAP_CLIENT");
+	const char *lang   = std::getenv("ERPL_SAP_LANG");
+
+	if (!ashost || !sysnr || !user || !passwd || !client || !lang) {
+		WARN("Skipping: ERPL_SAP_* environment variables not set (needs a live SAP system)");
+		return;
+	}
+
+	RfcAuthParams params;
+	params.ashost = ashost;
+	params.sysnr = sysnr;
+	params.user = user;
+	params.password = passwd;
+	params.client = client;
+	params.lang = lang;
+
+	auto conn = params.Connect();
+	REQUIRE(conn != nullptr);
+	REQUIRE(conn->handle != NULL);
+
+	// Force the handle invalid out-of-band: close it directly via the SDK,
+	// leaving conn->handle non-null.  This is exactly the stale / double-close
+	// state that triggered issue #78 on long-running sessions.
+	RFC_ERROR_INFO error_info;
+	RFC_RC rc = RfcCloseConnection(conn->handle, &error_info);
+	REQUIRE(rc == RFC_OK);
+
+	// Before the fix this threw IOException (RFC_INVALID_HANDLE); afterwards it
+	// is benign because Close() treats an already-gone handle as nothing to do.
+	REQUIRE_NOTHROW(conn->Close());
+
+	// And destruction must also never throw — an escaping exception here would
+	// std::terminate the whole process.
+	REQUIRE_NOTHROW(conn.reset());
+}


### PR DESCRIPTION
## Summary

Fixes #78 — a long-running ERPL container crashes with:

```
terminate called after throwing an instance of 'duckdb::IOException'
  what(): Error during SAP RFC connection closing: RFC_INVALID_HANDLE: An invalid handle 'RFC_CONNECTION_HANDLE' was passed to the API call
```

This is a `std::terminate` abort, not an OOM.

## Root cause

`RfcConnection::Close()` threw an `IOException` whenever `RfcCloseConnection`
returned anything but `RFC_OK`, and `~RfcConnection()` called `Close()` with no
try/catch. The destructor is implicitly `noexcept`, so any throw escaping it
calls `std::terminate` and aborts the host process.

The handle goes invalid via two real paths on long-running sessions:

1. **Stale cached handle** — the scan caches a `shared_ptr<RfcConnection>` for
   the scan lifetime (persistent connections default on). When the SAP gateway
   drops an idle/long-lived connection, the eventual teardown close hits an
   invalid handle.
2. **Double close** — `InvalidateCachedConnection()` calls `Close()` in a
   try/catch, but on failure `Close()` did not null `handle`; the subsequent
   `shared_ptr` reset ran the destructor, which closed the same handle a second
   time → `RFC_INVALID_HANDLE` → throw escaped the `noexcept` destructor.

## Fix

- `RfcConnection::Close()` nulls `handle` immediately after `RfcCloseConnection`
  regardless of outcome (kills the double-close path) and treats
  `RFC_INVALID_HANDLE` as benign rather than throwing.
- `~RfcConnection()` wraps `Close()` in try/catch — no exception can escape.
- `RfcInvocation::~RfcInvocation()` logs `RfcDestroyFunction` failures via
  `ERPL_TRACE_ERROR` instead of throwing; it and `RfcFunction`'s destructor are
  now correctly marked `noexcept` (same latent terminate risk).

## Reproduction / test

New live C++ test `rfc/test/cpp/test_connection_close.cpp` (tag `[connection]`)
opens a real connection against the trial system, closes the underlying handle
out-of-band, then asserts `Close()`/destruction no longer throw.

Verified against the live a4h trial:

- **Before the fix** the test is RED — `REQUIRE_NOTHROW(conn->Close())` fails and
  the destructor aborts with the *exact* message from #78
  (`terminate called after throwing an instance of 'duckdb::IOException' ...
  RFC_INVALID_HANDLE ...`, exit 134).
- **After the fix** all assertions pass.

Regression: `[batching]` C++ tests, `sap_rfc_ping.test`, and `sap_read_table.test`
all still pass.
