### PR TITLE
chore: bump DuckDB to v1.5.5 (keep v1.4 LTS)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -37,11 +37,11 @@ jobs:
       deploy_versioned: ${{ !(startsWith(github.ref, 'refs/tags/v')) && !(github.ref == 'refs/heads/master') }}
 
   duckdb-stable-build-v154:
-    name: Build v.1.5.4 extension binaries
+    name: Build v.1.5.5 extension binaries
     uses: ./.github/workflows/_extension_build.yml
     secrets: inherit
     with:
-      duckdb_version: v1.5.4
+      duckdb_version: v1.5.5
       extension_name: erpl
       exclude_archs: linux_arm64;windows_amd64_rtools;wasm_mvp;wasm_eh;wasm_threads;
 
@@ -51,7 +51,7 @@ jobs:
     uses: ./.github/workflows/_extension_deploy.yml
     secrets: inherit
     with:
-      duckdb_version: v1.5.4
+      duckdb_version: v1.5.5
       extension_name: erpl
       exclude_archs: linux_arm64;windows_amd64_rtools;wasm_mvp;wasm_eh;wasm_threads;
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
## Summary
- Bumps the `duckdb` submodule from **v1.5.4** (`08e34c447b`) to **v1.5.5** (`d8cdaa33fd`).
- Keeps the dual v1.4 LTS / v1.5 stable release matrix in `MainDistributionPipeline.yml`.

## Workflow edits (`.github/workflows/MainDistributionPipeline.yml`)
- `duckdb-stable-build-v154` / `duckdb-stable-deploy-v154`: `duckdb_version: v1.5.4` -> `v1.5.5`, job display name "Build v.1.5.4 extension binaries" -> "Build v.1.5.5 extension binaries".
- v1.4 LTS jobs (`duckdb-stable-build-v145` / `duckdb-stable-deploy-v145`) were already pinned to `v1.4.5` — left unchanged (already normalized).
- No `ci_tools_version:` / external `uses: duckdb/extension-ci-tools@...` ref exists in this repo — CI tooling is invoked via the local `./.github/workflows/_extension_build.yml` / `_extension_deploy.yml`, which take `duckdb_version` as an input and have no hardcoded version pins, so nothing else needed changing there.
- Grepped for other pinned refs (Makefile, CMakeLists.txt, vcpkg.json) — no other genuine version pins to the old duckdb version found outside the `duckdb/` submodule itself.

## Local verification on bigfox
- **Build:** PASS — `GEN=ninja make release` built cleanly on GCC-16 (no ODR/link errors); all extension artifacts produced (`erpl`, `erpl_rfc`, `erpl_tunnel`, `erpl_bics`, `erpl_odp`, `core_functions`, `parquet`).
- **Test:** PASS — `make smoke_test` (installs the official v1.5.5 DuckDB CLI, loads the built extension, verifies `sap_read_table`/`sap_rfc_invoke`/`sap_show_tables` are registered, and exercises the double-connection load regression test for issue #52) passed end-to-end. Full SQL test suites (`sql_tests_rfc`/`sql_tests_bics`/`sql_tests_odp`/`sql_tests_tunnel`) require a live SAP system / Docker mock and were not run locally; CI is the gate for those.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787475260&installation_model_id=425457&pr_number=95&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F95&signature=776c9f0b537bd14bdaf60f993c07683c990aa393c5918cc595b234c4762eb6dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->