### PR TITLE
fix: harden non-ascii text handling against STRING -> BLOB conversion (#107)

### DIFF
--- a/rfc/src/duckdb_argument_helper.cpp
+++ b/rfc/src/duckdb_argument_helper.cpp
@@ -196,8 +196,11 @@ namespace duckdb
         if (list_values.size() > 0)
         {
             auto current_type = list_values[0].type();
-            auto casted_type = new_value.DefaultCastAs(current_type);
-            list_values.push_back(new_value);
+            // Push the converted value. The cast used to go into a throw-away
+            // local while the uncast value was pushed; Value::LIST below then
+            // cast it to the same type anyway, so this is a dead-store cleanup
+            // rather than a behaviour change.
+            list_values.push_back(new_value.DefaultCastAs(current_type));
         }
         else
         {

--- a/rfc/src/duckdb_serialization_helper.cpp
+++ b/rfc/src/duckdb_serialization_helper.cpp
@@ -335,6 +335,13 @@ namespace duckdb
         auto data = std::string(size, ' ');
         
         Blob::FromBase64(base64, data_ptr_cast(data.data()), size);
+        // Value::BLOB (not BLOB_RAW) is deliberate and pairs with
+        // SerializeBlobJson, which base64-encodes Value::ToString() — i.e. the
+        // "\xAB"-escaped rendering, which is always pure ASCII. Value::BLOB
+        // parses those escapes back into the original bytes. Using BLOB_RAW
+        // here would keep the backslash-x text as literal content and corrupt
+        // every non-ASCII byte (issue #107 proposed exactly that; the
+        // round-trip test below pins the invariant down).
         return Value::BLOB(data);
     }
 

--- a/rfc/test/cpp/test_serialization_helper.cpp
+++ b/rfc/test/cpp/test_serialization_helper.cpp
@@ -167,6 +167,43 @@ TEST_CASE("DeserializeJson blob type", "[duckdb_serialization_helper]")
     REQUIRE(val.GetValue<string>() == "TEST");
 }
 
