### PR TITLE
fix(bics): tolerate BW releases without I_CONFIRM_AUTORETRY (#81)

### DIFF
--- a/rfc/src/duckdb_argument_helper.cpp
+++ b/rfc/src/duckdb_argument_helper.cpp
@@ -329,6 +329,52 @@ namespace duckdb
         }
     }
 
+    Value SelectSupportedNamedArgs(const Value &named_args,
+                                   const std::set<std::string> &supported_names,
+                                   const std::set<std::string> &droppable_names,
+                                   std::vector<std::string> *out_dropped) {
+        if (named_args.IsNull() || named_args.type().id() != LogicalTypeId::STRUCT) {
+            return named_args;
+        }
+
+        // Compare names case-insensitively: SAP RFC parameter names are
+        // upper-case, but callers should not have to rely on exact casing.
+        auto to_upper_set = [](const std::set<std::string> &names) {
+            std::set<std::string> upper;
+            for (const auto &name : names) {
+                upper.insert(StringUtil::Upper(name));
+            }
+            return upper;
+        };
+        auto supported_upper = to_upper_set(supported_names);
+        auto droppable_upper = to_upper_set(droppable_names);
+
+        auto &child_types = StructType::GetChildTypes(named_args.type());
+        auto &child_values = StructValue::GetChildren(named_args);
+
+        child_list_t<Value> kept;
+        for (idx_t i = 0; i < child_types.size(); i++) {
+            const auto &field_name = child_types[i].first;
+            auto upper_name = StringUtil::Upper(field_name);
+
+            // Only drop a field that the target does not support AND that the
+            // caller explicitly marked as droppable. Everything else is kept so
+            // unexpected/misspelled parameters still raise a clear error later.
+            bool unsupported = supported_upper.find(upper_name) == supported_upper.end();
+            bool droppable = droppable_upper.find(upper_name) != droppable_upper.end();
+            if (unsupported && droppable) {
+                if (out_dropped != nullptr) {
+                    out_dropped->push_back(field_name);
+                }
+                continue;
+            }
+
+            kept.push_back(std::make_pair(field_name, child_values[i]));
+        }
+
+        return Value::STRUCT(kept);
+    }
+
 // TableWrapper ---------------------------------------------------------------
 
 TableWrapper::TableWrapper(std::shared_ptr<Value> struct_oriented_value, std::string root_path)

--- a/rfc/src/include/duckdb_argument_helper.hpp
+++ b/rfc/src/include/duckdb_argument_helper.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <set>
+#include <string>
+#include <vector>
+
 #include "duckdb.hpp"
 
 namespace duckdb
@@ -60,6 +64,27 @@ private:
 
 bool HasParam(named_parameter_map_t &named_params, const std::string &name);
 Value ConvertBoolArgument(named_parameter_map_t &named_params, const std::string &name, const bool default_value);
