### PR TITLE
v2026.06.28: ODP delta hardening (CloseSession destructor safety)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ LOAD erpl;
 
 ---
 
+## v2026.06.28 — ODP delta hardening
+
+- **[odp]** Fix: make `OdpFetchSession::CloseSession()` exception-safe on the
+  destructor path. It runs from `~OdpFetchSession` on the FULL read path; the
+  v2026.06.27 trace-logging addition could throw (string allocation / trace
+  macro) and escape the destructor as `std::terminate`. The trace call is now
+  wrapped in its own guard with a final `catch(...)`. Found by a post-release
+  Codex review of the shipped delta-replication diff.
+
 ## v2026.06.27 — SAP ODP delta replication
 
 - **[odp]** ODP **delta replication**. New `sap_odp_read_delta(odp_context,


### PR DESCRIPTION
Patch release on top of v2026.06.27. Bumps the `odp` submodule to bring in a
destructor-safety fix found by a post-release Codex review (DataZooDE/erpl-odp#2).

- `odp` gitlink: `93e9fd9` → `d934af7`
- `CHANGELOG.md`: `v2026.06.28 — ODP delta hardening`

The fix makes `OdpFetchSession::CloseSession()` exception-safe: it runs from the
destructor on the FULL read path, and the v2026.06.27 trace-logging change could
throw and escalate to `std::terminate`. Low-probability but a real destructor
defect. Smoke-tested (FULL read exercises the changed path → 5005 rows; delta +
close_delta_cursor OK).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785158361&installation_id=142929061&pr_number=88&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F88&signature=da382fd6e83c9b68cf86e70496697189bf562284a1541c158ec9294931579157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->