+TEST_CASE("Blob with non-ascii bytes survives a JSON round-trip (issue #107)",
+          "[duckdb_serialization_helper]")
+{
+    // "Crédit Agricole SA" in UTF-8 — 0xC3 0xA9 is the 'e' with acute accent.
+    // SerializeBlobJson base64-encodes Value::ToString() (the "\xAB"-escaped,
+    // always-ASCII rendering) and DeserializeJsonBlob feeds that back through
+    // Value::BLOB, which parses the escapes. The two must stay paired: swapping
+    // either side for a raw-bytes variant silently corrupts non-ASCII payloads.
+    const string raw = "Cr\xC3\xA9" "dit Agricole SA";
+
+    auto json = ErplSerializer::SerializeJson(Value::BLOB_RAW(raw), true);
+    Value val;
+    REQUIRE_NOTHROW(val = ErplSerializer::DeserializeJson(json));
+    REQUIRE(val.type().id() == LogicalTypeId::BLOB);
+    // StringValue::Get returns the stored bytes; GetValue<string>() would return
+    // the "\xC3\xA9"-escaped rendering instead.
+    REQUIRE(StringValue::Get(val) == raw);
+}
+
+TEST_CASE("Serializer keeps non-ascii text as VARCHAR, never BLOB (issue #107)",
+          "[duckdb_serialization_helper]")
+{
+    // Guard against the Value::CreateValue(std::string) footgun: that overload
+    // resolves to Value::BLOB(const string &), so any std::string carrying
+    // non-ASCII text would abort instead of becoming a VARCHAR.
+    const string text = "Cr\xC3\xA9" "dit Agricole SA";
+
+    auto val = Value(text);
+    REQUIRE(val.type().id() == LogicalTypeId::VARCHAR);
+
+    auto json = ErplSerializer::SerializeJson(val, true);
+    Value round_tripped;
+    REQUIRE_NOTHROW(round_tripped = ErplSerializer::DeserializeJson(json));
+    REQUIRE(round_tripped.type().id() == LogicalTypeId::VARCHAR);
+    REQUIRE(round_tripped.GetValue<string>() == text);
+}
+
 TEST_CASE("DeserializeJson struct type", "[duckdb_serialization_helper]") 
 {
     auto struct_str = string("{\"$type\":\"STRUCT\",\"$value\":{\"a\":{\"$type\":\"INTEGER\",\"$value\":123},\"b\":{\"$type\":\"VARCHAR\",\"$value\":\"TEST\"}}}");

--- a/rfc/test/sql/sap_non_ascii_text.test
+++ b/rfc/test/sql/sap_non_ascii_text.test
@@ -1,0 +1,65 @@
+# name: test/sql/sap_non_ascii_text.test
+# description: Non-ASCII (UTF-8) text from SAP must survive as VARCHAR and never
+#              be routed through a STRING -> BLOB conversion. Regression test for
+#              issue #107 ("Invalid byte encountered in STRING -> BLOB conversion
+#              of string \"Crédit Agricole SA\"").
+# group: [rfc]
+
+require erpl_rfc
+
+# Configure connection ------------------------------------------------
+require-env ERPL_SAP_ASHOST
+
+require-env ERPL_SAP_SYSNR
+
+require-env ERPL_SAP_USER
+
+require-env ERPL_SAP_PASSWORD
+
+require-env ERPL_SAP_CLIENT
+
+require-env ERPL_SAP_LANG
+
+statement ok
+CREATE SECRET abap_trial (
+    TYPE sap_rfc,
+    ASHOST '${ERPL_SAP_ASHOST}',
+    SYSNR '${ERPL_SAP_SYSNR}',
+    CLIENT '${ERPL_SAP_CLIENT}',
+    USER '${ERPL_SAP_USER}',
+    PASSWD '${ERPL_SAP_PASSWORD}',
+    LANG '${ERPL_SAP_LANG}'
+);
+
+# T005T ships with accented country names in the German locale, so this needs no
+# fixture setup. Reading them must not raise a conversion error.
+query II
+SELECT LAND1, LANDX
+FROM sap_read_table('T005T')
+WHERE SPRAS = 'D' AND LAND1 IN ('AT', 'EG')
+ORDER BY LAND1;
+----
+AT	Österreich
+EG	Ägypten
+
+# The column must be VARCHAR — a BLOB here is the bug: it means the text was
+# pushed through Blob::ToBlob, which rejects every byte above 0x7F.
+query I
+SELECT typeof(LANDX) FROM sap_read_table('T005T') WHERE SPRAS = 'D' AND LAND1 = 'AT';
+----
+VARCHAR
+
+# The bytes must round-trip intact, not be stripped or hex-escaped.
+query I
+SELECT LANDX <> strip_accents(LANDX)
+FROM sap_read_table('T005T')
+WHERE SPRAS = 'D' AND LAND1 = 'AT';
+----
+true
+
+# Non-ASCII text must also survive a WHERE-clause round trip (filter pushdown
+# builds a SQL literal from the value).
+query I
+SELECT count(*) FROM sap_read_table('T005T') WHERE SPRAS = 'D' AND LAND1 = 'EG';
+----
+1


### PR DESCRIPTION
Closes #107.

## What the investigation found

The reported symptom — `sap_bics_result` aborting with
`Invalid byte encountered in STRING -> BLOB conversion of string "Crédit Agricole SA"`
— **does not reproduce**, and the suspected line in the issue is **not** the cause.
Both were checked against a live SAP system rather than by reading source:

**1. The BICS result path is clean.** I injected `Crédit Agricole` into the BW
demo master-data text (`/BI0/TD_NW_PROD`, InfoObject `0D_NW_PROD`) on the ABAP
trial, switched the row-axis characteristic to `DISPLAY = 'TEXT'`, and ran the
full BEx workflow (`sap_bics_begin` → `sap_bics_rows` → `sap_bics_set_char_prop`
→ `sap_bics_result`). The accented text came back intact, no error. That matches
the code: `BicsResultSet::GetResultTypes()` hard-codes VARCHAR / INTEGER / DOUBLE
and deliberately ignores InfoObject DDIC metadata (since #84), so no BLOB target
exists on that path.

**2. `ErplSerializer::DeserializeJsonBlob` is correct as written.** The issue
proposed swapping `Value::BLOB(data)` for `Value::BLOB_RAW(data)`. That would
introduce a bug rather than fix one: the matching `SerializeBlobJson`
base64-encodes `Value::ToString()`, i.e. the `\xAB`-escaped rendering, which is
always pure ASCII. `Value::BLOB` parses those escapes back into the original
bytes, so the pair round-trips correctly and cannot throw for anything this
serializer produced. `BLOB_RAW` would
keep the literal backslash-x text as content and corrupt every non-ASCII byte.
I found this by writing the round-trip test first — it failed against the
proposed fix. The line is now commented and pinned by that test.

**3. There is a real defect of exactly this class, elsewhere.** DuckDB's
`Value::CreateValue` has an easy-to-miss overload asymmetry:

```cpp
template <> Value Value::CreateValue(const char *value) { return Value(string(value)); } // VARCHAR
template <> Value Value::CreateValue(string value)      { return Value::BLOB(value);   } // BLOB (!)
```

So `Value::CreateValue(some_std_string)` silently builds a **BLOB** and routes the
text through `Blob::ToBlob`, which rejects every byte above `0x7F` with precisely
the error from the issue. ASCII input round-trips invisibly (which is why this
never showed up in tests or demo data); the first accented character aborts the
query. This repo already documents the trap in a comment at
`rfc/src/sap_type_conversion.cpp:168`, but 13 call sites in `bics/` still used it
on `std::string` fields carrying BW object texts and InfoObject metadata.

## Changes

- **bics**: `scanner_bics_show.hpp` (7 sites) and `scanner_bics_describe_infoobject.cpp`
  (6 sites) now use `Value(std::string)` so the columns stay VARCHAR.
  `scanner_bics_describe_infoobject` runs on every `sap_bics_describe_infoobject`
  call; the `scanner_bics_show` sites are in a currently-disabled multi-level
  fetch path, fixed so it is not a landmine when re-enabled.
- **rfc**: comment `DeserializeJsonBlob` to explain why `Value::BLOB` is required
  and must stay paired with `SerializeBlobJson`.
- **rfc**: `ValueHelper::AddToList` cast into a discarded local while pushing the
  uncast value. `Value::LIST` cast it to the same type immediately afterwards, so
  this is a dead-store cleanup, not a behaviour change.

## Tests

- `rfc/test/sql/sap_non_ascii_text.test` — **new, runs against the real a4h
  system**. Uses `T005T`'s natively accented German country names (`Österreich`,
  `Ägypten`), so it needs no fixture setup, and asserts the values survive, that
  the column is `VARCHAR` (a BLOB here *is* the bug), and that the bytes are not
  stripped or hex-escaped.
- Two new `[duckdb_serialization_helper]` cases: a non-ASCII BLOB JSON round-trip
  (this is the one that disproved the proposed fix) and a guard that non-ASCII
  text stays VARCHAR.

## Verification

| Suite | Result |
| --- | --- |
| `rfc` SQL suite vs. a4h (24 files, incl. the new test) | 24 passed, 0 failed |
| `bics` SQL suite vs. a4h (43 files) | 42 passed, 1 pre-existing failure |
| `erpl_rfc_tests` offline tags (88 cases) | 2927 assertions passed |

The single BICS failure, `sap_bics_show.test`, is **pre-existing and unrelated**:
it asserts a hardcoded cube count of 54 while the system reports 56. I confirmed
the identical `56 <> 54` failure on a pristine tree with these changes stashed,
and all 56 cubes were last changed in 2017 (shipped demo content). Left alone
deliberately — I cannot tell whether 56 is correct for a clean trial image or
specific to this instance, so silently rewriting the expectation would be wrong.

All BW master data mutated during the investigation was backed up beforehand,
restored afterwards (verified byte-for-byte against the backup), and the two
temporary ABAP helper classes were deleted.

## Review notes

Reviewed by Codex (gpt-5.1), which confirmed all of the above against the vendored
DuckDB source and found no blocking issues. Two points it raised:

- *"`can never throw` is too strong"* — fair, and softened above: `DeserializeJsonBlob`
  can still throw on hand-written/malformed JSON whose `$value` base64-decodes to raw
  non-ASCII. Not reachable from our own serializer, and the function has no production
  callers today.
- *`odp/src/scanner_odp_preview.cpp:63` and `odp/src/odp_fetch.cpp:611` call
  `Blob::ToBlob(/E_XML)` directly — same error family?* — checked against the live
  system: `RODPS_REPL_ODP_READ_DIRECT_XML`'s `E_XML` is `RFCTYPE_XSTRING`, so our RFC
  layer already produces a BLOB and `GetValue<std::string>()` hands back the escaped
  rendering that `Blob::ToBlob` then parses. Same safe escape/parse pairing as
  `DeserializeJsonBlob`. No change needed.

## Follow-up (not in this PR)

`sap_read_table` on a `RAW` / `LRAW` / `RAWSTRING` / `RSTR` column returns a BLOB
whose *content is the ASCII hex text* rather than the decoded bytes —
`RfcType::ConvertCsvValue`'s `default:` branch hands the CSV VARCHAR straight
into a BLOB-typed vector. Confirmed live on `/DMO/AGENCY.ATTACHMENT`. It cannot
throw (hex is always ASCII) so it is a separate correctness bug; worth its own
issue.