+
+// Returns a copy of `named_args` (a single STRUCT Value as produced by
+// ArgBuilder::Build) with version-specific optional fields removed when the
+// target system does not define them.
+//
+// A field is dropped only when it is BOTH absent from `supported_names` AND
+// present in `droppable_names`. Any other unsupported field is kept untouched so
+// that a genuine mistake (e.g. a misspelled required parameter) still surfaces
+// as a clear "Parameter not found" error during argument adaptation rather than
+// being silently swallowed. Name comparisons are case-insensitive; SAP RFC
+// parameter names are upper-case. The names of dropped fields are appended to
+// `out_dropped` when it is non-null.
+//
+// This lets internal callers send a hard-coded optional RFC import parameter
+// (e.g. I_CONFIRM_AUTORETRY, which only exists on newer SAP BW releases) without
+// breaking older systems. If `named_args` is not a STRUCT it is returned
+// unchanged.
+Value SelectSupportedNamedArgs(const Value &named_args,
+                               const std::set<std::string> &supported_names,
+                               const std::set<std::string> &droppable_names,
+                               std::vector<std::string> *out_dropped = nullptr);
 
 template<typename T>
 std::vector<T> ConvertListValueToVector(Value &value) {

--- a/rfc/src/include/sap_function.hpp
+++ b/rfc/src/include/sap_function.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <set>
+
 #include "duckdb.hpp"
 #include "sapnwrfc.h"
 
@@ -148,6 +150,10 @@ bool GetRfcStrictTypeCheck();
             std::string GetName();
             std::vector<RfcFunctionParameterDesc> GetParameterInfos();
             RfcFunctionParameterDesc GetParameterInfo(std::string name);
+            // Names of all parameters (any direction) the target system defines
+            // for this function. Used to skip optional import parameters that a
+            // given SAP release does not expose.
+            std::set<std::string> GetParameterNames();
             std::vector<LogicalType> GetResultTypes();
             std::vector<string> GetResultNames();
             std::vector<RfcFunctionParameterDesc> GetResultInfos();

--- a/rfc/src/sap_function.cpp
+++ b/rfc/src/sap_function.cpp
@@ -1273,7 +1273,7 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
      * @param name The name of the parameter.
      * @return The RfcFunctionParameterDesc object.
     */
-    RfcFunctionParameterDesc RfcFunction::GetParameterInfo(std::string name) 
+    RfcFunctionParameterDesc RfcFunction::GetParameterInfo(std::string name)
     {
         for (auto &param : GetParameterInfos()) {
             if (param.GetName() == name) {
@@ -1282,6 +1282,20 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
         }
 
         throw std::runtime_error(StringUtil::Format("Parameter '%s' not found", name.c_str()));
+    }
+
+    /**
+     * @brief Returns the names of all parameters (any direction) the target
+     *        system defines for this function.
+     * @return A set of parameter names.
+    */
+    std::set<std::string> RfcFunction::GetParameterNames()
+    {
+        std::set<std::string> names;
+        for (auto &param : GetParameterInfos()) {
+            names.insert(param.GetName());
+        }
+        return names;
     }
 
     /**

--- a/rfc/test/cpp/CMakeLists.txt
+++ b/rfc/test/cpp/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TEST_SOURCES
     test_telemetry.cpp
     test_read_table_batching.cpp
     test_connection_close.cpp
+    test_select_supported_args.cpp
     test_main.cpp
 )
 

--- a/rfc/test/cpp/test_select_supported_args.cpp
+++ b/rfc/test/cpp/test_select_supported_args.cpp
@@ -1,0 +1,119 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb.hpp"
+
+#include "duckdb_argument_helper.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+namespace {
+
+// Mirrors the argument list ERPL builds for BICS_PROV_GET_RESULT_SET.
+Value MakeResultSetArgs()
+{
+    return ArgBuilder()
+        .Add("I_DATA_PROVIDER_HANDLE", Value("0003"))
+        .Add("I_OLAP_CACHE_WARM_UP", Value(""))
+        .Add("I_MAX_DATA_CELLS", Value::BIGINT(1000000))
+        .Add("I_SKIP_READ", Value(""))
+        .Add("I_REFRESH_DATA", Value(""))
+        .Add("I_APPLICATION_HANDLE", Value("0001"))
+        .Add("I_DELTA_UPDATE", Value(""))
+        .Add("I_CONFIRM_AUTORETRY", Value(""))
+        .Build();
+}
+
+std::set<std::string> FieldNames(const Value &struct_value)
+{
+    std::set<std::string> names;
+    for (auto &child : StructType::GetChildTypes(struct_value.type())) {
+        names.insert(child.first);
+    }
+    return names;
+}
+
+// The args BICS_PROV_GET_RESULT_SET defines on an older BW release (no autoretry).
+const std::set<std::string> kOlderRelease = {
+    "I_APPLICATION_HANDLE", "I_DATA_PROVIDER_HANDLE", "I_DELTA_UPDATE",
+    "I_MAX_DATA_CELLS", "I_OLAP_CACHE_WARM_UP", "I_REFRESH_DATA", "I_SKIP_READ"
+};
+const std::set<std::string> kDroppable = { "I_CONFIRM_AUTORETRY" };
+
+} // namespace
+
+TEST_CASE("SelectSupportedNamedArgs drops an unsupported droppable parameter", "[select_supported_args]") {
+    // Older BW release whose BICS_PROV_GET_RESULT_SET has no I_CONFIRM_AUTORETRY (issue #81).
+    std::vector<std::string> dropped;
+    auto filtered = SelectSupportedNamedArgs(MakeResultSetArgs(), kOlderRelease, kDroppable, &dropped);
+
+    auto names = FieldNames(filtered);
+    REQUIRE(names.count("I_CONFIRM_AUTORETRY") == 0);
+    REQUIRE(names.count("I_DATA_PROVIDER_HANDLE") == 1);
+    REQUIRE(names.size() == 7);
+
+    REQUIRE(dropped.size() == 1);
+    REQUIRE(dropped[0] == "I_CONFIRM_AUTORETRY");
+}
+
+TEST_CASE("SelectSupportedNamedArgs keeps every field on a newer release", "[select_supported_args]") {
+    auto newer_release = kOlderRelease;
+    newer_release.insert("I_CONFIRM_AUTORETRY");
+
+    std::vector<std::string> dropped;
+    auto filtered = SelectSupportedNamedArgs(MakeResultSetArgs(), newer_release, kDroppable, &dropped);
+
+    REQUIRE(FieldNames(filtered).size() == 8);
+    REQUIRE(dropped.empty());
+}
+
+TEST_CASE("SelectSupportedNamedArgs keeps an unsupported field that is NOT droppable", "[select_supported_args]") {
+    // A misspelled / unexpected required parameter must NOT be silently dropped:
+    // it should be retained so argument adaptation raises a clear error.
+    auto args = ArgBuilder()
+        .Add("I_DATA_PROVIDER_HANDLE", Value("0003"))
+        .Add("I_TYPodanger", Value("oops"))   // unsupported and not in the droppable allowlist
+        .Build();
+
+    std::vector<std::string> dropped;
+    auto filtered = SelectSupportedNamedArgs(args, {"I_DATA_PROVIDER_HANDLE"}, kDroppable, &dropped);
+
+    REQUIRE(FieldNames(filtered).count("I_TYPodanger") == 1);
+    REQUIRE(dropped.empty());
+}
+
+TEST_CASE("SelectSupportedNamedArgs matches names case-insensitively", "[select_supported_args]") {
+    std::set<std::string> supported = { "i_data_provider_handle" };
+    std::set<std::string> droppable = { "i_confirm_autoretry" };
+
+    auto args = ArgBuilder()
+        .Add("I_DATA_PROVIDER_HANDLE", Value("0003"))
+        .Add("I_CONFIRM_AUTORETRY", Value(""))
+        .Build();
+
+    std::vector<std::string> dropped;
+    auto filtered = SelectSupportedNamedArgs(args, supported, droppable, &dropped);
+
+    REQUIRE(FieldNames(filtered).count("I_DATA_PROVIDER_HANDLE") == 1);
+    REQUIRE(dropped.size() == 1);
+    REQUIRE(dropped[0] == "I_CONFIRM_AUTORETRY");
+}
+
+TEST_CASE("SelectSupportedNamedArgs preserves values of kept fields", "[select_supported_args]") {
+    auto args = ArgBuilder()
+        .Add("I_DATA_PROVIDER_HANDLE", Value("0042"))
+        .Add("I_CONFIRM_AUTORETRY", Value(""))
+        .Build();
+
+    auto filtered = SelectSupportedNamedArgs(args, {"I_DATA_PROVIDER_HANDLE"}, kDroppable, nullptr);
+    auto children = StructValue::GetChildren(filtered);
+
+    REQUIRE(children.size() == 1);
+    REQUIRE(children[0].ToString() == "0042");
+}
+
+TEST_CASE("SelectSupportedNamedArgs returns non-struct input unchanged", "[select_supported_args]") {
+    auto scalar = Value("not a struct");
+    auto filtered = SelectSupportedNamedArgs(scalar, {"X"}, {"X"}, nullptr);
+    REQUIRE(filtered.ToString() == "not a struct");
+}


### PR DESCRIPTION
## Problem

Fixes #81. `sap_bics_result` fails on some SAP BW systems with:

> Failed to adapt value for invocation argument 'I_CONFIRM_AUTORETRY': Parameter 'I_CONFIRM_AUTORETRY' not found

## Root cause

`FetchResultSet` calls `BICS_PROV_GET_RESULT_SET` and unconditionally passes the optional import parameter `I_CONFIRM_AUTORETRY` (`bics/src/bics.cpp`). That parameter was only added to the function in newer SAP BW releases — on older systems it isn't part of the signature, so ERPL's argument adapter rejects it before the call is ever sent. The reporter's own metadata dump confirms their `BICS_PROV_GET_RESULT_SET` has no such parameter.

## Fix

**RFC layer (`rfc/`)**
- New pure helper `SelectSupportedNamedArgs(named_args, supported_names, droppable_names, out_dropped)` — removes version-specific optional fields from a named-argument struct. A field is dropped **only** when it is both (a) absent from the target function's signature **and** (b) present in an explicit droppable allowlist. Any other unsupported field is kept, so a genuine mistake (e.g. a misspelled required parameter) still surfaces as a clear `Parameter not found` during adaptation. Case-insensitive on names. Covered by 6 offline unit tests (`[select_supported_args]`).
- New `RfcFunction::GetParameterNames()` to introspect the target system's actual signature.

**BICS layer (submodule bump `615eb6b → f497410`)**
- `FetchResultSet` looks up the function's real parameter set, drops `I_CONFIRM_AUTORETRY` only when the target release doesn't define it (tracing what was dropped), and invokes through the already-fetched `RfcFunction` instead of re-fetching it. Behavior is unchanged on systems that do define the parameter.

## Why this shape

The drop is gated by an explicit allowlist (`{ "I_CONFIRM_AUTORETRY" }`) rather than blanket-filtering every unknown field, so this fixes the version-compatibility problem without masking future typos in required parameters. The mechanism is reusable for any other version-specific optional RFC parameter.

## Review & testing

Reviewed with codex (the allowlist shape addresses its feedback about silently dropping required args). Full debug build green; offline C++ suites pass (`erpl_rfc_tests` incl. the new `[select_supported_args]`, `erpl_bics_tests`). SQL tests require a live SAP BW system and were not run.