### PR TITLE
test(rfc): cover layout, size boundaries and buffer contracts

### DIFF
--- a/rfc/src/sap_type_conversion.cpp
+++ b/rfc/src/sap_type_conversion.cpp
@@ -165,7 +165,13 @@ namespace duckdb
         if (str.empty()) {
             return Value();
         }
-        return Value::CreateValue(str);
+        // NOTE: Value::CreateValue<std::string>() produces a *BLOB*, not a
+        // VARCHAR (see duckdb/src/common/types/value.cpp).  Building a BLOB
+        // from arbitrary text re-interprets the bytes as a blob literal, so
+        // any non-ASCII byte throws ("Invalid byte encountered in STRING ->
+        // BLOB conversion") and a literal "\x.." sequence would be silently
+        // decoded.  RFCTYPE_STRING is character data — construct a VARCHAR.
+        return Value(str);
     }
 
     /**

--- a/rfc/test/cpp/test_type_conversion.cpp
+++ b/rfc/test/cpp/test_type_conversion.cpp
@@ -21,6 +21,27 @@ TEST_CASE("Test sapuc2duckval with rtrim = 1", "[sap_type_conversion]") {
     REQUIRE(StringValue::Get(result) == "Hello World");
 }
 
+// RFCTYPE_STRING is character data.  Value::CreateValue<std::string>() builds
+// a BLOB, which re-interprets the bytes as a blob literal: non-ASCII throws
+// and a literal "\x.." sequence would be silently decoded.
+TEST_CASE("Test sapuc2duckval yields VARCHAR, not BLOB", "[sap_type_conversion]") {
+    SAP_UC str[] = {'H', 'e', 'l', 'l', 'o', '\0'};
+    Value result = uc2duck(str, 5, false);
+    REQUIRE(result.type().id() == LogicalTypeId::VARCHAR);
+}
+
+TEST_CASE("Test sapuc2duckval with non-ASCII characters", "[sap_type_conversion]") {
+    SAP_UC str[] = {'s', 't', 'r', 'a', 0x00DF, 'e', '\0'};
+    Value result = uc2duck(str, 6, false);
+    REQUIRE(StringValue::Get(result) == "stra\xC3\x9F" "e");
+}
+
+TEST_CASE("Test sapuc2duckval keeps a literal backslash-x sequence", "[sap_type_conversion]") {
+    SAP_UC str[] = {'\\', 'x', '4', '1', '\0'};
+    Value result = uc2duck(str, 4, false);
+    REQUIRE(StringValue::Get(result) == "\\x41");
+}
+
 TEST_CASE("Test sapuc2duckval with len = 0", "[sap_type_conversion]") {
     SAP_UC str[] = {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd', '\0'};
     Value result = uc2duck(str, 0);

--- a/rfc/test/sql/sap_rfc_size_boundaries.test
+++ b/rfc/test/sql/sap_rfc_size_boundaries.test
@@ -1,0 +1,166 @@
+# name: test/sql/sap_rfc_size_boundaries.test
+# description: Length-prefix boundaries for variable-length values.
+#
+#              A value longer than 65535 bytes cannot be described by a 16-bit
+#              length and switches to an extended length form on the wire.
+#              Getting the switch-over wrong desynchronises the stream: the
+#              symptom is a truncated value, a hang, or a protocol error on the
+#              *next* call rather than this one.  Only an ODP test hit this
+#              before, and only by accident.
+#
+#              Each case round-trips a payload through a pure echo and checks
+#              both its length and its content, at 65534/65535/65536 bytes
+#              (either side of the boundary) and at ~100000 bytes (well past
+#              it, where a second extension step would show up).
+# group: [rfc]
+
+require erpl_rfc
+
+require-env ERPL_SAP_ASHOST
+
+require-env ERPL_SAP_SYSNR
+
+require-env ERPL_SAP_USER
+
+require-env ERPL_SAP_PASSWORD
+
+require-env ERPL_SAP_CLIENT
+
+require-env ERPL_SAP_LANG
+
+statement ok
+CREATE SECRET abap_trial (
+    TYPE sap_rfc,
+    ASHOST '${ERPL_SAP_ASHOST}',
+    SYSNR '${ERPL_SAP_SYSNR}',
+    CLIENT '${ERPL_SAP_CLIENT}',
+    USER '${ERPL_SAP_USER}',
+    PASSWD '${ERPL_SAP_PASSWORD}',
+    LANG '${ERPL_SAP_LANG}'
+);
+
+# -------------------------------------------------------------------------
+# 1. STRING just below the 16-bit boundary.  S_APCRFC_STRING is `so = si`.
+#    md5 is compared rather than the text itself so a mangled interior is
+#    caught as well as a wrong length.
+# -------------------------------------------------------------------------
+query TT
+SELECT length(SO)::VARCHAR, (md5(SO) = md5(repeat('x', 65534)))::VARCHAR
+FROM sap_rfc_invoke('S_APCRFC_STRING', {'SI': repeat('x', 65534)}, SECRET='abap_trial');
+----
+65534
+true
+
+# -------------------------------------------------------------------------
+# 2. STRING exactly at the boundary.
+# -------------------------------------------------------------------------
+query TT
+SELECT length(SO)::VARCHAR, (md5(SO) = md5(repeat('x', 65535)))::VARCHAR
+FROM sap_rfc_invoke('S_APCRFC_STRING', {'SI': repeat('x', 65535)}, SECRET='abap_trial');
+----
+65535
+true
+
+# -------------------------------------------------------------------------
+# 3. STRING one past the boundary — the first length that needs the extended
+#    form.
+# -------------------------------------------------------------------------
+query TT
+SELECT length(SO)::VARCHAR, (md5(SO) = md5(repeat('x', 65536)))::VARCHAR
+FROM sap_rfc_invoke('S_APCRFC_STRING', {'SI': repeat('x', 65536)}, SECRET='abap_trial');
+----
+65536
+true
+
+# -------------------------------------------------------------------------
+# 4. STRING well past the boundary.
+# -------------------------------------------------------------------------
+query TT
+SELECT length(SO)::VARCHAR, (md5(SO) = md5(repeat('x', 100000)))::VARCHAR
+FROM sap_rfc_invoke('S_APCRFC_STRING', {'SI': repeat('x', 100000)}, SECRET='abap_trial');
+----
+100000
+true
+
+# -------------------------------------------------------------------------
+# 5. A stream that desynchronised on an oversized value would fail on the
+#    *following* call, so a short round-trip is issued immediately after the
+#    100000-character one to prove the connection is still in step.
+# -------------------------------------------------------------------------
+query T
+SELECT SO FROM sap_rfc_invoke('S_APCRFC_STRING', {'SI': 'still in step'}, SECRET='abap_trial');
+----
+still in step
+
+# -------------------------------------------------------------------------
+# 6-9. The same four sizes for XSTRING, where the unit is bytes rather than
+#      characters.  S_APCRFCXSTRING echoes its CHANGING parameter PARAM into
+#      the export EPARAM.  The payload is 0xBE so a byte lost to a length
+#      miscount cannot be mistaken for padding.
+# -------------------------------------------------------------------------
+query TT
+SELECT octet_length(EPARAM)::VARCHAR, (md5(EPARAM) = md5(repeat('\xBE'::BLOB, 65534)))::VARCHAR
+FROM sap_rfc_invoke('S_APCRFCXSTRING', {
+    'PARAM': repeat('\xBE'::BLOB, 65534),
+    'STRUC': {'F1':'a','X':'\x00'::BLOB},
+    'TABLE': []
+}, SECRET='abap_trial');
+----
+65534
+true
+
+query TT
+SELECT octet_length(EPARAM)::VARCHAR, (md5(EPARAM) = md5(repeat('\xBE'::BLOB, 65535)))::VARCHAR
+FROM sap_rfc_invoke('S_APCRFCXSTRING', {
+    'PARAM': repeat('\xBE'::BLOB, 65535),
+    'STRUC': {'F1':'a','X':'\x00'::BLOB},
+    'TABLE': []
+}, SECRET='abap_trial');
+----
+65535
+true
+
+query TT
+SELECT octet_length(EPARAM)::VARCHAR, (md5(EPARAM) = md5(repeat('\xBE'::BLOB, 65536)))::VARCHAR
+FROM sap_rfc_invoke('S_APCRFCXSTRING', {
+    'PARAM': repeat('\xBE'::BLOB, 65536),
+    'STRUC': {'F1':'a','X':'\x00'::BLOB},
+    'TABLE': []
+}, SECRET='abap_trial');
+----
+65536
+true
+
+query TT
+SELECT octet_length(EPARAM)::VARCHAR, (md5(EPARAM) = md5(repeat('\xBE'::BLOB, 100000)))::VARCHAR
+FROM sap_rfc_invoke('S_APCRFCXSTRING', {
+    'PARAM': repeat('\xBE'::BLOB, 100000),
+    'STRUC': {'F1':'a','X':'\x00'::BLOB},
+    'TABLE': []
+}, SECRET='abap_trial');
+----
+100000
+true
+
+# -------------------------------------------------------------------------
+# 10. Both a large STRING and a large XSTRING inside one structure, with a
+#     scalar on either side.  This is the size boundary and the deep-field
+#     alignment in the same record: I and C must survive two consecutive
+#     oversized components.
+# -------------------------------------------------------------------------
+query TTTT
+SELECT ECHOSTRUCT.I::VARCHAR,
+       ECHOSTRUCT.C,
+       length(ECHOSTRUCT.STR)::VARCHAR,
+       octet_length(ECHOSTRUCT.XSTR)::VARCHAR
+FROM sap_rfc_invoke('STFC_DEEP_STRUCTURE', {'IMPORTSTRUCT': {
+    'I': 2147483647,
+    'C': 'ZZ',
+    'STR': repeat('s', 100000),
+    'XSTR': repeat('\xBE'::BLOB, 70000)
+}}, SECRET='abap_trial');
+----
+2147483647
+ZZ
+100000
+70000

--- a/rfc/test/sql/sap_rfc_struct_layout.test
+++ b/rfc/test/sql/sap_rfc_struct_layout.test
@@ -1,0 +1,265 @@
+# name: test/sql/sap_rfc_struct_layout.test
+# description: Structure field alignment — the fields *after* a nested STRING
+#              must still round-trip.
+#
+#              A deep (variable-length) component inside an otherwise flat
+#              structure is 8-byte aligned on the wire, so every field that
+#              follows it sits at an offset that depends on where the deep
+#              component ends.  Getting that wrong moves the following fields
+#              by 4-8 bytes; the call still succeeds and the values are still
+#              of the right DuckDB type, so a typeof()-only test sees nothing.
+#
+#              The tests below vary only the length of the deep component and
+#              assert that the neighbouring scalars are unchanged.  Lengths 7,
+#              8 and 9 straddle the 8-byte boundary in both directions.
+# group: [rfc]
+
+require erpl_rfc
+
+require-env ERPL_SAP_ASHOST
+
+require-env ERPL_SAP_SYSNR
+
+require-env ERPL_SAP_USER
+
+require-env ERPL_SAP_PASSWORD
+
+require-env ERPL_SAP_CLIENT
+
+require-env ERPL_SAP_LANG
+
+statement ok
+CREATE SECRET abap_trial (
+    TYPE sap_rfc,
+    ASHOST '${ERPL_SAP_ASHOST}',
+    SYSNR '${ERPL_SAP_SYSNR}',
+    CLIENT '${ERPL_SAP_CLIENT}',
+    USER '${ERPL_SAP_USER}',
+    PASSWD '${ERPL_SAP_PASSWORD}',
+    LANG '${ERPL_SAP_LANG}'
+);
+
+# -------------------------------------------------------------------------
+# 1. STFC_DEEP_STRUCTURE — STFCCPLXT is (I, C, STR, XSTR): an INT and a CHAR,
+#    then a STRING, then an XSTRING.  The XSTRING follows the STRING, so it is
+#    the field whose offset moves if the STRING is mis-sized.
+#
+#    STR is empty here; an empty ABAP STRING surfaces as NULL.
+# -------------------------------------------------------------------------
+query TTTT
+SELECT ECHOSTRUCT.I::VARCHAR,
+       ECHOSTRUCT.C,
+       coalesce(length(ECHOSTRUCT.STR)::VARCHAR, '<initial>'),
+       hex(ECHOSTRUCT.XSTR)
+FROM sap_rfc_invoke('STFC_DEEP_STRUCTURE', {'IMPORTSTRUCT': {
+    'I': -2147483648, 'C': 'ZY', 'STR': '', 'XSTR': '\x00\xFF\xBE'::BLOB
+}}, SECRET='abap_trial');
+----
+-2147483648
+ZY
+<initial>
+00FFBE
+
+# -------------------------------------------------------------------------
+# 2. …one character before the 8-byte boundary.
+# -------------------------------------------------------------------------
+query TTTT
+SELECT ECHOSTRUCT.I::VARCHAR,
+       ECHOSTRUCT.C,
+       length(ECHOSTRUCT.STR)::VARCHAR,
+       hex(ECHOSTRUCT.XSTR)
+FROM sap_rfc_invoke('STFC_DEEP_STRUCTURE', {'IMPORTSTRUCT': {
+    'I': -2147483648, 'C': 'ZY', 'STR': repeat('s', 7), 'XSTR': '\x00\xFF\xBE'::BLOB
+}}, SECRET='abap_trial');
+----
+-2147483648
+ZY
+7
+00FFBE
+
+# -------------------------------------------------------------------------
+# 3. …exactly on the boundary.
+# -------------------------------------------------------------------------
+query TTTT
+SELECT ECHOSTRUCT.I::VARCHAR,
+       ECHOSTRUCT.C,
+       length(ECHOSTRUCT.STR)::VARCHAR,
+       hex(ECHOSTRUCT.XSTR)
+FROM sap_rfc_invoke('STFC_DEEP_STRUCTURE', {'IMPORTSTRUCT': {
+    'I': -2147483648, 'C': 'ZY', 'STR': repeat('s', 8), 'XSTR': '\x00\xFF\xBE'::BLOB
+}}, SECRET='abap_trial');
+----
+-2147483648
+ZY
+8
+00FFBE
+
+# -------------------------------------------------------------------------
+# 4. …one character past it.
+# -------------------------------------------------------------------------
+query TTTT
+SELECT ECHOSTRUCT.I::VARCHAR,
+       ECHOSTRUCT.C,
+       length(ECHOSTRUCT.STR)::VARCHAR,
+       hex(ECHOSTRUCT.XSTR)
+FROM sap_rfc_invoke('STFC_DEEP_STRUCTURE', {'IMPORTSTRUCT': {
+    'I': -2147483648, 'C': 'ZY', 'STR': repeat('s', 9), 'XSTR': '\x00\xFF\xBE'::BLOB
+}}, SECRET='abap_trial');
+----
+-2147483648
+ZY
+9
+00FFBE
+
+# -------------------------------------------------------------------------
+# 5. SAPCRFC_STRU_ALLTYPES has a STRING as its *second* field, so eighteen
+#    scalars of assorted widths follow the deep component.  Send a STRING that
+#    lands on the 8-byte boundary and assert the fields behind it.
+# -------------------------------------------------------------------------
+query TTTTTTTTT
+SELECT length(O.STRING)::VARCHAR,
+       O.INT1::VARCHAR,
+       O.INT2::VARCHAR,
+       O.INT4::VARCHAR,
+       O.INT8::VARCHAR,
+       O.DEC::VARCHAR,
+       O.DATE::VARCHAR,
+       O.CHAR2,
+       O.NUMC3
+FROM sap_rfc_invoke('S_APCRFC_ECHO', {'I': {
+    'CHAR10':'ABCD',
+    'STRING':repeat('s', 8),
+    'INT1':123::TINYINT,
+    'INT2':32123::SMALLINT,
+    'INT4':-2147483123,
+    'INT8':9223372036854775123::BIGINT,
+    'DEC':(-123456789)::DECIMAL(25,0),
+    'DATE':'2013-12-11'::DATE,
+    'CHAR2':'AB',
+    'NUMC3':'3'
+}}, SECRET='abap_trial');
+----
+8
+123
+32123
+-2147483123
+9223372036854775123
+-123456789
+2013-12-11
+AB
+003
+
+# -------------------------------------------------------------------------
+# 6. …the same structure with the deep component one character shorter.  The
+#    trailing scalars must be identical to case 5.
+# -------------------------------------------------------------------------
+query TTTTTTTTT
+SELECT length(O.STRING)::VARCHAR,
+       O.INT1::VARCHAR,
+       O.INT2::VARCHAR,
+       O.INT4::VARCHAR,
+       O.INT8::VARCHAR,
+       O.DEC::VARCHAR,
+       O.DATE::VARCHAR,
+       O.CHAR2,
+       O.NUMC3
+FROM sap_rfc_invoke('S_APCRFC_ECHO', {'I': {
+    'CHAR10':'ABCD',
+    'STRING':repeat('s', 7),
+    'INT1':123::TINYINT,
+    'INT2':32123::SMALLINT,
+    'INT4':-2147483123,
+    'INT8':9223372036854775123::BIGINT,
+    'DEC':(-123456789)::DECIMAL(25,0),
+    'DATE':'2013-12-11'::DATE,
+    'CHAR2':'AB',
+    'NUMC3':'3'
+}}, SECRET='abap_trial');
+----
+7
+123
+32123
+-2147483123
+9223372036854775123
+-123456789
+2013-12-11
+AB
+003
+
+# -------------------------------------------------------------------------
+# 7. …and with the deep component carrying multi-byte characters, so its
+#    character count and its byte count differ.  A layout that sizes the
+#    following fields from the wrong one of the two drifts here.
+# -------------------------------------------------------------------------
+query TTTTTTTTT
+SELECT O.STRING,
+       O.INT1::VARCHAR,
+       O.INT2::VARCHAR,
+       O.INT4::VARCHAR,
+       O.INT8::VARCHAR,
+       O.DEC::VARCHAR,
+       O.DATE::VARCHAR,
+       O.CHAR2,
+       O.NUMC3
+FROM sap_rfc_invoke('S_APCRFC_ECHO', {'I': {
+    'CHAR10':'ABCD',
+    'STRING':'straße 東京',
+    'INT1':123::TINYINT,
+    'INT2':32123::SMALLINT,
+    'INT4':-2147483123,
+    'INT8':9223372036854775123::BIGINT,
+    'DEC':(-123456789)::DECIMAL(25,0),
+    'DATE':'2013-12-11'::DATE,
+    'CHAR2':'AB',
+    'NUMC3':'3'
+}}, SECRET='abap_trial');
+----
+straße 東京
+123
+32123
+-2147483123
+9223372036854775123
+-123456789
+2013-12-11
+AB
+003
+
+# -------------------------------------------------------------------------
+# 8. S_APCRFC_ALIGNMENT — SAP's own alignment fixtures.  SAPCRFC_ALIGNMENT1 is
+#    (CHAR, INT4, RAW, INT2) and SAPCRFC_ALIGNMENT2 appends an INT1, which
+#    changes the structure's internal padding.  The server rejects the row if
+#    any field does not carry its expected value, and appends a copy of the
+#    last row it read — so two identical rows come back only if the layout is
+#    right in both directions.
+# -------------------------------------------------------------------------
+query TTTT
+SELECT F1, F2::VARCHAR, hex(F3), F4::VARCHAR
+FROM sap_rfc_invoke('S_APCRFC_ALIGNMENT', {'TAB1': [
+    {'F1':'ABCD','F2':4711,'F3':'\xA1'::BLOB,'F4':42::SMALLINT}
+]}, SECRET='abap_trial', path='/TAB1');
+----
+ABCD
+4711
+A1
+42
+ABCD
+4711
+A1
+42
+
+query TTTTT
+SELECT F1, F2::VARCHAR, hex(F3), F4::VARCHAR, T1::VARCHAR
+FROM sap_rfc_invoke('S_APCRFC_ALIGNMENT', {'TAB2': [
+    {'F1':'ABCD','F2':4711,'F3':'\xA1'::BLOB,'F4':42::SMALLINT,'T1':7::TINYINT}
+]}, SECRET='abap_trial', path='/TAB2');
+----
+ABCD
+4711
+A100
+42
+7
+ABCD
+4711
+A100
+42
+7

--- a/rfc/test/sql/sap_rfc_type_matrix.test
+++ b/rfc/test/sql/sap_rfc_type_matrix.test
@@ -1,0 +1,314 @@
+# name: test/sql/sap_rfc_type_matrix.test
+# description: Exact-value round-trip of every ABAP scalar type through the
+#              RFC layer, including boundary values.
+#
+#              sap_rfc_type_coverage.test asserts typeof() only, so a
+#              correctly-typed *wrong number* passes it.  This file asserts the
+#              value itself.  The vehicle is S_APCRFC_ECHO from SAP's own RFC
+#              verification function group S_APCRFC (`o = i`, a pure echo of
+#              SAPCRFC_STRU_ALLTYPES which carries one field of every ABAP
+#              type).  Because the server does nothing but copy the structure,
+#              any difference between what we send and what we get back is a
+#              defect in our marshalling.
+#
+#              Defect classes covered here:
+#                * scalar values decoded with the wrong type code
+#                  (e.g. a DECFLOAT34 read as a decimal64 — a plausible wrong
+#                  number, not an error)
+#                * integer boundaries at the limits of INT1/2/4/8
+#                * fixed-width CHAR/RAW buffer contracts (trailing content)
+#                * RFC_DATE being exactly 8 characters and RFC_TIME exactly 6
+#                * non-Latin-1 text in a variable-length STRING
+# group: [rfc]
+
+require erpl_rfc
+
+require-env ERPL_SAP_ASHOST
+
+require-env ERPL_SAP_SYSNR
+
+require-env ERPL_SAP_USER
+
+require-env ERPL_SAP_PASSWORD
+
+require-env ERPL_SAP_CLIENT
+
+require-env ERPL_SAP_LANG
+
+statement ok
+CREATE SECRET abap_trial (
+    TYPE sap_rfc,
+    ASHOST '${ERPL_SAP_ASHOST}',
+    SYSNR '${ERPL_SAP_SYSNR}',
+    CLIENT '${ERPL_SAP_CLIENT}',
+    USER '${ERPL_SAP_USER}',
+    PASSWD '${ERPL_SAP_PASSWORD}',
+    LANG '${ERPL_SAP_LANG}'
+);
+
+# -------------------------------------------------------------------------
+# 1. Canonical round-trip — every field of SAPCRFC_STRU_ALLTYPES at once.
+#
+# Every value is compared as VARCHAR so the assertion is on the exact digits,
+# not on a rounded floating-point rendering.
+# -------------------------------------------------------------------------
+query TTTTTTTTTTTTTTTT
+SELECT O.CHAR10,
+       O.STRING,
+       O.INT1::VARCHAR,
+       O.INT2::VARCHAR,
+       O.INT4::VARCHAR,
+       O.INT8::VARCHAR,
+       O.FLOAT::VARCHAR,
+       O.DEC::VARCHAR,
+       O.DECFLOAT16::VARCHAR,
+       O.DECFLOAT34::VARCHAR,
+       O.NUMC,
+       O.DATE::VARCHAR,
+       O.TIME::VARCHAR,
+       O.CHAR2,
+       O.NUMC2,
+       O.NUMC3
+FROM sap_rfc_invoke('S_APCRFC_ECHO', {'I': {
+    'CHAR10':'ABCD',
+    'STRING':'straße 東京',
+    'INT1':123::TINYINT,
+    'INT2':32123::SMALLINT,
+    'INT4':-2147483123,
+    'INT8':9223372036854775123::BIGINT,
+    'FLOAT':1.5::DOUBLE,
+    'DEC':(-123456789)::DECIMAL(25,0),
+    'RAW':'\x00\xFF\xBE'::BLOB,
+    'XSTRING':'\x00\xFF\xBE\xEF'::BLOB,
+    'DECFLOAT16':9999999999999999::DECIMAL(16,0),
+    'DECFLOAT34':'9999999999999999999999999999999999'::DECIMAL(34,0),
+    'NUMC':'1234567890',
+    'DATE':'2013-12-11'::DATE,
+    'TIME':'23:59:59'::TIME,
+    'CHAR2':'AB',
+    'NUMC2':'12',
+    'NUMC3':'3'
+}}, SECRET='abap_trial');
+----
+ABCD
+straße 東京
+123
+32123
+-2147483123
+9223372036854775123
+1.5
+-123456789
+9999999999999999
+9999999999999999999999999999999999
+1234567890
+2013-12-11
+23:59:59
+AB
+0000000012
+003
+
+# -------------------------------------------------------------------------
+# 2. Integer, decimal and float boundaries.
+#
+# INT2/INT4/INT8 at their negative limit, DEC at the full 25-digit width of
+# DEC_25 and DECFLOAT16/34 at their full significand width, negative.  A
+# sign-handling or width bug shows up as a plausible wrong number here, which
+# is exactly what a typeof()-only assertion cannot see.
+#
+# NOTE ON INT1: ABAP INT1 is unsigned 0..255 but is surfaced as a DuckDB
+# TINYINT (signed -128..127), so only 0..127 is reachable from SQL.  0 is
+# asserted below; 128..255 is out of scope for this file.
+# -------------------------------------------------------------------------
+query TTTTTTTT
+SELECT O.INT1::VARCHAR,
+       O.INT2::VARCHAR,
+       O.INT4::VARCHAR,
+       O.INT8::VARCHAR,
+       O.FLOAT::VARCHAR,
+       O.DEC::VARCHAR,
+       O.DECFLOAT16::VARCHAR,
+       O.DECFLOAT34::VARCHAR
+FROM sap_rfc_invoke('S_APCRFC_ECHO', {'I': {
+    'INT1':0::TINYINT,
+    'INT2':(-32768)::SMALLINT,
+    'INT4':-2147483648,
+    'INT8':(-9223372036854775808)::BIGINT,
+    'FLOAT':(-1.7976931348623157e308)::DOUBLE,
+    'DEC':'-1234567890123456789012345'::DECIMAL(25,0),
+    'DECFLOAT16':(-9999999999999999)::DECIMAL(16,0),
+    'DECFLOAT34':'-9999999999999999999999999999999999'::DECIMAL(34,0)
+}}, SECRET='abap_trial');
+----
+0
+-32768
+-2147483648
+-9223372036854775808
+-1.7976931348623157e+308
+-1234567890123456789012345
+-9999999999999999
+-9999999999999999999999999999999999
+
+# -------------------------------------------------------------------------
+# 3. DECFLOAT16 vs DECFLOAT34 must not be confused.
+#
+# The two share a decoder shape and differ only in width (8 vs 16 bytes).
+# Swapping the type codes decodes a DECFLOAT34 as a decimal64: a plausible
+# wrong number rather than an error.  The DECFLOAT34 value below needs 34
+# significant digits, so it cannot survive a decimal64 decode intact.
+# -------------------------------------------------------------------------
+query TT
+SELECT O.DECFLOAT16::VARCHAR, O.DECFLOAT34::VARCHAR
+FROM sap_rfc_invoke('S_APCRFC_ECHO', {'I': {
+    'DECFLOAT16':1234567890123456::DECIMAL(16,0),
+    'DECFLOAT34':'1234567890123456789012345678901234'::DECIMAL(34,0)
+}}, SECRET='abap_trial');
+----
+1234567890123456
+1234567890123456789012345678901234
+
+# -------------------------------------------------------------------------
+# 4. RFC_DATE is exactly 8 characters, RFC_TIME exactly 6.
+#
+# An off-by-one in either buffer shifts the digits, so a year at each end of
+# the range plus the last representable second are asserted verbatim.
+#
+# ABAP-initial DATS ('00000000') and TIMS ('000000') surface as NULL: DATE
+# and TIME_ILL below are left unsupplied, and TIME is sent as 00:00:00.
+# -------------------------------------------------------------------------
+query TTTT
+SELECT O.DATE::VARCHAR,
+       O.DATE_ILL::VARCHAR,
+       coalesce(O.TIME::VARCHAR, '<initial>'),
+       O.TIME_ILL::VARCHAR
+FROM sap_rfc_invoke('S_APCRFC_ECHO', {'I': {
+    'DATE':'0001-01-01'::DATE,
+    'DATE_ILL':'9999-12-31'::DATE,
+    'TIME':'00:00:00'::TIME,
+    'TIME_ILL':'23:59:59'::TIME
+}}, SECRET='abap_trial');
+----
+0001-01-01
+9999-12-31
+<initial>
+23:59:59
+
+# -------------------------------------------------------------------------
+# 5. Fixed-width CHAR: trailing content.
+#
+# CHAR10 is a DDIC CHAR(10).  A value shorter than the field must come back as
+# exactly the value — no uninitialised tail.  An unpadded read of the SDK
+# buffer keeps the right prefix and picks up whatever follows it, so both the
+# exact text and its length are asserted.  '0UNIT' is the literal shape of a
+# real defect of this kind.
+# -------------------------------------------------------------------------
+query TTTT
+SELECT '[' || O.CHAR10 || ']',
+       length(O.CHAR10)::VARCHAR,
+       '[' || O.CHAR2 || ']',
+       length(O.CHAR2)::VARCHAR
+FROM sap_rfc_invoke('S_APCRFC_ECHO', {'I': {
+    'CHAR10':'0UNIT',
+    'CHAR2':'ÄÖ'
+}}, SECRET='abap_trial');
+----
+[0UNIT]
+5
+[ÄÖ]
+2
+
+# -------------------------------------------------------------------------
+# 6. Fixed-width CHAR filled to its full DDIC width, non-Latin-1.
+#
+# S_APCRFC_UTF16 exports a CHAR(10) holding exactly ten non-ASCII characters.
+# The field is full, so nothing can be hidden by a trailing-blank trim: the
+# result must be ten characters, not ten bytes and not five.
+# -------------------------------------------------------------------------
+query TT
+SELECT TOLONG, length(TOLONG)::VARCHAR
+FROM sap_rfc_invoke('S_APCRFC_UTF16', SECRET='abap_trial');
+----
+ÄÖÜÄÖÜÄÖÜÄ
+10
+
+# -------------------------------------------------------------------------
+# 7. Fixed-width RAW: high bytes and the zero-padded tail.
+#
+# RAW in SAPCRFC_STRU_ALLTYPES is a RAW(25).  A three-byte payload containing
+# 0x00, 0xFF and 0xBE must round-trip and the field must come back at its full
+# declared width, zero-padded — a short read here is the byte-oriented twin of
+# the CHAR case above.
+# -------------------------------------------------------------------------
+query TT
+SELECT octet_length(O.RAW)::VARCHAR, hex(O.RAW)
+FROM sap_rfc_invoke('S_APCRFC_ECHO', {'I': {
+    'RAW':'\x00\xFF\xBE'::BLOB
+}}, SECRET='abap_trial');
+----
+25
+00FFBE00000000000000000000000000000000000000000000
+
+# -------------------------------------------------------------------------
+# 8. Variable-length XSTRING: high bytes, exact length, no padding.
+# -------------------------------------------------------------------------
+query TT
+SELECT octet_length(O.XSTRING)::VARCHAR, hex(O.XSTRING)
+FROM sap_rfc_invoke('S_APCRFC_ECHO', {'I': {
+    'XSTRING':'\x00\xFF\xBE\xEF'::BLOB
+}}, SECRET='abap_trial');
+----
+4
+00FFBEEF
+
+# -------------------------------------------------------------------------
+# 9. NUMC is right-aligned and zero-padded to its DDIC width by the server.
+#
+# NUMC2 is a NUMC(10); sending '12' must come back as '0000000012', and NUMC3
+# is a NUMC(3) so '3' becomes '003'.  Getting the field width wrong shifts the
+# digits and silently changes the number.
+# -------------------------------------------------------------------------
+query TTTT
+SELECT O.NUMC2, length(O.NUMC2)::VARCHAR, O.NUMC3, length(O.NUMC3)::VARCHAR
+FROM sap_rfc_invoke('S_APCRFC_ECHO', {'I': {
+    'NUMC2':'12',
+    'NUMC3':'3'
+}}, SECRET='abap_trial');
+----
+0000000012
+10
+003
+3
+
+# -------------------------------------------------------------------------
+# 10. Packed decimals with a scale, including a negative and the full
+#     31-digit width of a DEC(31,2).
+#
+# S_APCRFC_PACKED verifies the packed values it receives on the server side
+# and then adds 1 to P_4, so the returned 13.3456 proves the server decoded
+# 12.3456 exactly; MAX/MAX1 exercise the widest packed field, which does not
+# fit a 64-bit integer.
+# -------------------------------------------------------------------------
+query TTTTTT
+SELECT P.P_2::VARCHAR,
+       P.P_4::VARCHAR,
+       P.I::VARCHAR,
+       P.DF::VARCHAR,
+       P.MAX::VARCHAR,
+       P.MAX1::VARCHAR
+FROM sap_rfc_invoke('S_APCRFC_PACKED', {'P': {
+    'P_2': (-1234.56)::DECIMAL(11,2),
+    'P_4': 12.3456::DECIMAL(11,4),
+    'I': 123456,
+    'DF': (-12.3456)::DECIMAL(16,14),
+    'PU': 0::DECIMAL(9,2),
+    'EMPTY': 0::DECIMAL(13,2),
+    'SIMPLE': 0::DECIMAL(13,0),
+    'MAX': '12345678901234567890123456789.12'::DECIMAL(31,2),
+    'MAX1': '1234567890123456789012345678.91'::DECIMAL(31,2)
+}}, SECRET='abap_trial');
+----
+-1234.56
+13.3456
+123456
+-12.34560000000000
+12345678901234567890123456789.12
+1234567890123456789012345678.91


### PR DESCRIPTION
## Why

The RFC SQL suite asserted *scalar parameter values* and `typeof()`. That leaves three defect classes invisible, all of which produce a plausible wrong answer rather than an error:

1. **Structure field alignment.** A deep (variable-length) component inside an otherwise flat structure is 8-byte aligned, so every field after it sits at an offset that depends on where the deep component ends. Getting that wrong moves the following fields by 4-8 bytes — the call still succeeds and the values are still of the right DuckDB type.
2. **The 16-bit length boundary.** A value longer than 65535 bytes needs an extended length form on the wire. Getting it wrong desynchronises the stream, and the symptom lands on the *next* call. Only an ODP test hit this before, by accident.
3. **Fixed-width buffer contracts.** A `CHAR(n)`/`RAW(n)` field must come back at its declared width. An unpadded read keeps the right prefix and picks up whatever follows it — the value looks like `0UNIT` followed by poison bytes.

These were found by running this suite against an independent RFC library implementation. The suite caught every defect about scalar values and missed every one of the above.

## What each test covers

| File | Defect class |
|---|---|
| `rfc/test/sql/sap_rfc_type_matrix.test` | Exact-value round-trip of every ABAP scalar. INT1/2/4/8 at their limits; DECFLOAT16 and DECFLOAT34 at full significand width (swapping the two type codes decodes a DECFLOAT34 as a decimal64 — a plausible wrong number, not an error); packed decimals with scale and a negative, up to `DEC(31,2)`; RAW and XSTRING carrying `0x00`/`0xFF`/`0xBE`; `RFC_DATE` at both ends of its 8-character range and `RFC_TIME` at `23:59:59`; NUMC zero-padding; fixed-width CHAR asserted by both exact text *and* `length()`, since an uninitialised tail has the right prefix and the wrong length; a `STRING` holding `straße 東京`. `sap_rfc_type_coverage.test` asserts `typeof()` only, so a correctly-typed wrong number passes it today. |
| `rfc/test/sql/sap_rfc_struct_layout.test` | Alignment drift. Varies *only* the length of the deep component (0/7/8/9 characters, straddling the 8-byte boundary in both directions) and asserts the neighbouring scalars are unchanged — via `STFC_DEEP_STRUCTURE` (`I`, `C`, `STR`, `XSTR`: a STRING in the middle) and via `SAPCRFC_STRU_ALLTYPES`, which has a STRING as its second field and eighteen scalars behind it. Adds SAP's own `SAPCRFC_ALIGNMENT1`/`2` fixtures, which differ by a trailing INT1 and therefore by their internal padding. |
| `rfc/test/sql/sap_rfc_size_boundaries.test` | STRING and XSTRING at 65534, 65535, 65536 and 100000, checked for both length and content (md5), plus a short call issued straight after the largest one to prove the stream is still in step. |

The vehicle throughout is SAP's own RFC verification function group `S_APCRFC` (present on an ABAP Platform Trial): `S_APCRFC_ECHO` is a pure `o = i` echo of a structure carrying one field of every ABAP type, so any difference between what is sent and what comes back is a marshalling defect. Each file is small and independently runnable.

## Drive-by fix

`uc2duck()` built `RFCTYPE_STRING` values with `Value::CreateValue<std::string>()`, which returns a **BLOB**, not a VARCHAR. Building a BLOB from text re-interprets the bytes as a blob literal, so any non-ASCII character threw

```
Invalid byte encountered in STRING -> BLOB conversion of string "straße 東京"
```

and a literal `\x..` sequence coming back from SAP would have been silently decoded. Any ABAP `STRING` containing a non-ASCII character was unreadable. Fixed to construct a VARCHAR, with C++ regression tests.

## Verification

Everything below ran against the SAP NetWeaver RFC SDK (`LD_LIBRARY_PATH=../nwrfcsdk/linux/lib`) on an ABAP Platform Trial 7.58.

```
$ ../build/debug/test/unittest --test-dir . "test/sql/*"
[23/23] (100%): test/sql/sap_read_table.test
All tests passed (535 assertions in 23 test cases)
```

The three new files individually: 51, 62 and 22 assertions, all passing. C++ unit tests: 111 assertions in 51 test cases, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789196044&installation_model_id=425457&pr_number=106&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F106&signature=8d037ff607fbc6386b217369dde72f46a668d789fa97f58d76b94fbe8eda7e9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->