### PR TITLE
ci: bump the Node-based actions that still ran on the deprecated runtime

### DIFF
--- a/.github/workflows/_extension_build.yml
+++ b/.github/workflows/_extension_build.yml
@@ -63,7 +63,7 @@ jobs:
           private-key: ${{ secrets.REPO_READONLY_GITHUB_APP_KEY }}
           repositories: "erpl,erpl-bics,erpl-odp"
           
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'true'
@@ -344,7 +344,7 @@ jobs:
           vcpkgGitURL: ${{ inputs.vcpkg_url }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::331993160594:role/ErplGithubOicdRole
           role-session-name: ErplGithubOicdSession
@@ -430,7 +430,7 @@ jobs:
           app_id: ${{ secrets.REPO_READONLY_GITHUB_APP_ID }}
           private_key: ${{ secrets.REPO_READONLY_GITHUB_APP_KEY }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'true'

--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -64,7 +64,7 @@ jobs:
           private-key: ${{ secrets.REPO_READONLY_GITHUB_APP_KEY }}
           repositories: "erpl,erpl-bics,erpl-odp"
           
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'true'
@@ -99,14 +99,14 @@ jobs:
           private-key: ${{ secrets.REPO_READONLY_GITHUB_APP_KEY }}
           repositories: "erpl,erpl-bics,erpl-odp"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'true'
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::331993160594:role/ErplGithubOicdRole
           role-session-name: ErplGithubOicdSession


### PR DESCRIPTION
The `linux_amd64_musl` deploy leg of the **v2026.07.30** master run failed in `aws-actions/configure-aws-credentials@v1`:

```
##[error]Error message: Cannot read properties of undefined (reading 'message')
```

with the runner warning `Node 20 is being deprecated. This workflow is running with Node 24 by default`. `@v1` predates that runtime and surfaces the incompatibility as this opaque JS error instead of something diagnosable.

It is **intermittent** — the other four deploy legs passed on the same run, and the leg went green on re-run. That is exactly why it is worth pinning down rather than re-running each time it bites; the failure lands on the step that uploads release binaries to S3.

## Change

The repo was already inconsistent — `_extension_build.yml` pinned `@v4` in two places and `@v1` in a third, and mixed `actions/checkout@v3` with `@v4`. This brings every call site to the version already in use elsewhere:

| Action | Before | After | Sites |
|---|---|---|---|
| `aws-actions/configure-aws-credentials` | `@v1` | `@v4` | 2 |
| `actions/checkout` | `@v3` | `@v4` | 4 |

Both are drop-in:

- The AWS action keeps the same three inputs (`role-to-assume`, `role-session-name`, `aws-region`) that the existing `@v4` call sites already pass.
- OIDC still works: `id-token: write` is granted in `MainDistributionPipeline.yml` and inherited by the reusable workflows.

All three workflow files were checked to still parse.

## Caveat on verification

The `deploy` job only runs on `master` and tags (`deploy_latest`), so **a PR run exercises the build path but not the deploy path this actually fixes**. Real confirmation comes from the first master run after merge.

No code or extension behaviour changes — workflow files only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788025250&installation_model_id=425457&pr_number=103&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F103&signature=e00f3ef41d25c27dfcaf70c604742b33c635ebd5cea5781608a0c29b67c69945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->