### PR TITLE
feat: add a feedback banner to the trampoline

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "third_party/posthog-telemetry"]
 	path = third_party/posthog-telemetry
 	url = git@github.com:DataZooDE/posthog-telemetry.git
+[submodule "datazoo-banner"]
+	path = datazoo-banner
+	url = https://github.com/DataZooDE/duckdb-extension-banner.git

--- a/trampoline/CMakeLists.txt
+++ b/trampoline/CMakeLists.txt
@@ -124,6 +124,13 @@ if(UNIX AND APPLE)
     endforeach()
 endif()
 
+# Feedback banner (header-only). Telemetry OFF: the trampoline does not link
+# posthog-telemetry -- that lives in erpl_rfc, which this extension merely
+# extracts and loads.
+set(DATAZOO_BANNER_TELEMETRY OFF CACHE BOOL "" FORCE)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../datazoo-banner datazoo-banner-build)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../datazoo-banner/include)
+
 include_directories(src/include)
 
 message(STATUS "SAPNWRFC_LIB_OBJECTS: ${SAPNWRFC_LIB_OBJECTS}")

--- a/trampoline/src/erpl_extension.cpp
+++ b/trampoline/src/erpl_extension.cpp
@@ -8,6 +8,7 @@
 #include <locale>
 #include <fstream>
 #include <iostream>
+#include "datazoo_banner_duckdb.hpp"
 
 #ifdef __linux__
 
@@ -91,6 +92,11 @@ extern const unsigned int erpl_odp_duckdb_extension_len;
 
 #endif
 
+
+// Deliberately outside namespace duckdb: the banner library is DuckDB-agnostic
+// (the same header serves erpl-adt and flapi).
+const datazoo::BannerInfo ERPL_BANNER {
+    "erpl", "2026.07.24", "https://github.com/DataZooDE/erpl"};
 
 namespace duckdb 
 {
@@ -561,6 +567,13 @@ static std::string Separator() {
                  << "(The purpose of the extension is to extract dependencies and load the ERPL implementation)" << std::endl;
        ExtractExtensionsAndSapLibs();
        LoadExtensions(loader.GetDatabaseInstance());
+
+       // The banner lives here rather than in erpl_rfc / erpl_bics / erpl_odp:
+       // `LOAD erpl` is what a user types, and those three are implementation
+       // details this trampoline extracts and loads on their behalf. Putting it
+       // in each of them would stack four banners on a single LOAD.
+       datazoo::RegisterBannerOption(loader);
+       datazoo::ShowBanner(ERPL_BANNER);
     }
 
     void ErplExtension::Load(ExtensionLoader &loader) 


### PR DESCRIPTION
ERPL fails against SAP systems, gateways and network setups we cannot reproduce here, so the users who hit a problem are the only ones who can tell us what it was — and almost none of them do.

This is the last of a fleet-wide rollout using the shared [`DataZooDE/duckdb-extension-banner`](https://github.com/DataZooDE/duckdb-extension-banner) submodule, alongside erpl-adt (released), erpl-rev (released), [erpl-tunnel#2](https://github.com/DataZooDE/erpl-tunnel/pull/2), [erpl-idoc#7](https://github.com/DataZooDE/erpl-idoc/pull/7), [erpl-web#56](https://github.com/DataZooDE/erpl-web/pull/56) and the anofox extensions.

## Banner in the trampoline only

`LOAD erpl` is what a user types. `erpl_rfc`, `erpl_bics` and `erpl_odp` are implementation details this extension extracts and loads on their behalf — a banner in each would stack four on a single `LOAD`. The trampoline already prints at load today, which makes it the natural home.

```
┌──────────────────────────────────────────────────────────────────┐
│ erpl 2026.07.24                                                  │
│ Hit a bug or something unexpected? Please tell us --             │
│   https://github.com/DataZooDE/erpl/issues                       │
│ ★ If it saved you time, a star helps others find it.             │
│ (silence this: SET datazoo_banner=false, or DATAZOO_NO_BANNER=1) │
└──────────────────────────────────────────────────────────────────┘
```

## One thing worth knowing

`erpl_tunnel` ships its own banner from its own repo and is loaded by this trampoline, so a user who loads `erpl` may see **two** — one per product, each pointing at its own tracker. That is intended: separate repos, separate issue lists. Both are rate-limited independently to once a day.

No error guards here — the trampoline only extracts and loads; the errors users actually hit come from `erpl_rfc` and friends, which are separate concerns.

## Verified against the built artifact

- Banner appears on an interactive `LOAD`, **absent when output is piped**
- `duckdb` submodule pin untouched
- 24-line diff

One fix worth flagging for reviewers of the other PRs: the banner include initially landed inside `#elif __APPLE__`, so the Linux build could not see it. Auditing all 14 repos for the same fault found two more (anofox-scenario, anofox-forecast, both inside `#ifdef HAS_POSTHOG_TELEMETRY`), now fixed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788625819&installation_model_id=425457&pr_number=105&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F105&signature=6eb72e2508e5a78cf09135f0869dbbf39c819b36665e144259a2fcb81d3fd5fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->