### PR TITLE
feat(bics): BEx query variable submission (#96) + result schema fix (#99)

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -514,19 +514,78 @@ SELECT * FROM sap_bics_hierarchy('ZCOSTCENTER_H01', version='A', date_to='202512
 
 BICS queries use a stateful workflow: initialize a session, configure axes and filters, then fetch results.
 
-#### Step 1: `sap_bics_begin(cube_name [, id, return, secret])`
+#### Step 1: `sap_bics_begin(cube_name [, id, return, variables, hierarchy_variables, variant, secret])`
 
-Initialize a BICS query session.
+Initialize a BICS query session. `cube_name` may also be a BEx query technical
+name, which is resolved to its InfoProvider via `RSRREPDIR`.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `cube_name` | VARCHAR | *required* | Cube technical name |
+| `cube_name` | VARCHAR | *required* | Cube or BEx query technical name |
 | `id` | VARCHAR | — | User-defined state ID |
 | `return` | BICS_RETURN | `'DESCRIBE'` | `'DESCRIBE'` for metadata, `'RESULT'` for data |
+| `variables` | LIST\<STRUCT\> | — | BEx variable values (see below) |
+| `hierarchy_variables` | LIST\<STRUCT\> | — | Hierarchy-node variable values (see below) |
+| `variant` | VARCHAR | — | Name of a saved BEx variant to fill the variables |
 | `secret` | VARCHAR | — | Named secret |
 
 ```sql
 SELECT * FROM sap_bics_begin('MY_CUBE', id='my_session');
+```
+
+**`variables` shape** — `LIST<STRUCT(NAME, SIGN, OP, LOW, HIGH)>`, mapped onto
+SAP's `BICS_PROV_STATE_INIT_VARIABLES` row type and submitted with
+`BICS_PROV_OPEN`. It mirrors the ODP `filters` shape, with `NAME` naming a BEx
+variable instead of a field:
+
+| Field | Type | Semantics |
+|-------|------|-----------|
+| `NAME` | VARCHAR | BEx variable technical name |
+| `SIGN` | VARCHAR | `'I'` (include) or `'E'` (exclude); defaults to `'I'` |
+| `OP` | VARCHAR | `'EQ'`, `'BT'`, `'GE'`, `'LE'`, `'CP'`, …; defaults to `'BT'` when `HIGH` is given, else `'EQ'` |
+| `LOW` | VARCHAR | Value, or lower bound of an interval |
+| `HIGH` | VARCHAR | Upper bound of an interval; empty otherwise |
+
+Repeat `NAME` to fill a multi-value variable — that is how multiple values
+travel on the wire.
+
+```sql
+SELECT * FROM sap_bics_begin('MY_QUERY', id='q1',
+    variables => [
+        {'NAME':'ZVAR_YEAR', 'SIGN':'I', 'OP':'EQ', 'LOW':'2026', 'HIGH':''},
+        {'NAME':'ZVAR_DATE', 'SIGN':'I', 'OP':'BT', 'LOW':'20260101', 'HIGH':'20260131'}
+    ]);
+```
+
+Values are stored with the session state and replayed whenever the session is
+restored, so a chained `begin → rows → result` workflow stays restricted.
+
+**`hierarchy_variables` shape** — `LIST<STRUCT(NAME, LOW, HIERARCHY_NAME,
+HIERARCHY_VERSION, HIERARCHY_DUE_DATE)>`. Separate from `variables` so the
+common case does not have to spell out the hierarchy fields;
+`HIERARCHY_DUE_DATE` defaults to `'99991231'`.
+
+A variable name the query does not expose as input-ready is rejected — BW would
+otherwise ignore it silently and return an unrestricted result.
+
+#### `sap_bics_variables(info_provider [, query, id, secret])`
+
+List the BEx variables of a query, to find out what `variables` has to fill.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `name` | VARCHAR | Technical name |
+| `text` | VARCHAR | Description |
+| `mandatory` | BOOLEAN | BW refuses to produce a result until this one has a value |
+| `input_enabled` | BOOLEAN | Can be filled by the caller (exit variables cannot) |
+| `is_exit_variable` | BOOLEAN | Filled by a BW customer-exit, not by the caller |
+| `var_type` | VARCHAR | `CHARACTERISTIC_VALUE`, `HIERARCHY`, `TEXT`, `FORMULA`, `HIERARCHY_NODE` |
+| `selection_type` | VARCHAR | `SINGLE_VALUE`, `INTERVAL`, `SELECTION_OPTION`, `MULTIPLE_VALUES`, `PRECALCULATED_VALUE_SET` |
+| `entry_type` | VARCHAR | `OPTIONAL`, `MANDATORY`, `MANDATORY_NOT_INITIAL` |
+| `reference_char` | VARCHAR | Characteristic a hierarchy-node variable refers to |
+
+```sql
+SELECT * FROM sap_bics_variables('MY_QUERY');
 ```
 
 #### Step 2: `sap_bics_rows(state_id, char1 [, char2, ..., op, return])`

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -681,6 +681,17 @@ Fetch result set from configured query state.
 |-----------|------|---------|-------------|
 | `state_id` | VARCHAR | *required* | State ID |
 
+**Result shape** — one `VARCHAR` column per row-axis element carrying the formatted
+member key or text, one `INTEGER` `<name>_HIER_LEVEL` column per row-axis element, then
+one `DOUBLE` column per column-axis leaf.
+
+The number of row-axis columns follows the result set the BW server returns; when a
+result carries no rows at all, the session state's axis is used instead so a query's
+schema does not change shape just because it returned nothing.
+Column names come from the session state when it describes the axis; BEx queries whose
+drilldown lives in the query definition rather than the state are named from the result's
+own members, falling back to `ROW_1`, `ROW_2`, … when no metadata is available for them.
+
 ```sql
 -- Complete workflow
 SELECT * FROM sap_bics_begin('MY_CUBE', id='q1');

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -688,9 +688,12 @@ one `DOUBLE` column per column-axis leaf.
 The number of row-axis columns follows the result set the BW server returns; when a
 result carries no rows at all, the session state's axis is used instead so a query's
 schema does not change shape just because it returned nothing.
-Column names come from the session state when it describes the axis; BEx queries whose
-drilldown lives in the query definition rather than the state are named from the result's
-own members, falling back to `ROW_1`, `ROW_2`, … when no metadata is available for them.
+
+Column names are resolved in order: the session state, then the query's design-time
+metadata (one extra RFC call, made only when the state cannot name the axis — the case
+for BEx queries whose drilldown lives in the query definition), then `ROW_1`, `ROW_2`,
+…. Both metadata sources are matched on the member's characteristic id, never by
+position, so a column is never labelled with an unrelated characteristic.
 
 ```sql
 -- Complete workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,24 @@ LOAD erpl;
   a DuckDB internal error ("Table function must return at least one column").
   It now reports which variables are missing. A variable name the query does
   not expose as input-ready is rejected instead of being silently ignored by BW.
+- **[bics]** Fix `sap_bics_result` for BEx queries whose row axis the state does not
+  describe ([#99](https://github.com/DataZooDE/erpl/issues/99)). The result schema was
+  sized from the persisted state's axis tables while the data was written using the
+  result's own row-element count, so the schema collapsed to the column-axis leaves
+  (all `DOUBLE`) and materialization failed with e.g. `Could not convert string
+  'FC008' to DOUBLE`; data cells were targeted past the end of the chunk and silently
+  dropped. The schema now follows the result set, which is the only source that always
+  knows the axis width; a result with no rows at all falls back to the state, so a
+  query's schema does not narrow just because it returned nothing. State-derived column
+  names are unchanged whenever the state agrees on the count; otherwise names come from
+  the result's own members, falling back to `ROW_<n>`.
+- **[bics]** Revive the C++ tests that had gone dark: the test binaries link
+  `dummy_static_extension_loader`, whose `LoadAllExtensions` is a no-op, so nothing
+  registered `core_functions` and every test that evaluates a serialized `Value`
+  (the captured-response fixtures, the state repository round trip) failed on a missing
+  `list_value`. Test databases are now built through `MakeTestDatabase()`, which
+  registers the statically linked extension directly. Seven test cases, including the
+  `GetColumnNames` / `GetResultTypes` coverage over captured BW responses, run again.
 - **[bics]** Fix session restore for query-based sessions: the InfoProvider and
   query names are now persisted with the state. `BICS_PROV_GET_INITIAL_STATE`
   does not carry them for queries, so any second statement against a session

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,15 @@ LOAD erpl;
   query's schema does not narrow just because it returned nothing. State-derived column
   names are unchanged whenever the state agrees on the count; otherwise names come from
   the result's own members, falling back to `ROW_<n>`.
+- **[bics]** Name the row axis from the query's design-time metadata when the session
+  state carries none, instead of falling back to `ROW_1`, `ROW_2`, …. The extra
+  `BICS_PROV_GET_DESIGN_TIME_INFO` call is made only when the state cannot name the
+  axis, and both sources are matched on the characteristic id rather than by position,
+  so a column is never labelled with an unrelated characteristic.
+- **[odp]** `test_odp_com` hardcoded SAP credentials with a password that no longer
+  matched the trial system, so every run performed a failed logon — enough repeats lock
+  the SAP user globally and break every other suite. It now reads the standard
+  `ERPL_SAP_*` variables and skips when they are unset.
 - **[bics]** Revive the C++ tests that had gone dark: the test binaries link
   `dummy_static_extension_loader`, whose `LoadAllExtensions` is a no-op, so nothing
   registered `core_functions` and every test that evaluates a serialized `Value`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,29 @@ LOAD erpl;
 
 ---
 
+## Unreleased
+
+- **[bics]** Support **BEx query variable submission** ([#96](https://github.com/DataZooDE/erpl/issues/96)).
+  `sap_bics_begin` gains `variables => LIST<STRUCT(NAME, SIGN, OP, LOW, HIGH)>`,
+  `hierarchy_variables => …` and `variant => …`. Values are submitted with
+  `BICS_PROV_OPEN` through `I_T_VIEW_VARIABLE_VALUES`, so a BEx query with a
+  mandatory variable prompt can be initialized and executed. Single values,
+  intervals, multiple values (repeat `NAME`) and hierarchy nodes are supported.
+  The shape mirrors the existing ODP `filters` select-option convention.
+- **[bics]** New `sap_bics_variables(info_provider [, query])` lists a query's
+  variables with their `mandatory` / `input_enabled` flags, so callers can
+  discover what has to be filled.
+- **[bics]** A query whose mandatory variables are unfilled used to surface as
+  a DuckDB internal error ("Table function must return at least one column").
+  It now reports which variables are missing. A variable name the query does
+  not expose as input-ready is rejected instead of being silently ignored by BW.
+- **[bics]** Fix session restore for query-based sessions: the InfoProvider and
+  query names are now persisted with the state. `BICS_PROV_GET_INITIAL_STATE`
+  does not carry them for queries, so any second statement against a session
+  opened by query name previously failed with "Failed to open data provider …
+  for info provider ''". This affected every chained `begin → rows → result`
+  workflow on a BEx query, not just variable-driven ones.
+
 ## v2026.07.12 — Cross-product telemetry (schema 2)
 
 - **[all]** Adopt the shared cross-product **posthog-telemetry schema-2**


### PR DESCRIPTION
Closes #96. Closes #99.

BEx queries with a mandatory variable prompt could not be executed — BW refuses to produce a result structure while a mandatory variable is unfilled, and ERPL had no way to supply values. Fixing that surfaced a second, independent bug in the result path, which is fixed here too.

This bumps the `bics` submodule to **DataZooDE/erpl-bics#3** and documents the new surface.

## #96 — variable submission

```sql
-- what does this query want?
SELECT * FROM sap_bics_variables('MY_QUERY');

-- fill it
SELECT * FROM sap_bics_begin('MY_QUERY', id='q1',
    variables => [
        {'NAME':'ZVAR_YEAR', 'SIGN':'I', 'OP':'EQ', 'LOW':'2026',     'HIGH':''},
        {'NAME':'ZVAR_DATE', 'SIGN':'I', 'OP':'BT', 'LOW':'20260101', 'HIGH':'20260131'}
    ]);
SELECT * FROM sap_bics_result('q1');
```

Values are submitted with `BICS_PROV_OPEN` via `I_T_VIEW_VARIABLE_VALUES` — not the interactive `BICS_PROV_VAR_SET_VARIABLES` the issue assumed, which carries a different and much heavier payload. The struct mirrors the ODP select-option convention (`sap_odp_read(filters => ...)`) so both extensions spell a SAP range the same way.

Single values, intervals, multiple values (repeat `NAME`) and hierarchy nodes (`hierarchy_variables =>`) are supported, plus `variant =>` for a saved BEx variant.

Also: an unfilled mandatory prompt used to surface as a DuckDB internal error (*"Table function must return at least one column"*) and now names the missing variables; a variable name the query does not expose as input-ready is rejected rather than being silently ignored by BW; and the InfoProvider/query names are persisted with the session state, because `BICS_PROV_GET_INITIAL_STATE` does not return `QUERY_PROPERTIES` for query-based sessions and every chained `begin → rows → result` on a BEx query was failing with `info provider ''`.

## #99 — result schema derived from the wrong source

`sap_bics_result` failed with `Could not convert string 'FC008' to DOUBLE` for BEx queries whose row axis the state does not describe. The schema was sized from the **state's** axis tables while the data was written using the **result's** `NRowElements()`. Instrumenting `0D_FC_AE_CONDITION_Q0015`:

```
GetResultTypes:  state_row_chars=0 leaves=1 NRowElements=2 NRows=18
FetchNextResult: n_row_elements=2 row_value_offset=4 output_cols=1
```

Beyond the reported cast, writes at indices 1–3 went past a one-column chunk, and every data cell targeted index 4 and was silently dropped.

The result set is now the single source of truth for the axis width. A result with **no rows** falls back to the state, so a query does not bind a narrower schema when it happens to return nothing.

## Row-axis naming

Column names resolve in order: session state → the query's design-time metadata (`BICS_PROV_GET_DESIGN_TIME_INFO`, one extra RFC call made only when the state cannot name the axis) → `ROW_1`, `ROW_2`, …. Both metadata sources are matched on the member's **characteristic id, never by position**, so a column is never labelled with an unrelated characteristic. `0D_FC_AE_CONDITION_Q0015` now reports `0D_FC_CUST` / `0D_FC_PH2` instead of `ROW_1` / `ROW_2`.

## Test harness revived

The test binaries link `dummy_static_extension_loader`, whose `LoadAllExtensions` is a no-op, so nothing registered `core_functions` and every test evaluating a serialized `Value` failed on a missing `list_value()`. Seven test cases had been dark since the DuckDB v1.5 bump — including the `GetColumnNames` / `GetResultTypes` coverage over captured BW responses, which is precisely what guards the #99 change. Test databases now go through `MakeTestDatabase()`, which registers the statically linked extension directly (and is deliberately leaked — DuckDB's block allocator tears down thread-local state before static destructors, tripping a use-after-free under ASan otherwise).

Those revived tests immediately caught an over-reach in the first version of the #99 fix — the empty-result case above.

## Adversarial review round

An independent review of the branch found two real defects and four smaller ones, all fixed here:

| Severity | Finding |
|---|---|
| Major | `RowAxisWidth`'s fallback was gated on `NRowElements() == 0`, but `FetchNextResult` offsets by `2 * NRowElements()` regardless — a result with rows but no reported row elements would bind state-width columns and write cells into them. Now gated on `NRows() == 0`, the condition that actually makes it safe. |
| Major | The session constructor guarded `Open()` but not the variable validation after it, so a rejected variable name threw with the data area open — and a destructor does not run for a constructor that threw. The `vars_typo` test leaked a BW data area on every run. |
| Minor | The unfilled-variable diagnostic constructed a `BicsHandle` outside its try; `BicsHandle` throws on a non-4-char value, so a malformed container handle replaced the real SAP message. |
| Minor | `MEMBER_TABLE_INDEX == 0` underflowed into the catch-all, hiding malformed references behind a plausible schema. |
| Minor | Row-axis names escaped the duplicate-name policy and could collide with a measure. A final uniqueness pass now covers the whole schema. |
| Minor | `SIGN` is now validated against its closed `I`/`E` domain. `OP` is deliberately left a pass-through: `RSOPTION` is longer and version-dependent, and an incomplete allow-list would reject operators the server accepts. Both choices are pinned by tests. |

No critical findings. The review also specifically cleared SQL injection through `id`, the `ALTER TABLE … ADD COLUMN IF NOT EXISTS` migration, and the leaked test database.

## Testing

- **C++**: 160 test cases / 626 assertions, **all passing** (was 145/152 with 7 failures on master).
- **Live SQL** against the trial system: 11 files, 264 assertions, all passing — including every naming-sensitive test (`query_cube`, `multidim_result`, `navattr_in_result`, `slice_via_axis`, `type_coverage`, `filter`, `dice_operations`).

With #99 fixed, the value-level restriction assertion for #96 that previously had to live at the marshalling boundary is now a real SQL test — three variable combinations, three different answers:

| `0D_FC_P02` | `0D_FC_P21` | `dyn_kf_1` | `dyn_kf_2` |
|---|---|---|---|
| 2005 | FC001 | 2.0 | NULL |
| 2004 | FC002 | NULL | 2.0 |
| 2004 | FC001 | NULL | NULL |

## Remaining limits

- **Hierarchy-node variables** are plumbed, validated and unit-tested, but no hierarchy is loaded for `0D_FC_SEMP` on the trial system, so there is no live end-to-end assertion. `BICS_PROV_VAR_SET_HIERARCHY` remains the fallback if the open-time table proves insufficient against a real BW.
- **Measure columns are still named `dyn_kf_1`, `dyn_kf_2`** where BW returns structure members without a name. The design-time fallback added here is keyed on characteristic id and does not resolve key-figure structure members; that is separate work.

Sibling test-suite audit went out separately: #100 / DataZooDE/erpl-odp#4 (odp had a hardcoded stale SAP password causing a failed logon on every run). `rfc` needed no change.
