### PR TITLE
fix(bics): sap_bics_meta_transform_fields returns transformation mappings (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ LOAD erpl;
 
 ---
 
+## v2026.07.02 — BICS transformation field mappings
+
+- **[bics]** Fix: `sap_bics_meta_transform_fields` returned **0 rows on every
+  system** (reported on BW/4HANA in #89). It queried `RSTRANFIELD` with column
+  names that do not exist (`FIELDNAME`, `IOBJNM`, `ROLE`, `ROUTINE`, `RULE_*`);
+  both the "enhanced" and "basic" reads threw and a catch-all swallowed the
+  error into an empty result. The scanner now reads the real `RSTRANFIELD`
+  schema (`TRANID, OBJVERS, RULEID, PARAMTYPE, PARAMNM, FIELDNM, FIELDTYPE,
+  KEYFLAG`) and pairs source/target rows by `RULEID` via `PARAMTYPE`
+  (`0` = source, `1` = target), preferring the active object version (`A`) over
+  delivered (`D`). The swallow-to-empty path is replaced by a traced fallback so
+  a genuinely missing table still degrades gracefully on non-BW systems. The
+  `bw_transformation_mappings` view, which builds on this function, was broken
+  the same way and is fixed by the same change.
+
 ## v2026.06.28 — ODP delta hardening
 
 - **[odp]** Fix: make `OdpFetchSession::CloseSession()` exception-safe on the


### PR DESCRIPTION
Fixes #89.

## Problem

`sap_bics_meta_transform_fields` returned **0 rows on every system** (reported on BW/4HANA). It read `RSTRANFIELD` with column names that **do not exist** (`FIELDNAME`, `IOBJNM`, `ROLE`, `ROUTINE`, `RULE_*`); both the "enhanced" and "basic" `ReadTable` calls threw, and a catch-all swallowed the error into an empty result. The `bw_transformation_mappings` view was broken the same way.

Verified live against the ABAP trial: the function returned 0 rows even for a transformation with obvious field mappings.

## Fix (in the `bics` submodule — DataZooDE/erpl-bics#1)

- Read the real `RSTRANFIELD` schema: `TRANID, OBJVERS, RULEID, PARAMTYPE, PARAMNM, FIELDNM, FIELDTYPE, KEYFLAG`.
- Rewrite `PairRSTRANFIELD` to pair rows by `RULEID` using `PARAMTYPE` (`0` = source, `1` = target).
- Prefer the active object version (`A`) over delivered (`D`) so versions don't mix.
- Replace the swallow-to-empty path with a traced fallback for non-BW systems.

This PR bumps the `bics` gitlink to the merged fix and adds the CHANGELOG entry for `v2026.07.02`.

## Tests (red → green)

- C++ unit tests rewritten against the real schema (pairing + version preference): `All tests passed (67 assertions in 11 test cases)`.
- SQL regression assertion added (EPM demo: `EMPLOYEE_ID → 0EPM_EMPID`).
- Live proof: the function and the `bw_transformation_mappings` view now return the full mapping on the ABAP trial.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785606790&installation_id=142929061&pr_number=90&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F90&signature=641a68b35621ffb5995fab4e3d13d1ea0ee8f94d6c69378db9b7b274994de0f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->