### PR TITLE
ODP delta replication: bump erpl-odp + docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ python-env/*
 
 # Experiments
 /examples/experiments/*
+.adt.creds

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -71,6 +71,8 @@ SELECT * FROM sap_bics_show_cubes();
 | `sap_bics_set_char_prop` | AO-style char property (Display/Sort/Totals) | `SELECT * FROM sap_bics_set_char_prop('q1', '0CNTRY', 'DISPLAY', 'TEXT')` |
 | `sap_odp_read_full` | Extract ODP data (full snapshot) | `SELECT * FROM sap_odp_read_full('BW', 'MY_ODP')` |
 | `sap_odp_read_delta` | Extract ODP data (incremental delta) | `SELECT * FROM sap_odp_read_delta('BW', 'MY_ODP', 'MY_PIPELINE')` |
+| `sap_odp_get_last_modified` | Last-modified timestamp of an ODP object (cheap delta probe) | `SELECT * FROM sap_odp_get_last_modified('ABAP_CDS', 'MY_CDS$E')` |
+| `sap_odp_get_subscriptions` | List subscriptions for one ODP object | `SELECT * FROM sap_odp_get_subscriptions('ABAP_CDS', 'MY_CDS$E')` |
 | `ATTACH` | Mount SAP as database | `ATTACH '' AS sap (TYPE sap_rfc)` |
 
 ---
@@ -830,14 +832,18 @@ your pipeline is done.
 | `odp_context` | VARCHAR | *required* | ODP context (e.g. `'BW'`, `'ABAP_CDS'`) |
 | `odp_name` | VARCHAR | *required* | ODP provider name |
 | `subscriber_process` | VARCHAR | *required* | **Stable** identifier that keys the server-side delta pointer across calls. Choose a deterministic name per pipeline (e.g. `'MY_ETL_BUPA_DAILY'`). |
-| `threads` | UINTEGER | 5 | Parallel read threads |
-| `columns` | LIST(VARCHAR) | all | Columns to extract |
-| `filters` | LIST(STRUCT) | — | Server-side selection predicates (same shape as `sap_odp_read_full`) |
-| `recover` | BOOLEAN | `false` | When true, re-stream the last unconfirmed packet (`I_EXTRACTION_MODE='R'`) without advancing the pointer. Useful after a fetch was interrupted. |
+| `threads` | UINTEGER | 1 | Accepted for API symmetry but **delta/RECOVER fetch is serialized** (capped to 1). Parallel package fetch can race a multi-package delta into an under-count, and delta packets are small; use `sap_odp_read_full` `threads` for large parallel snapshots. Must be ≥ 1. |
+| `columns` | LIST(VARCHAR) | all | Columns to extract (not allowed together with `recover=true`) |
+| `filters` | LIST(STRUCT) | — | Server-side selection predicates (same shape as `sap_odp_read_full`; not allowed together with `recover=true`) |
+| `recover` | BOOLEAN | `false` | When true, re-stream the last unconfirmed packet (`I_EXTRACTION_MODE='R'`) without advancing the pointer, using the **original** open's projection/filters. Useful after a fetch was interrupted. Cannot be combined with `columns`/`filters`. |
 | `secret` | VARCHAR | — | Named secret |
 
 **Concurrency note:** do not run two `sap_odp_read_delta` calls with the same
 `subscriber_process` in parallel — they will race the server-side pointer.
+
+**Change semantics:** for `ABAP_CDS` byElement-tracked sources, inserts and
+updates both surface as after-images (`ODQ_CHANGEMODE='U'`); physical deletes are
+**not** reported by the byElement annotation (the row simply leaves the snapshot).
 
 ```sql
 -- First call: SAP auto-DELTAINIT — returns full current snapshot, registers
@@ -883,6 +889,45 @@ List ODP extraction cursors for delta tracking. Cursors created by
 
 ```sql
 SELECT * FROM sap_odp_show_cursors();
+```
+
+---
+
+#### `sap_odp_get_last_modified(odp_context, odp_name [, secret])`
+
+Return the last-modified UTC timestamp of an ODP object (invokes
+`RODPS_REPL_ODP_GET_LAST_MODIF`) **without** fetching any rows. Use it as a cheap
+probe before `sap_odp_read_delta`: if the timestamp has not advanced since your
+last run, there is nothing to extract.
+
+Output columns: `odp_name` (VARCHAR), `last_modified` (DECIMAL(21,7) — a SAP UTC
+timestamp; comparable against the `pointer` column of `sap_odp_show_cursors`).
+
+```sql
+SELECT * FROM sap_odp_get_last_modified('ABAP_CDS', 'MY_CDS_VIEW$E');
+```
+
+---
+
+#### `sap_odp_get_subscriptions(odp_context, odp_name [, subscriber_name, subscriber_process, secret])`
+
+List the subscriptions registered for a specific ODP object (invokes
+`RODPS_REPL_ODP_GET_SUBSCR`). Unlike `sap_odp_show_subscriptions` (which lists all
+subscriptions), this is scoped to one `odp_name` and can be further filtered.
+
+Output columns: `subscriber_type`, `subscriber_name`, `subscriber_process`,
+`queue_name`, `subscription_id`.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `odp_context` | VARCHAR | ODP context (e.g. `'BW'`, `'ABAP_CDS'`) |
+| `odp_name` | VARCHAR | ODP object name |
+| `subscriber_name` | VARCHAR | *(named)* optional subscriber-name filter |
+| `subscriber_process` | VARCHAR | *(named)* optional subscriber-process filter |
+| `secret` | VARCHAR | *(named)* optional secret name |
+
+```sql
+SELECT * FROM sap_odp_get_subscriptions('ABAP_CDS', 'MY_CDS_VIEW$E');
 ```
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,26 @@ LOAD erpl;
 
 ---
 
+## Unreleased
+
+- **[odp]** ODP **delta replication**. New `sap_odp_read_delta(odp_context,
+  odp_name, subscriber_process [, columns, filters, recover, threads, secret])`:
+  the first call with a `subscriber_process` performs SAP's auto-DELTAINIT
+  (full snapshot + registers a delta pointer); subsequent calls return only
+  changes since the pointer. `recover=true` re-streams the last unconfirmed
+  packet. Delta fetch is serialized (single-threaded) for correct multi-package
+  ordering. Validated end-to-end against an ABAP_CDS byElement source on the
+  trial system (insert/update/delete/mixed/bulk/recover/filters).
+- **[odp]** New `PRAGMA sap_odp_close_delta_cursor(odp_context,
+  subscriber_process, odp_name)` — graceful, idempotent cursor close that leaves
+  the subscription resumable (counterpart to `sap_odp_drop`/`RODPS_REPL_ODP_RESET`).
+- **[odp]** New `sap_odp_get_last_modified(odp_context, odp_name)` (cheap
+  delta probe) and `sap_odp_get_subscriptions(odp_context, odp_name [, …])`
+  (per-object subscription list).
+- **[odp]** `sap_odp_drop` is now a `PragmaCall` with an explicit 4-argument
+  signature (the previous zero-arg registration failed to bind the documented
+  call).
+
 ## v2026.06.17 — DuckDB v1.4.5 (LTS) + v1.5.4 (latest)
 
 Tracks DuckDB's latest patch releases on both supported lines. No SAP-facing behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ LOAD erpl;
 
 ---
 
-## Unreleased
+## v2026.06.27 — SAP ODP delta replication
 
 - **[odp]** ODP **delta replication**. New `sap_odp_read_delta(odp_context,
   odp_name, subscriber_process [, columns, filters, recover, threads, secret])`:


### PR DESCRIPTION
Bumps the `odp` submodule to land **ODP delta replication** and reconciles the
public docs. Submodule PR: DataZooDE/erpl-odp#1.

## New public surface (in `erpl_odp`)

- `sap_odp_read_delta(odp_context, odp_name, subscriber_process [, columns, filters, recover, threads, secret])`
- `PRAGMA sap_odp_close_delta_cursor(odp_context, subscriber_process, odp_name)`
- `sap_odp_get_last_modified(odp_context, odp_name)`
- `sap_odp_get_subscriptions(odp_context, odp_name [, …])`
- `sap_odp_drop` now binds its documented 4-arg signature (`PragmaCall`)

## Validation

26/26 real-change scenarios pass against an ABAP_CDS byElement delta source on
the ABAP trial (insert/update/delete/mixed/drain/recover/bulk-multipackage/
threads-sweep/filters). The submodule PR includes review-driven fixes
(serialized delta fetch to remove a parallel-fetch race, locking, input
validation, dedup).

## Contents of this PR

- `odp` gitlink: `e35698b` → `c472288`
- `API_REFERENCE.md`: add `get_last_modified` / `get_subscriptions`; correct
  `read_delta` `threads`/`recover` semantics; note ABAP_CDS byElement change
  semantics
- `CHANGELOG.md`: Unreleased entry
- `.gitignore`: ignore `.adt.creds` (local ADT test-harness credentials)

⚠️ Merge order: merge erpl-odp#1 first, then re-point this gitlink at the
resulting `main` commit if it differs from `c472288`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785151742&installation_id=142929061&pr_number=87&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F87&signature=cda1952348938ce3f260bda4f86e275be4e333c2747b8d33a291415ffe62ba79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->