### PR TITLE
feat: SNC support and the remaining RfcOpenConnection parameters (#98)

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1148,13 +1148,27 @@ All parameters are VARCHAR. Choose either direct connection or load-balanced par
 | `group` | Logon group | — | required |
 | `client` | SAP client number | required | required |
 | `user` | Username | required | required |
-| `passwd` | Password (redacted) | required | required |
+| `passwd` | Password (redacted) | required¹ | required¹ |
 | `lang` | Language (e.g. `'EN'`) | optional | optional |
+| `snc_mode` | Activate SNC — `'1'` on, `'0'` off | optional | optional |
+| `snc_sso` | Use the SNC identity for logon (`'1'`/`'0'`) | optional | optional |
 | `snc_qop` | SNC quality of protection | optional | optional |
 | `snc_myname` | SNC client name | optional | optional |
 | `snc_partnername` | SNC server name | optional | optional |
 | `snc_lib` | SNC library path | optional | optional |
-| `mysapsso2` | SSO2 ticket | optional | optional |
+| `mysapsso2` | SSO2 ticket (redacted) | optional | optional |
+| `x509cert` | X.509 certificate for logon (redacted) | optional | optional |
+| `saprouter` | SAProuter string, e.g. `'/H/routerhost/S/3299'` | optional | optional |
+| `gwhost` | Gateway host | optional | optional |
+| `gwserv` | Gateway service | optional | optional |
+| `codepage` | Logon codepage, e.g. `'4103'` | optional | optional |
+| `trace` | SAP RFC trace level `'0'`–`'3'` | optional | optional |
+| `dest` | Destination in `sapnwrfc.ini` | optional | optional |
+
+¹ Not required when logging on via SNC or an SSO2 ticket.
+
+The parameter names are passed through to `RfcOpenConnection` unchanged, so they
+follow the SAP NetWeaver RFC SDK documentation.
 
 ```sql
 -- Direct connection
@@ -1170,7 +1184,21 @@ CREATE SECRET my_sap_lb (
     MSHOST 'sapms.example.com', SYSID 'PRD', GROUP 'PUBLIC',
     CLIENT '100', USER 'sapuser', PASSWD 'password'
 );
+
+-- SNC / Kerberos logon, without a password
+CREATE SECRET my_sap_snc (
+    TYPE sap_rfc,
+    ASHOST 'sap.example.com', SYSNR '00', CLIENT '100', USER 'sapuser',
+    SNC_MODE '1',
+    SNC_PARTNERNAME 'p:CN=SAP/sap.example.com@EXAMPLE.LOCAL',
+    SNC_LIB '/usr/lib/libgsskrb5.so'
+);
 ```
+
+A secret is selected by name via the `secret` argument, e.g.
+`PRAGMA sap_rfc_ping(secret='my_sap_snc')` or
+`SELECT * FROM sap_read_table('SFLIGHT', secret='my_sap_snc')`. Without it, the
+best-matching `sap_rfc` secret in scope is used.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,39 @@ LOAD erpl;
 
 ---
 
+## v2026.07.30.1 — SNC logon and the full RfcOpenConnection parameter set
+
+Connecting through **SNC (Kerberos, X.509, SAP Single Sign-On) is now possible**:
+`SNC_MODE` could not be set on a `sap_rfc` secret, so the SAP RFC SDK never
+activated SNC and a password was effectively mandatory.
+
+- **[rfc]** The `sap_rfc` secret accepts the remaining documented
+  `RfcOpenConnection` parameters ([#98](https://github.com/DataZooDE/erpl/issues/98)):
+  `SNC_MODE`, `SNC_SSO`, `X509CERT`, `SAPROUTER`, `GWHOST`, `GWSERV`, `CODEPAGE`,
+  `TRACE` and `DEST`, alongside the existing `SNC_QOP` / `SNC_MYNAME` /
+  `SNC_PARTNERNAME` / `SNC_LIB`. A secret without `PASSWD` is valid — an
+  SNC or SSO2 logon needs none. Names are passed to the SDK unchanged.
+- **[rfc]** *Fix:* the `secret => '<name>'` argument selected a secret by **scope
+  instead of by name**. It was passed to DuckDB's `LookupSecret()` as a path, so
+  with more than one `sap_rfc` secret defined, ERPL could silently connect to a
+  different system than the one named — and a misspelled name resolved to some
+  other secret rather than erroring. Naming a secret now selects exactly that
+  secret, and an unknown name is reported.
+- **[rfc]** *Fix:* the password was **not redacted** in `duckdb_secrets()`. The
+  redact list named `password` while the stored key is `passwd`, so the plaintext
+  password was printed. `passwd`, `mysapsso2` and `x509cert` are now redacted.
+- **[rfc]** The connection parameters are defined once in a single table instead
+  of being repeated across four hand-maintained lists, which also removes a
+  fixed-size `RFC_CONNECTION_PARAMETER params[15]` stack array that exactly
+  matched the old parameter count. Telemetry's `auth_kind` recognises an
+  SNC logon that sets only `SNC_MODE` (previously reported as `basic`).
+
+Not verified end to end: the SNC handshake itself needs an SNC-enabled SAP
+system, which the ABAP trial used for CI is not. What is verified live is that
+`SNC_MODE '1'` makes the SDK initialize SNC and load the configured `SNC_LIB`.
+
+---
+
 ## v2026.07.30 — BEx query variables
 
 The headline is that **BEx queries with a variable prompt can finally be executed**.

--- a/rfc/src/include/sap_connection.hpp
+++ b/rfc/src/include/sap_connection.hpp
@@ -73,30 +73,64 @@ namespace duckdb
 	};
 
 	struct RfcAuthParams {
+		// Connection / logon
 		string ashost;
 		string sysnr;
 		string user;
 		string password;
 		string client;
 		string lang;
+		// Load balancing via a message server
 		string mshost;
 		string msserv;
 		string sysid;
 		string group;
+		// SNC (Secure Network Communications)
+		string snc_mode;
+		string snc_sso;
 		string snc_qop;
 		string snc_myname;
 		string snc_partnername;
 		string snc_lib;
+		// Other credential material
 		string mysapsso2;
+		string x509cert;
+		// Routing and miscellaneous
+		string saprouter;
+		string gwhost;
+		string gwserv;
+		string codepage;
+		string trace;
+		string dest;
 
 		static RfcAuthParams FromContext(ClientContext &context, const string &secret_name = SAP_SECRET_DEFAULT_PATH);
 		string ToString();
 		std::shared_ptr<RfcConnection> Connect();
 
+		// The (name, value) pairs handed to RfcOpenConnection, in table order and
+		// with unset parameters omitted — the SDK treats an empty value as an
+		// explicit empty setting for some parameters.
+		vector<std::pair<string, string>> BuildConnectionParams() const;
+
 		// Enumerated auth kind (basic|sso|snc) for telemetry — derived purely
 		// from which credential fields are set. Returns no credential material.
 		const char *TelemetryAuthKind() const;
 	};
+
+	// One entry per supported connection parameter. `name` is used verbatim as
+	// the `sap_rfc` secret parameter, as the key in the secret map, and as the
+	// RfcOpenConnection parameter name, so a parameter is added in exactly one
+	// place. Keep this the single source of truth — the secret registration,
+	// the secret -> RfcAuthParams conversion, ToString() and the SDK parameter
+	// array are all derived from it.
+	struct RfcAuthParamDefinition {
+		const char *name;
+		string RfcAuthParams::*member;
+		// Whether the value must be hidden in any human-readable rendering.
+		bool secret;
+	};
+
+	const vector<RfcAuthParamDefinition> &RfcAuthParamDefinitions();
 
 	// Maps an RFC_RC failure code to an enumerated telemetry error_class
 	// (auth_error|connection_failed|timeout|rfc_error). Code-controlled enum in,

--- a/rfc/src/include/sap_secret.hpp
+++ b/rfc/src/include/sap_secret.hpp
@@ -6,11 +6,16 @@
 
 namespace duckdb {
 
-class RfcAuthParams; // Forward declaration
+struct RfcAuthParams; // Forward declaration
 
 static constexpr const char *SAP_SECRET_PROVIDER = "config";
 static constexpr const char *SAP_SECRET_TYPE_NAME = "sap_rfc";
 static constexpr const char *SAP_SECRET_DEFAULT_PATH = "*";
+
+// The parameter names accepted by a `sap_rfc` secret. Derived from
+// RfcAuthParamDefinitions() in sap_connection.hpp, which is the single source
+// of truth for the supported RfcOpenConnection parameters.
+const vector<string> &SapSecretParameterNames();
 
 // Convert a DuckDB secret to an RfcAuthParams
 RfcAuthParams ConvertSecretToAuthParams(const KeyValueSecret &duck_secret);

--- a/rfc/src/sap_connection.cpp
+++ b/rfc/src/sap_connection.cpp
@@ -38,7 +38,24 @@ namespace duckdb
         auto &secret_manager = duckdb::SecretManager::Get(context);
         auto transaction = duckdb::CatalogTransaction::GetSystemCatalogTransaction(context);
 
-        // Lookup the secret
+        // A caller that named a secret gets that secret. LookupSecret() matches
+        // the argument against the secret *scopes*, not against the name, so
+        // using it here handed back whatever sap_rfc secret happened to be in
+        // scope — silently connecting with another system's credentials.
+        if (!secret_name.empty() && secret_name != SAP_SECRET_DEFAULT_PATH) {
+            auto secret_entry = secret_manager.GetSecretByName(transaction, secret_name);
+            if (!secret_entry) {
+                throw InvalidInputException("Secret '%s' not found", secret_name);
+            }
+            if (secret_entry->secret->GetType() != SAP_SECRET_TYPE_NAME) {
+                throw InvalidInputException("Secret '%s' is of type '%s', expected '%s'", secret_name,
+                                            secret_entry->secret->GetType(), SAP_SECRET_TYPE_NAME);
+            }
+            const auto &named_secret = dynamic_cast<const KeyValueSecret &>(*secret_entry->secret);
+            return ConvertSecretToAuthParams(named_secret);
+        }
+
+        // No secret named: fall back to the best scope match.
         auto secret_match = secret_manager.LookupSecret(transaction, secret_name, "sap_rfc");
         if (! secret_match.HasMatch()) {
 
@@ -50,142 +67,100 @@ namespace duckdb
         return ConvertSecretToAuthParams(duck_secret);
     }
 
+    const vector<RfcAuthParamDefinition> &RfcAuthParamDefinitions()
+    {
+        // The names are the ones documented for RfcOpenConnection in the SAP
+        // NetWeaver RFC SDK; they are passed through unchanged.
+        static const vector<RfcAuthParamDefinition> definitions = {
+            {"ashost",          &RfcAuthParams::ashost,          false},
+            {"sysnr",           &RfcAuthParams::sysnr,           false},
+            {"user",            &RfcAuthParams::user,            false},
+            {"passwd",          &RfcAuthParams::password,        true},
+            {"client",          &RfcAuthParams::client,          false},
+            {"lang",            &RfcAuthParams::lang,            false},
+            {"mshost",          &RfcAuthParams::mshost,          false},
+            {"msserv",          &RfcAuthParams::msserv,          false},
+            {"sysid",           &RfcAuthParams::sysid,           false},
+            {"group",           &RfcAuthParams::group,           false},
+            {"snc_mode",        &RfcAuthParams::snc_mode,        false},
+            {"snc_sso",         &RfcAuthParams::snc_sso,         false},
+            {"snc_qop",         &RfcAuthParams::snc_qop,         false},
+            {"snc_myname",      &RfcAuthParams::snc_myname,      false},
+            {"snc_partnername", &RfcAuthParams::snc_partnername, false},
+            {"snc_lib",         &RfcAuthParams::snc_lib,         false},
+            {"mysapsso2",       &RfcAuthParams::mysapsso2,       true},
+            {"x509cert",        &RfcAuthParams::x509cert,        true},
+            {"saprouter",       &RfcAuthParams::saprouter,       false},
+            {"gwhost",          &RfcAuthParams::gwhost,          false},
+            {"gwserv",          &RfcAuthParams::gwserv,          false},
+            {"codepage",        &RfcAuthParams::codepage,        false},
+            {"trace",           &RfcAuthParams::trace,           false},
+            {"dest",            &RfcAuthParams::dest,            false},
+        };
+        return definitions;
+    }
+
+    vector<std::pair<std::string, std::string>> RfcAuthParams::BuildConnectionParams() const
+    {
+        vector<std::pair<std::string, std::string>> params;
+        for (auto &definition : RfcAuthParamDefinitions()) {
+            const auto &value = this->*definition.member;
+            if (value.empty()) {
+                continue;
+            }
+            params.emplace_back(definition.name, value);
+        }
+        return params;
+    }
+
     std::string RfcAuthParams::ToString() {
         std::stringstream ss;
-        ss << "ashost=" << ashost;
-        if (!sysnr.empty()) ss << " sysnr=" << sysnr;
-        if (!user.empty()) ss << " user=" << user;
-        if (!password.empty()) ss << " password=***";
-        if (!client.empty()) ss << " client=" << client;
-        if (!lang.empty()) ss << " lang=" << lang;
-        if (!mshost.empty()) ss << " mshost=" << mshost;
-        if (!msserv.empty()) ss << " msserv=" << msserv;
-        if (!sysid.empty()) ss << " sysid=" << sysid;
-        if (!group.empty()) ss << " group=" << group;
-        if (!snc_qop.empty()) ss << " snc_qop=" << snc_qop;
-        if (!snc_myname.empty()) ss << " snc_myname=" << snc_myname;
-        if (!snc_partnername.empty()) ss << " snc_partnername=" << snc_partnername;
-        if (!snc_lib.empty()) ss << " snc_lib=" << snc_lib;
-        if (!mysapsso2.empty()) ss << " mysapsso2=" << mysapsso2;
+        bool first = true;
+        for (auto &definition : RfcAuthParamDefinitions()) {
+            const auto &value = this->*definition.member;
+            if (value.empty()) {
+                continue;
+            }
+            if (!first) {
+                ss << " ";
+            }
+            first = false;
+            ss << definition.name << "=" << (definition.secret ? "***" : value);
+        }
         return ss.str();
     }
 
     std::shared_ptr<RfcConnection> RfcAuthParams::Connect() 
     {
         RFC_ERROR_INFO error_info;
-        RFC_CONNECTION_PARAMETER params[15];
-        size_t param_count = 0; 
 
-        auto ashost = std2uc(this->ashost);
-        if (strlenR(ashost.get()) > 0) {
-            params[param_count].name = cU("ashost");
-            params[param_count].value = ashost.get();
-            param_count++;
-        }
+        // Marshal the parameter list into the SDK's wide-character representation.
+        // `storage` owns the converted strings and must outlive the RfcOpenConnection
+        // call, since RFC_CONNECTION_PARAMETER only holds pointers into it.
+        auto param_list = BuildConnectionParams();
+        std::vector<unique_ptr<SAP_UC, void (*)(void *)>> storage;
+        std::vector<RFC_CONNECTION_PARAMETER> params;
+        storage.reserve(param_list.size() * 2);
+        params.reserve(param_list.size());
 
-        auto sysnr = std2uc(this->sysnr);
-        if (strlenR(sysnr.get()) > 0) {
-            params[param_count].name = cU("sysnr");	
-            params[param_count].value = sysnr.get();
-            param_count++;
-        }
+        for (auto &param : param_list) {
+            storage.push_back(std2uc(param.first));
+            auto name = storage.back().get();
+            storage.push_back(std2uc(param.second));
+            auto value = storage.back().get();
 
-        auto user = std2uc(this->user);
-        if (strlenR(user.get()) > 0) {
-            params[param_count].name = cU("user");	
-            params[param_count].value = user.get();
-            param_count++;
+            RFC_CONNECTION_PARAMETER rfc_param;
+            rfc_param.name = name;
+            rfc_param.value = value;
+            params.push_back(rfc_param);
         }
+        auto param_count = params.size();
 
-        auto password = std2uc(this->password);
-        if (strlenR(password.get()) > 0) {
-            params[param_count].name = cU("passwd");	
-            params[param_count].value = password.get();
-            param_count++;
-        }
-
-        auto client = std2uc(this->client);
-        if (strlenR(client.get()) > 0) {
-            params[param_count].name = cU("client");	
-            params[param_count].value = client.get();
-            param_count++;
-        }
-
-        auto lang = std2uc(this->lang);
-        if (strlenR(lang.get()) > 0) {
-            params[param_count].name = cU("lang");	
-            params[param_count].value = lang.get(); 
-            param_count++;
-        }
-
-        auto mshost = std2uc(this->mshost);
-        if (strlenR(mshost.get()) > 0) {
-            params[param_count].name = cU("mshost");	
-            params[param_count].value = mshost.get();
-            param_count++;
-        }
-
-        auto msserv = std2uc(this->msserv);
-        if (strlenR(msserv.get()) > 0) {
-            params[param_count].name = cU("msserv");	
-            params[param_count].value = msserv.get();
-            param_count++;
-        }
-
-        auto sysid = std2uc(this->sysid);
-        if (strlenR(sysid.get()) > 0) {
-            params[param_count].name = cU("sysid");	
-            params[param_count].value = sysid.get();
-            param_count++;
-        }   
-
-        auto group = std2uc(this->group);
-        if (strlenR(group.get()) > 0) {
-            params[param_count].name = cU("group");	
-            params[param_count].value = group.get();
-            param_count++;
-        }
-
-        auto snc_qop = std2uc(this->snc_qop);
-        if (strlenR(snc_qop.get()) > 0) {
-            params[param_count].name = cU("snc_qop");	
-            params[param_count].value = snc_qop.get();
-            param_count++;
-        }
-        
-        auto snc_myname = std2uc(this->snc_myname);
-        if (strlenR(snc_myname.get()) > 0) {
-            params[param_count].name = cU("snc_myname");	
-            params[param_count].value = snc_myname.get();
-            param_count++;
-        }
-        
-        auto snc_partnername = std2uc(this->snc_partnername);
-        if (strlenR(snc_partnername.get()) > 0) {
-            params[param_count].name = cU("snc_partnername");	
-            params[param_count].value = snc_partnername.get();
-            param_count++;
-        }
-        
-        auto snc_lib = std2uc(this->snc_lib);
-        if (strlenR(snc_lib.get()) > 0) {
-            params[param_count].name = cU("snc_lib");	
-            params[param_count].value = snc_lib.get();
-            param_count++;
-        }
-        
-        auto mysapsso2 = std2uc(this->mysapsso2);
-        if (strlenR(mysapsso2.get()) > 0) {
-            params[param_count].name = cU("mysapsso2");	
-            params[param_count].value = mysapsso2.get();
-            param_count++;
-        }
-        
         // Telemetry: classify the auth method before the round-trip (pure local
         // field checks, no credential material). Emitted only on success below.
         const char *auth = TelemetryAuthKind();
 
-        auto connection_handle = RfcOpenConnection(params, param_count, &error_info);
+        auto connection_handle = RfcOpenConnection(params.data(), param_count, &error_info);
 
         if (connection_handle == NULL) {
             // Telemetry: $exception {error_class (from RFC_RC enum), feature,
@@ -208,7 +183,8 @@ namespace duckdb
         if (!mysapsso2.empty()) {
             return erpl_telemetry::auth_kind::kSso;
         }
-        if (!snc_lib.empty() || !snc_myname.empty() || !snc_partnername.empty()) {
+        if (!snc_mode.empty() || !snc_sso.empty() || !snc_lib.empty() || !snc_myname.empty() ||
+            !snc_partnername.empty() || !snc_qop.empty() || !x509cert.empty()) {
             return erpl_telemetry::auth_kind::kSnc;
         }
         return erpl_telemetry::auth_kind::kBasic;

--- a/rfc/src/sap_secret.cpp
+++ b/rfc/src/sap_secret.cpp
@@ -4,71 +4,54 @@
 #include "sap_secret.hpp"
 #include "sap_connection.hpp"
 
+#include <algorithm>
+
 namespace duckdb {
+
+const vector<string> &SapSecretParameterNames() {
+	static const vector<string> names = []() {
+		vector<string> result;
+		for (auto &definition : RfcAuthParamDefinitions()) {
+			result.emplace_back(definition.name);
+		}
+		return result;
+	}();
+	return names;
+}
 
 unique_ptr<BaseSecret> CreateSapSecretFunction(ClientContext &context, CreateSecretInput &input) {
 	// apply any overridden settings
 	vector<string> prefix_paths;
 	auto result = make_uniq<KeyValueSecret>(prefix_paths, "sap_rfc", "config", input.name);
+	auto &names = SapSecretParameterNames();
 	for (const auto &named_param : input.options) {
 		auto lower_name = StringUtil::Lower(named_param.first);
 
-		if (lower_name == "ashost") {
-			result->secret_map["ashost"] = named_param.second.ToString();
-		} else if (lower_name == "sysnr") {
-			result->secret_map["sysnr"] = named_param.second.ToString();
-		} else if (lower_name == "user") {
-			result->secret_map["user"] = named_param.second.ToString();
-		} else if (lower_name == "passwd") {
-			result->secret_map["passwd"] = named_param.second.ToString();
-		} else if (lower_name == "client") {
-			result->secret_map["client"] = named_param.second.ToString();
-		} else if (lower_name == "lang") {
-			result->secret_map["lang"] = named_param.second.ToString();
-		} else if (lower_name == "mshost") {
-			result->secret_map["mshost"] = named_param.second.ToString();
-		} else if (lower_name == "msserv") {
-			result->secret_map["msserv"] = named_param.second.ToString();
-		} else if (lower_name == "sysid") {
-			result->secret_map["sysid"] = named_param.second.ToString();
-		} else if (lower_name == "group") {
-			result->secret_map["group"] = named_param.second.ToString();
-		} else if (lower_name == "snc_qop") {
-			result->secret_map["snc_qop"] = named_param.second.ToString();
-		} else if (lower_name == "snc_myname")  {
-			result->secret_map["snc_myname"] = named_param.second.ToString();
-		} else if (lower_name == "snc_partnername") {
-			result->secret_map["snc_partnername"] = named_param.second.ToString();
-		} else if (lower_name == "snc_lib") {
-			result->secret_map["snc_lib"] = named_param.second.ToString();
-		} else if (lower_name == "mysapsso2") {
-			result->secret_map["mysapsso2"] = named_param.second.ToString();
-		} else {
-			throw InternalException("Unknown named parameter passed to CreateSapSecretFunction: " + lower_name);
+		if (std::find(names.begin(), names.end(), lower_name) == names.end()) {
+			// Normally unreachable — DuckDB rejects unregistered named parameters
+			// while binding CREATE SECRET — but the two lists are only kept in
+			// sync by RfcAuthParamDefinitions(), so fail on user input, not with
+			// an INTERNAL error.
+			throw InvalidInputException("Unknown parameter '%s' for secret type 'sap_rfc'", lower_name);
 		}
+		result->secret_map[lower_name] = named_param.second.ToString();
 	}
 
-	//! Set redact keys
-	result->redact_keys = {"password"};
+	//! Set redact keys. The key names are the secret map keys, so `passwd` —
+	//! naming the RfcAuthParams member (`password`) here silently disabled
+	//! redaction and printed the password in duckdb_secrets().
+	for (auto &definition : RfcAuthParamDefinitions()) {
+		if (definition.secret) {
+			result->redact_keys.insert(definition.name);
+		}
+	}
 	return std::move(result);
 }
 
 void SetSapSecretParameters(CreateSecretFunction &function) {
-	function.named_parameters["ashost"] = LogicalType::VARCHAR;
-	function.named_parameters["sysnr"] = LogicalType::VARCHAR;
-	function.named_parameters["user"] = LogicalType::VARCHAR;
-	function.named_parameters["passwd"] = LogicalType::VARCHAR;
-	function.named_parameters["client"] = LogicalType::VARCHAR;
-	function.named_parameters["lang"] = LogicalType::VARCHAR;
-	function.named_parameters["mshost"] = LogicalType::VARCHAR;
-	function.named_parameters["msserv"] = LogicalType::VARCHAR;
-	function.named_parameters["sysid"] = LogicalType::VARCHAR;
-	function.named_parameters["group"] = LogicalType::VARCHAR;
-	function.named_parameters["snc_qop"] = LogicalType::VARCHAR;
-	function.named_parameters["snc_myname"] = LogicalType::VARCHAR;
-	function.named_parameters["snc_partnername"] = LogicalType::VARCHAR;
-	function.named_parameters["snc_lib"] = LogicalType::VARCHAR;
-	function.named_parameters["mysapsso2"] = LogicalType::VARCHAR;
+	for (auto &name : SapSecretParameterNames()) {
+		function.named_parameters[name] = LogicalType::VARCHAR;
+	}
 }
 
 void RegisterSapSecretType(ExtensionLoader &loader) 
@@ -86,84 +69,17 @@ void RegisterSapSecretType(ExtensionLoader &loader)
 	loader.RegisterFunction(sap_rfc_secret_function);
 }
 
-RfcAuthParams ConvertSecretToAuthParams(const KeyValueSecret &duck_secret) 
+RfcAuthParams ConvertSecretToAuthParams(const KeyValueSecret &duck_secret)
 {
 	RfcAuthParams auth_params;
 
-    auto ashost_val = duck_secret.TryGetValue("ashost");
-    if (! ashost_val.IsNull()) {
-        auth_params.ashost = ashost_val.ToString();
-    }
-
-    auto sysnr_val = duck_secret.TryGetValue("sysnr");
-    if (! sysnr_val.IsNull()) {
-        auth_params.sysnr = sysnr_val.ToString();
-    }
-
-    auto user_val = duck_secret.TryGetValue("user");
-    if (! user_val.IsNull()) {
-        auth_params.user = user_val.ToString();
-    }
-
-    auto passwd_val = duck_secret.TryGetValue("passwd");
-    if (! passwd_val.IsNull()) {
-        auth_params.password = passwd_val.ToString();
-    }
-
-    auto client_val = duck_secret.TryGetValue("client");
-    if (! client_val.IsNull()) {
-        auth_params.client = client_val.ToString();
-    }
-
-    auto lang_val = duck_secret.TryGetValue("lang");
-    if (! lang_val.IsNull()) {
-        auth_params.lang = lang_val.ToString();
-    }
-
-    auto mshost_val = duck_secret.TryGetValue("mshost");    
-    if (! mshost_val.IsNull()) {
-        auth_params.mshost = mshost_val.ToString();
-    }
-
-    auto msserv_val = duck_secret.TryGetValue("msserv");
-    if (! msserv_val.IsNull()) {
-        auth_params.msserv = msserv_val.ToString();
-    }
-
-    auto sysid_val = duck_secret.TryGetValue("sysid");
-    if (! sysid_val.IsNull()) {
-        auth_params.sysid = sysid_val.ToString();
-    }
-
-    auto group_val = duck_secret.TryGetValue("group");
-    if (! group_val.IsNull()) {
-        auth_params.group = group_val.ToString();
-    }
-
-    auto snc_qop_val = duck_secret.TryGetValue("snc_qop");
-    if (! snc_qop_val.IsNull()) {
-        auth_params.snc_qop = snc_qop_val.ToString();
-    }
-
-    auto snc_myname_val = duck_secret.TryGetValue("snc_myname");
-    if (! snc_myname_val.IsNull()) {
-        auth_params.snc_myname = snc_myname_val.ToString();
-    }
-
-    auto snc_partnername_val = duck_secret.TryGetValue("snc_partnername");
-    if (! snc_partnername_val.IsNull()) {
-        auth_params.snc_partnername = snc_partnername_val.ToString();
-    }
-
-    auto snc_lib_val = duck_secret.TryGetValue("snc_lib");
-    if (! snc_lib_val.IsNull()) {
-        auth_params.snc_lib = snc_lib_val.ToString();
-    }
-
-    auto mysapsso2_val = duck_secret.TryGetValue("mysapsso2");
-    if (! mysapsso2_val.IsNull()) {
-        auth_params.mysapsso2 = mysapsso2_val.ToString();
-    }
+	for (auto &definition : RfcAuthParamDefinitions()) {
+		auto value = duck_secret.TryGetValue(definition.name);
+		if (value.IsNull()) {
+			continue;
+		}
+		auth_params.*definition.member = value.ToString();
+	}
 
 	return auth_params;
 }

--- a/rfc/test/cpp/CMakeLists.txt
+++ b/rfc/test/cpp/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TEST_SOURCES
     test_telemetry.cpp
     test_read_table_batching.cpp
     test_connection_close.cpp
+    test_sap_secret.cpp
     test_select_supported_args.cpp
     test_main.cpp
 )

--- a/rfc/test/cpp/test_sap_secret.cpp
+++ b/rfc/test/cpp/test_sap_secret.cpp
@@ -1,0 +1,144 @@
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "sapnwrfc.h"
+#include "sap_secret.hpp"
+#include "sap_connection.hpp"
+
+#include <algorithm>
+
+using namespace duckdb;
+
+// Issue #98: SNC_MODE (and a handful of other documented RfcOpenConnection
+// parameters) could not be expressed on a `sap_rfc` secret, so the SAP RFC SDK
+// never activated SNC and Kerberos/SNC logon was impossible.
+//
+// These tests cover the parameter mapping end to end *up to* RfcOpenConnection:
+// secret map -> RfcAuthParams -> the name/value list handed to the SDK.  The
+// SNC handshake itself needs an SNC-enabled SAP system and is out of scope
+// here; what is asserted is that every supported parameter survives both hops
+// with its name and value intact.
+
+namespace {
+
+KeyValueSecret MakeSecret(const case_insensitive_map_t<string> &values) {
+	vector<string> prefix_paths;
+	KeyValueSecret secret(prefix_paths, "sap_rfc", "config", "test_secret");
+	for (const auto &kv : values) {
+		secret.secret_map[kv.first] = Value(kv.second);
+	}
+	return secret;
+}
+
+// Looks up a parameter in the list built for RfcOpenConnection.  Returns the
+// value, or a null option when the parameter was not passed at all.
+optional_idx IndexOf(const vector<std::pair<string, string>> &params, const string &name) {
+	for (idx_t i = 0; i < params.size(); i++) {
+		if (params[i].first == name) {
+			return optional_idx(i);
+		}
+	}
+	return optional_idx();
+}
+
+} // namespace
+
+TEST_CASE("SNC parameters survive the secret -> RfcAuthParams hop", "[erpl_rfc][sap_secret]") {
+	auto secret = MakeSecret({{"ashost", "s4.local"},
+	                          {"sysnr", "00"},
+	                          {"client", "100"},
+	                          {"user", "DEMO"},
+	                          {"snc_mode", "1"},
+	                          {"snc_partnername", "p:saps4hsnc@EXAMPLE.LOCAL"},
+	                          {"snc_lib", "/usr/lib/libgsskrb5.so"}});
+
+	auto auth_params = ConvertSecretToAuthParams(secret);
+
+	REQUIRE(auth_params.ashost == "s4.local");
+	REQUIRE(auth_params.user == "DEMO");
+	REQUIRE(auth_params.snc_mode == "1");
+	REQUIRE(auth_params.snc_partnername == "p:saps4hsnc@EXAMPLE.LOCAL");
+	REQUIRE(auth_params.snc_lib == "/usr/lib/libgsskrb5.so");
+	// The issue's central point: SNC logon must work without a password.
+	REQUIRE(auth_params.password.empty());
+}
+
+TEST_CASE("All supported secret keys map onto RfcAuthParams", "[erpl_rfc][sap_secret]") {
+	// Every registered parameter gets a distinct value so a mis-wired mapping
+	// (copy-paste of the wrong member) shows up as a mismatch rather than as
+	// two equal empty strings.
+	case_insensitive_map_t<string> values;
+	for (const auto &key : SapSecretParameterNames()) {
+		values[key] = "v_" + key;
+	}
+	auto auth_params = ConvertSecretToAuthParams(MakeSecret(values));
+
+	auto params = auth_params.BuildConnectionParams();
+	REQUIRE(params.size() == SapSecretParameterNames().size());
+
+	for (const auto &key : SapSecretParameterNames()) {
+		auto idx = IndexOf(params, key);
+		REQUIRE(idx.IsValid());
+		REQUIRE(params[idx.GetIndex()].second == "v_" + key);
+	}
+}
+
+TEST_CASE("The secret exposes the connection parameters issue #98 asks for", "[erpl_rfc][sap_secret]") {
+	const auto &names = SapSecretParameterNames();
+	for (const char *expected : {"snc_mode", "snc_sso", "snc_qop", "snc_myname", "snc_partnername", "snc_lib",
+	                             "x509cert", "saprouter", "gwhost", "gwserv", "codepage", "trace", "dest"}) {
+		INFO("missing parameter: " << expected);
+		REQUIRE(std::find(names.begin(), names.end(), string(expected)) != names.end());
+	}
+}
+
+TEST_CASE("Unset parameters are not passed to RfcOpenConnection", "[erpl_rfc][sap_secret]") {
+	// The SDK treats an empty value as "explicitly empty" for some parameters,
+	// so anything the user did not set must be omitted entirely.
+	auto auth_params = ConvertSecretToAuthParams(MakeSecret({{"ashost", "s4.local"}, {"snc_mode", "1"}}));
+
+	auto params = auth_params.BuildConnectionParams();
+	REQUIRE(params.size() == 2);
+	REQUIRE(IndexOf(params, "ashost").IsValid());
+	REQUIRE(IndexOf(params, "snc_mode").IsValid());
+	REQUIRE_FALSE(IndexOf(params, "passwd").IsValid());
+	REQUIRE_FALSE(IndexOf(params, "snc_lib").IsValid());
+}
+
+TEST_CASE("The password parameter keeps its SDK spelling", "[erpl_rfc][sap_secret]") {
+	// `passwd` is the secret key *and* the RfcOpenConnection parameter name,
+	// while the RfcAuthParams member is called `password` — an easy place to
+	// drop the value on the floor.
+	auto auth_params = ConvertSecretToAuthParams(MakeSecret({{"passwd", "hunter2"}}));
+	REQUIRE(auth_params.password == "hunter2");
+
+	auto params = auth_params.BuildConnectionParams();
+	auto idx = IndexOf(params, "passwd");
+	REQUIRE(idx.IsValid());
+	REQUIRE(params[idx.GetIndex()].second == "hunter2");
+}
+
+TEST_CASE("ToString never leaks the password", "[erpl_rfc][sap_secret]") {
+	auto auth_params = ConvertSecretToAuthParams(
+	    MakeSecret({{"ashost", "s4.local"}, {"passwd", "hunter2"}, {"snc_mode", "1"}}));
+
+	auto rendered = auth_params.ToString();
+	REQUIRE(rendered.find("hunter2") == string::npos);
+	REQUIRE(rendered.find("passwd=***") != string::npos);
+	REQUIRE(rendered.find("snc_mode=1") != string::npos);
+}
+
+TEST_CASE("SNC_MODE alone classifies the connection as SNC for telemetry", "[erpl_rfc][sap_secret]") {
+	// TelemetryAuthKind inspects only the *presence* of credential fields.
+	// Before #98 it could not see snc_mode, so a Kerberos/SNC logon that set
+	// nothing but snc_mode was reported as basic auth.
+	auto snc = ConvertSecretToAuthParams(MakeSecret({{"ashost", "s4.local"}, {"snc_mode", "1"}}));
+	REQUIRE(string(snc.TelemetryAuthKind()) == "snc");
+
+	auto basic = ConvertSecretToAuthParams(MakeSecret({{"ashost", "s4.local"}, {"user", "DEMO"}, {"passwd", "pw"}}));
+	REQUIRE(string(basic.TelemetryAuthKind()) == "basic");
+
+	// An SSO2 ticket still wins over SNC.
+	auto sso = ConvertSecretToAuthParams(MakeSecret({{"mysapsso2", "ticket"}, {"snc_mode", "1"}}));
+	REQUIRE(string(sso.TelemetryAuthKind()) == "sso");
+}

--- a/rfc/test/sql/sap_rfc_secret.test
+++ b/rfc/test/sql/sap_rfc_secret.test
@@ -52,5 +52,20 @@ PRAGMA sap_rfc_ping(secret='correct_secret');
 ----
 PONG
 
+# The `secret` parameter selects a secret by name. It used to be handed to
+# SecretManager::LookupSecret() as a *path*, so the scope matcher could return a
+# completely different sap_rfc secret and the connection silently used the wrong
+# credentials — here, the still-existing wrong_secret must be the one used.
+statement error
+PRAGMA sap_rfc_ping(secret='wrong_secret');
+----
+
+# A name that does not exist must be reported, not silently replaced by whatever
+# other sap_rfc secret happens to be in scope.
+statement error
+PRAGMA sap_rfc_ping(secret='no_such_secret');
+----
+Secret 'no_such_secret' not found
+
 statement ok
-DROP SECRET correct_secret; 
+DROP SECRET correct_secret;

--- a/rfc/test/sql/sap_rfc_secret_params.test
+++ b/rfc/test/sql/sap_rfc_secret_params.test
@@ -1,0 +1,93 @@
+# name: test/sql/rfc/sap_rfc_secret_params.test
+# description: connection parameters accepted by the sap_rfc secret (issue #98)
+# group: [rfc]
+
+# These tests only create and inspect secrets, so they need no SAP system.
+
+require erpl_rfc
+
+# Issue #98: SNC_MODE was rejected at bind time, so the SAP RFC SDK could never
+# activate SNC and Kerberos/SNC logon was impossible. Note there is no PASSWD.
+statement ok
+CREATE SECRET snc_secret (
+    TYPE sap_rfc,
+    ASHOST 's4.local',
+    SYSNR '00',
+    CLIENT '100',
+    USER 'DEMO',
+    SNC_MODE '1',
+    SNC_PARTNERNAME 'p:saps4hsnc@EXAMPLE.LOCAL',
+    SNC_LIB '/usr/lib/libgsskrb5.so'
+);
+
+query I
+SELECT secret_string LIKE '%snc_mode=1%' FROM duckdb_secrets() WHERE name = 'snc_secret';
+----
+true
+
+query I
+SELECT secret_string LIKE '%snc_partnername=p:saps4hsnc@EXAMPLE.LOCAL%'
+FROM duckdb_secrets() WHERE name = 'snc_secret';
+----
+true
+
+statement ok
+DROP SECRET snc_secret;
+
+# ---------------------------------------------------------------------
+# The remaining documented RfcOpenConnection parameters
+
+statement ok
+CREATE SECRET routed_secret (
+    TYPE sap_rfc,
+    ASHOST 's4.local',
+    SYSNR '00',
+    CLIENT '100',
+    USER 'DEMO',
+    SNC_SSO '1',
+    SNC_QOP '9',
+    SNC_MYNAME 'p:CN=DEMO',
+    X509CERT 'MIIB...',
+    SAPROUTER '/H/router.local/S/3299',
+    GWHOST 'gw.local',
+    GWSERV 'sapgw00',
+    CODEPAGE '4103',
+    TRACE '1',
+    DEST 'A4H'
+);
+
+statement ok
+DROP SECRET routed_secret;
+
+# A parameter the SDK does not know must still be rejected, and not with an
+# INTERNAL error.
+statement error
+CREATE SECRET bogus_secret (TYPE sap_rfc, ASHOST 's4.local', NOT_A_PARAMETER 'x');
+----
+
+# ---------------------------------------------------------------------
+# The password must never show up in duckdb_secrets(). The redact list used to
+# name "password" while the stored key is "passwd", so it was printed in clear.
+
+statement ok
+CREATE SECRET redaction_secret (
+    TYPE sap_rfc,
+    ASHOST 's4.local',
+    SYSNR '00',
+    CLIENT '100',
+    USER 'DEMO',
+    PASSWD 'hunter2'
+);
+
+query I
+SELECT secret_string LIKE '%hunter2%' FROM duckdb_secrets() WHERE name = 'redaction_secret';
+----
+false
+
+query I
+SELECT secret_string LIKE '%passwd=redacted%' FROM duckdb_secrets() WHERE name = 'redaction_secret';
+----
+true
+
+statement ok
+DROP SECRET redaction_secret;


### PR DESCRIPTION
Closes #98.

## The problem

`SNC_MODE` was not a registered `sap_rfc` secret parameter, so `CREATE SECRET … SNC_MODE '1'` failed at bind time with `Binder Error: Unknown parameter 'snc_mode'`. Without it the SAP RFC SDK never activates SNC, which makes Kerberos/SNC logon impossible and a password effectively mandatory.

The secret accepted a closed list of 15 parameters, hand-maintained in **four** parallel places — the named-parameter registration, the secret-map if/else chain, the secret → `RfcAuthParams` conversion, and a fixed-size `RFC_CONNECTION_PARAMETER params[15]` whose size exactly matched the parameter count (adding a 16th would have overflowed the stack array).

## The change

`RfcAuthParamDefinitions()` in `rfc/src/sap_connection.cpp` is now the single source of truth; all four sites derive from it, and the SDK parameter array is built as a sized vector. Added on top of the existing SNC parameters: `SNC_MODE`, `SNC_SSO`, `X509CERT`, `SAPROUTER`, `GWHOST`, `GWSERV`, `CODEPAGE`, `TRACE`, `DEST`. A secret without `PASSWD` is valid — SNC and SSO2 logons need none.

```sql
CREATE SECRET s4 (
    TYPE sap_rfc,
    ASHOST 's4.local', SYSNR '00', CLIENT '100', USER 'DEMO',
    SNC_MODE '1',
    SNC_PARTNERNAME 'p:saps4hsnc@EXAMPLE.LOCAL',
    SNC_LIB '/path/to/snc/library'
);
```

### Two defects found on the way, fixed here

- **`secret => '<name>'` selected by scope, not by name.** The name was passed to `SecretManager::LookupSecret()` as a *path*, which matches on secret scopes. With more than one `sap_rfc` secret defined, ERPL could silently connect to a different system than the one named, and a misspelled name resolved to some other secret instead of erroring. Verified live before the fix: `PRAGMA sap_rfc_ping(secret='bogus_host')` on a secret whose `ASHOST` does not resolve returned `PONG`.
- **The password was not redacted** in `duckdb_secrets()` — the redact list named `password` while the stored key is `passwd`. `passwd`, `mysapsso2` and `x509cert` are redacted now.

Telemetry's `auth_kind` also recognises an SNC logon that sets only `SNC_MODE`; it previously reported `basic`.

## Tests (red first, then green)

- `rfc/test/cpp/test_sap_secret.cpp` — new, 7 cases / 82 assertions covering secret → `RfcAuthParams` → the name/value list handed to `RfcOpenConnection`, unset-parameter omission, the `passwd`/`password` naming trap, `ToString()` redaction and the telemetry auth kind. Ran red (no such member / no such function) before the change.
- `rfc/test/sql/sap_rfc_secret_params.test` — new, needs no SAP system. Ran red with the exact symptom from the issue: `Binder Error: Unknown parameter 'snc_mode'`.
- `rfc/test/sql/sap_rfc_secret.test` — extended with the secret-by-name cases. Ran red: `PRAGMA sap_rfc_ping(secret='wrong_secret')` succeeded because the name was ignored.

## Verification against the live ABAP trial

- Full RFC SQL suite: 18/20 pass. The two failures (`sap_rfc_invoke_decimal.test:35`, `sap_read_table.test:116`) are demo-data drift — one extra `SFLIGHT` row, `95 <> 94`. Confirmed pre-existing by rebuilding master's code and reproducing the identical mismatch.
- ODP SQL suite: 23/24, the one failure being an unrelated `recover=true` + `COLUMNS` validation mismatch inside the odp submodule.
- `SNC_MODE '0'` connects normally (`PONG`), so the new parameters reach the SDK without disturbing a password logon.
- `SNC_MODE '1'` makes the SDK genuinely initialize SNC and load the configured library:
  ```
  *** ERROR => SncPDLInit()==SNCERR_INIT, Adapter #1 (/nonexistent/libgssapi.so) not loaded
  IO Error: Error during SAP RFC logon: RFC_COMMUNICATION_FAILURE
  ```
  That code path is unreachable before this change.

**Not verified:** a successful SNC handshake. That needs an SNC-enabled SAP system; the ABAP trial used here has no SNC/GSS configuration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788034450&installation_model_id=425457&pr_number=104&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F104&signature=3364a49ddfe21e342891198cbbd4f5484f3dbd8c045b570f40cab14875af295c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->