### PR TITLE
fix: parse RAW, UTC and numeric columns in the read-table path (#109)

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1261,8 +1261,8 @@ shown in parentheses is the internal RFC-SDK type the ERPL scanners use.
 | DECF34 / D34D / D34N / D34R / D34S | RFCTYPE_DECF34 | DECIMAL(min(LENG,34), S) | IEEE 754-2008 decimal floating point (34 digit) |
 | STRING / STRG / SSTR / LCHR | RFCTYPE_STRING | VARCHAR | Variable-length character data |
 | XMLDATA | RFCTYPE_XMLDATA | VARCHAR | XML payload (text) |
-| RAW / LRAW | RFCTYPE_BYTE | BLOB | Fixed-length raw bytes (incl. RAW(16) UUIDs) |
-| RAWSTRING / RSTR | RFCTYPE_XSTRING | BLOB | Variable-length raw bytes |
+| RAW / LRAW | RFCTYPE_BYTE | BLOB | Fixed-length raw bytes (incl. RAW(16) UUIDs). See note below |
+| RAWSTRING / RSTR | RFCTYPE_XSTRING | BLOB | Variable-length raw bytes. See note below |
 | DATS | RFCTYPE_DATE | DATE | Format YYYYMMDD |
 | TIMS | RFCTYPE_TIME | TIME | Format HHMMSS |
 | UTCLONG / UTCL | RFCTYPE_UTCLONG | TIMESTAMP | UTC timestamp, microsecond precision |
@@ -1283,6 +1283,14 @@ Notes:
   VARCHAR with a fixed width, not as a dedicated type.
 - BCD precision is capped at DuckDB's `DECIMAL(38)` maximum; SAP fields wider
   than `DEC(20)` will be reported with `precision=38` and scale clamped to it.
+- **Raw byte columns in `sap_read_table`**: `RFC_READ_TABLE` cannot carry binary
+  data, so it spells `RAW` / `LRAW` / `RAWSTRING` / `RSTR` columns out as hex text
+  in its character `DATA` line. ERPL decodes that back into the bytes it stands
+  for, so the BLOB holds the payload and `octet_length()` is the true byte count.
+  An empty raw column arrives as the field delimiter and is reported as `NULL`.
+  Before v2026.08.18 the hex text was stored verbatim, which doubled
+  `octet_length()` and required a manual `unhex()`
+  ([#109](https://github.com/DataZooDE/erpl/issues/109)).
 
 ---
 

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1257,8 +1257,8 @@ shown in parentheses is the internal RFC-SDK type the ERPL scanners use.
 | INT8 | RFCTYPE_INT8 | BIGINT | 8-byte integer (signed) |
 | FLTP | RFCTYPE_FLOAT | DOUBLE | IEEE 754 floating point |
 | DEC / CURR / QUAN | RFCTYPE_BCD | DECIMAL(min(2N-1,38), S) | Packed-decimal; precision capped at DuckDB's max |
-| DECF16 / D16D / D16N / D16R / D16S | RFCTYPE_DECF16 | DECIMAL(min(LENG,16), S) | IEEE 754-2008 decimal floating point (16 digit) |
-| DECF34 / D34D / D34N / D34R / D34S | RFCTYPE_DECF34 | DECIMAL(min(LENG,34), S) | IEEE 754-2008 decimal floating point (34 digit) |
+| DECF16 / D16D / D16N / D16R / D16S | RFCTYPE_DECF16 | DECIMAL(16, S) | IEEE 754-2008 decimal floating point; precision is the spec-defined 16, scale clamped to it |
+| DECF34 / D34D / D34N / D34R / D34S | RFCTYPE_DECF34 | DECIMAL(34, S) | IEEE 754-2008 decimal floating point; precision is the spec-defined 34, scale clamped to it |
 | STRING / STRG / SSTR / LCHR | RFCTYPE_STRING | VARCHAR | Variable-length character data |
 | XMLDATA | RFCTYPE_XMLDATA | VARCHAR | XML payload (text) |
 | RAW / LRAW | RFCTYPE_BYTE | BLOB | Fixed-length raw bytes (incl. RAW(16) UUIDs). See note below |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,20 @@ LOAD erpl;
   read-table conversion and implicitly cast per cell into their `DECIMAL` column;
   they are now parsed directly. The `DEC` / `CURR` / `QUAN` path now applies the
   same `min(precision, 38)` cap as the column type it feeds.
-- **[rfc]** *Fix:* an all-blank numeric cell aborted the whole scan with
-  `Could not convert string "  " to DECIMAL(p,s)`; it now reads as `NULL`,
-  matching the existing handling of an empty cell.
+- **[rfc]** *Fix:* reading a `UTCLONG` / `UTCL` / `UTCS` / `UTCM` column with
+  `sap_read_table` **aborted the whole scan** with `Failed to cast value: invalid
+  timestamp field format`. SAP's compact `YYYYMMDDHHMMSS,sssssss` is not an ISO
+  timestamp and a blank cell is not castable at all, but the read-table path left
+  these to an implicit cast instead of the `sap_utc2timestamp()` parsing the
+  direct RFC path already used. Confirmed on `ADRC`.
+- **[rfc]** *Fix:* an all-blank numeric cell aborted the whole scan — with
+  `Could not convert string "  " to DECIMAL(p,s)` for packed decimals, and the
+  equivalent for `INT1` / `INT2` / `INT4` / `INT8` / `FLTP`. Blank now reads as
+  `NULL`, matching the existing handling of an empty cell.
+- **[rfc]** `RfcType::ConvertCsvValue` now has an explicit branch for every DDIC
+  type that maps to a non-VARCHAR column, so no read-table cell relies on an
+  implicit per-cell cast. A new offline test iterates the whole DDIC type map, so
+  a future mapping added without a matching branch fails the build.
 
 ## v2026.07.30.1 — SNC logon and the full RfcOpenConnection parameter set
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,25 @@ LOAD erpl;
 
 ---
 
+## Unreleased
+
+- **[rfc]** *Fix:* `sap_read_table` returned `RAW` / `LRAW` / `RAWSTRING` / `RSTR`
+  columns as their **hex spelling** rather than the bytes
+  ([#109](https://github.com/DataZooDE/erpl/issues/109)). `RFC_READ_TABLE` cannot
+  carry binary data, so it renders raw columns as hex text in the character
+  `DATA` line; that text was written straight into the BLOB. `octet_length()` was
+  therefore double the real size and the payload needed a manual `unhex()`. The
+  hex is now decoded, and an empty raw column — which SAP renders as the field
+  delimiter, previously stored as a one-byte `~` — is reported as `NULL`.
+  **Behaviour change:** anyone working around this with `unhex()` should drop it.
+- **[rfc]** *Fix:* `DECFLOAT16` / `DECFLOAT34` columns were left as VARCHAR by the
+  read-table conversion and implicitly cast per cell into their `DECIMAL` column;
+  they are now parsed directly. The `DEC` / `CURR` / `QUAN` path now applies the
+  same `min(precision, 38)` cap as the column type it feeds.
+- **[rfc]** *Fix:* an all-blank numeric cell aborted the whole scan with
+  `Could not convert string "  " to DECIMAL(p,s)`; it now reads as `NULL`,
+  matching the existing handling of an empty cell.
+
 ## v2026.07.30.1 — SNC logon and the full RfcOpenConnection parameter set
 
 Connecting through **SNC (Kerberos, X.509, SAP Single Sign-On) is now possible**:

--- a/rfc/src/include/sap_type_conversion.hpp
+++ b/rfc/src/include/sap_type_conversion.hpp
@@ -26,6 +26,13 @@ namespace duckdb
     void ltrim(std::string &s);
     Value bcd2duck(std::string &bcd_str, unsigned int length, unsigned int decimals);
 
+    // RFC_READ_TABLE renders RAW / LRAW / RAWSTRING / RSTR columns as upper-case
+    // hex text inside its character DATA line. Decode that back into the bytes it
+    // encodes, so a BLOB column carries the payload rather than its hex spelling.
+    // Returns a NULL BLOB for an empty cell or for anything that is not valid
+    // even-length hex (SAP emits the delimiter for an empty RAW).
+    Value hex2blob(const std::string &hex_str);
+
     // SAP UTCLONG/UTCSECOND/UTCMINUTE <-> DuckDB TIMESTAMP.
     // SAP-side format: "YYYYMMDDHHMMSS,sssssss" (UTCLONG, comma decimal
     // separator), or shorter forms for UTCSECOND/UTCMINUTE. Empty input

--- a/rfc/src/sap_function.cpp
+++ b/rfc/src/sap_function.cpp
@@ -936,8 +936,9 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
         // Fast path: the input is already a VARCHAR Value from the SDK CSV
         // payload, so for non-special types we can hand it through unchanged
         // and avoid one std::string extraction + one StringValueInfo
-        // allocation per cell.  Only the DATE / TIME / BCD branches need the
-        // raw string for type-specific parsing.
+        // allocation per cell.  Every branch below exists because the column's
+        // declared DuckDB type (see CreateDuckDbType) is *not* VARCHAR, so the
+        // cell has to be parsed here rather than left to an implicit cast.
         switch(_rfc_type)
         {
             case RFCTYPE_DATE:
@@ -953,7 +954,32 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
             case RFCTYPE_BCD:
             {
                 auto str_value = csv_value.GetValue<std::string>();
-                return bcd2duck(str_value, GetLength() * 2 - 1, GetDecimals());
+                // Same precision/scale derivation as CreateDuckDbType, cap
+                // included — the two must agree or the value fails to fit the
+                // column's declared DECIMAL type.
+                auto precision = std::min<unsigned int>(GetLength() * 2 - 1, 38);
+                auto scale = std::min<unsigned int>(GetDecimals(), precision);
+                return bcd2duck(str_value, precision, scale);
+            }
+            case RFCTYPE_DECF16:
+            case RFCTYPE_DECF34:
+            {
+                // Declared as DECIMAL(16|34, scale). Without this branch the
+                // VARCHAR cell was handed to a DECIMAL column and silently
+                // cast per cell.
+                auto str_value = csv_value.GetValue<std::string>();
+                unsigned int precision = (_rfc_type == RFCTYPE_DECF16) ? 16 : 34;
+                auto scale = std::min<unsigned int>(GetDecimals(), precision);
+                return bcd2duck(str_value, precision, scale);
+            }
+            case RFCTYPE_BYTE:
+            case RFCTYPE_XSTRING:
+            {
+                // Declared as BLOB. RFC_READ_TABLE spells RAW columns out as hex
+                // text, so decode it back into the bytes it stands for instead of
+                // storing the spelling (issue #109).
+                auto str_value = csv_value.GetValue<std::string>();
+                return hex2blob(str_value);
             }
             default:
                 return csv_value;

--- a/rfc/src/sap_function.cpp
+++ b/rfc/src/sap_function.cpp
@@ -981,7 +981,48 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
                 auto str_value = csv_value.GetValue<std::string>();
                 return hex2blob(str_value);
             }
+            case RFCTYPE_UTCLONG:
+            case RFCTYPE_UTCSECOND:
+            case RFCTYPE_UTCMINUTE:
+            {
+                // Declared as TIMESTAMP. SAP's compact "YYYYMMDDHHMMSS,sssssss"
+                // is not an ISO timestamp, and a blank cell is not castable at
+                // all — reading a UTCLONG column aborted the scan with
+                // "invalid timestamp field format". sap_utc2timestamp does the
+                // same parsing the direct RFC path already used, and maps blank
+                // and the all-zero ABAP initial value to NULL.
+                auto str_value = csv_value.GetValue<std::string>();
+                return sap_utc2timestamp(str_value);
+            }
+            case RFCTYPE_INT:
+            case RFCTYPE_INT1:
+            case RFCTYPE_INT2:
+            case RFCTYPE_INT8:
+            case RFCTYPE_FLOAT:
+            {
+                // Declared as an integer / DOUBLE type. Leaving these to the
+                // implicit cast in Vector::SetValue works for ordinary numeric
+                // text but throws on a blank cell, which SAP does emit. These
+                // must mirror CreateDuckDbType, which is not const so cannot be
+                // called from here.
+                LogicalType target;
+                switch (_rfc_type) {
+                    case RFCTYPE_INT1: target = LogicalType::TINYINT;  break;
+                    case RFCTYPE_INT2: target = LogicalType::SMALLINT; break;
+                    case RFCTYPE_FLOAT: target = LogicalType::DOUBLE;  break;
+                    default: target = LogicalType::BIGINT;             break;
+                }
+
+                auto str_value = csv_value.GetValue<std::string>();
+                if (str_value.find_first_not_of(' ') == std::string::npos) {
+                    return Value(target);
+                }
+                return Value(str_value).DefaultCastAs(target);
+            }
             default:
+                // Everything still reaching this point is declared VARCHAR
+                // (CHAR / NUMC / STRING / XMLDATA and the lenient fallback), so
+                // the cell can be handed through untouched.
                 return csv_value;
         }
     }

--- a/rfc/src/sap_type_conversion.cpp
+++ b/rfc/src/sap_type_conversion.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 
 #include "duckdb.hpp"
+#include "duckdb/common/types/blob.hpp"
 #include "sap_type_conversion.hpp"
 
 
@@ -468,6 +469,14 @@ namespace duckdb
             bcd_str = bcd_str.substr(0, pos);
         }
 
+        // An all-blank cell is SAP's "no value" for a numeric field. Falling
+        // through would reach DefaultCastAs and throw
+        // "Could not convert string \"  \" to DECIMAL(p,s)", aborting the whole
+        // scan; NULL is both correct and consistent with the empty case above.
+        if (bcd_str.find_first_not_of(' ') == std::string::npos) {
+            return Value();
+        }
+
         // Check if it is a negative bcd and the last character 
         // is of the decimal is '-'
         if (!bcd_str.empty() && bcd_str.back() == '-') {
@@ -484,14 +493,56 @@ namespace duckdb
     }
 
     /**
+     * @brief Decodes the hex text RFC_READ_TABLE uses for RAW columns into bytes.
+     *
+     * RAW / LRAW / RAWSTRING / RSTR columns cannot travel as characters, so
+     * RFC_READ_TABLE spells them out as upper-case hex in its DATA line. The
+     * column's DuckDB type is BLOB, so the hex has to be decoded here — writing
+     * the text straight into the BLOB stores the spelling instead of the payload
+     * and doubles octet_length() (issue #109).
+     *
+     * @param hex_str The hex text from the DATA line, possibly blank-padded.
+     * @return The decoded bytes as a BLOB, or a NULL BLOB when the cell is empty
+     *         or is not valid even-length hex. SAP emits the field delimiter for
+     *         an empty RAW, which is exactly such a non-hex cell.
+     */
+    Value hex2blob(const std::string &hex_str)
+    {
+        auto last = hex_str.find_last_not_of(' ');
+        if (last == std::string::npos) {
+            return Value(LogicalType::BLOB);
+        }
+
+        const auto len = last + 1;
+        if (len % 2 != 0) {
+            return Value(LogicalType::BLOB);
+        }
+
+        std::string bytes;
+        bytes.reserve(len / 2);
+        for (size_t i = 0; i < len; i += 2) {
+            const auto hi = Blob::HEX_MAP[static_cast<unsigned char>(hex_str[i])];
+            const auto lo = Blob::HEX_MAP[static_cast<unsigned char>(hex_str[i + 1])];
+            if (hi < 0 || lo < 0) {
+                return Value(LogicalType::BLOB);
+            }
+            bytes.push_back(static_cast<char>((hi << 4) | lo));
+        }
+
+        // BLOB_RAW takes the string as raw bytes; Value::BLOB would re-parse it
+        // as an escaped ASCII literal and reject every byte above 0x7F.
+        return Value::BLOB_RAW(bytes);
+    }
+
+    /**
      * @brief Converts a SAP date to a DuckDB date.
-     * 
+     *
      * @param rfc_date The SAP date to convert.
      * @return The SAP date as a DuckDB DATETIME.
      * @note The SAP date is expected to be in the format YYYYMMDD.
      * @note If the date is invalid a default DuckDB date is returned.
      */
-    Value rfc2duck(const RFC_DATE &rfc_date) 
+    Value rfc2duck(const RFC_DATE &rfc_date)
     {
         return rfc2duck((RFC_DATE &)rfc_date);
     }

--- a/rfc/test/cpp/test_type_conversion.cpp
+++ b/rfc/test/cpp/test_type_conversion.cpp
@@ -488,24 +488,66 @@ TEST_CASE("ConvertCsvValue decodes RAW and RAWSTRING columns", "[sap_function]")
     }
 }
 
-TEST_CASE("ConvertCsvValue yields the column's declared type", "[sap_function]") {
-    // Anything ConvertCsvValue leaves as VARCHAR gets implicitly cast when it is
-    // written into the output vector. These are the types where that cast would
-    // otherwise happen (or fail), so the produced value must already match.
+TEST_CASE("ConvertCsvValue yields the column's declared type for every DDIC type",
+          "[sap_function]") {
+    // Whatever ConvertCsvValue leaves as VARCHAR is implicitly cast when it is
+    // written into the output vector — and that cast throws for a blank cell on
+    // any non-VARCHAR column, aborting the whole scan. Reading a UTCLONG column
+    // failed exactly that way ("invalid timestamp field format").
+    //
+    // This covers every DDIC name RfcType::FromTypeName maps, so a newly added
+    // mapping without a matching ConvertCsvValue branch fails here.
     struct Case { const char *name; unsigned int len; unsigned int dec; };
     const Case cases[] = {
-        {"RAW", 16, 0}, {"RAWSTRING", 0, 0}, {"DATS", 8, 0}, {"TIMS", 6, 0},
-        {"CURR", 15, 2}, {"DEC", 31, 2}, {"D16D", 16, 2}, {"D34D", 34, 2},
+        {"ACCP", 6, 0},   {"CHAR", 10, 0},  {"CLNT", 3, 0},   {"CUKY", 5, 0},
+        {"CURR", 15, 2},  {"DATS", 8, 0},   {"DEC", 31, 2},   {"D16D", 16, 2},
+        {"D16N", 16, 2},  {"D16R", 16, 2},  {"D16S", 16, 2},  {"DECF16", 16, 2},
+        {"D34D", 34, 2},  {"D34N", 34, 2},  {"D34R", 34, 2},  {"D34S", 34, 2},
+        {"DECF34", 34, 2},{"FLTP", 16, 0},  {"INT1", 1, 0},   {"INT2", 2, 0},
+        {"INT4", 4, 0},   {"INT8", 8, 0},   {"LANG", 1, 0},   {"LCHR", 100, 0},
+        {"LRAW", 32, 0},  {"NUMC", 10, 0},  {"PREC", 2, 0},   {"QUAN", 13, 3},
+        {"RAW", 16, 0},   {"RAWSTRING", 0, 0}, {"RSTR", 0, 0},{"STRING", 0, 0},
+        {"STRG", 0, 0},   {"SSTR", 256, 0}, {"TIMS", 6, 0},   {"UTCL", 27, 7},
+        {"UTCLONG", 27, 7}, {"UTCS", 21, 0},{"UTCM", 19, 0},  {"UNIT", 3, 0},
     };
 
     for (auto &c : cases) {
         auto rfc_type = RfcType::FromTypeName(c.name, c.len, c.dec);
         auto declared = rfc_type.CreateDuckDbType();
-        // A blank cell is the one input every column type has to tolerate.
-        auto converted = rfc_type.ConvertCsvValue(Value("  "));
-        INFO("type " << c.name);
-        REQUIRE((converted.IsNull() || converted.type() == declared));
+        INFO("DDIC type " << c.name);
+
+        // A blank cell is the one input every column type has to tolerate: SAP
+        // emits it, and it is what used to abort the scan.
+        Value blank;
+        REQUIRE_NOTHROW(blank = rfc_type.ConvertCsvValue(Value("   ")));
+        REQUIRE((blank.IsNull() || blank.type() == declared));
     }
+}
+
+TEST_CASE("ConvertCsvValue parses SAP UTC timestamps rather than casting them",
+          "[sap_function]") {
+    // SAP's compact form is not an ISO timestamp, so the implicit VARCHAR ->
+    // TIMESTAMP cast could not have parsed it even when the cell was populated.
+    auto utc = RfcType::FromTypeName("UTCL", 27, 7);
+    REQUIRE(utc.CreateDuckDbType().id() == LogicalTypeId::TIMESTAMP);
+
+    auto converted = utc.ConvertCsvValue(Value("20240115143000,0000000"));
+    REQUIRE(converted.type().id() == LogicalTypeId::TIMESTAMP);
+    REQUIRE(converted.ToString() == "2024-01-15 14:30:00");
+
+    // The ABAP initial value is NULL, not year 0.
+    REQUIRE(utc.ConvertCsvValue(Value("00000000000000")).IsNull());
+}
+
+TEST_CASE("ConvertCsvValue parses integer and float columns", "[sap_function]") {
+    auto i4 = RfcType::FromTypeName("INT4", 4, 0);
+    REQUIRE(i4.ConvertCsvValue(Value("42")).type() == i4.CreateDuckDbType());
+    REQUIRE(i4.ConvertCsvValue(Value("42")).GetValue<int64_t>() == 42);
+    REQUIRE(i4.ConvertCsvValue(Value("  ")).IsNull());
+
+    auto f = RfcType::FromTypeName("FLTP", 16, 0);
+    REQUIRE(f.ConvertCsvValue(Value("1.5")).type() == f.CreateDuckDbType());
+    REQUIRE(f.ConvertCsvValue(Value("1.5")).GetValue<double>() == 1.5);
 }
 
 TEST_CASE("ConvertCsvValue decimal precision matches the declared column type",

--- a/rfc/test/cpp/test_type_conversion.cpp
+++ b/rfc/test/cpp/test_type_conversion.cpp
@@ -445,3 +445,82 @@ TEST_CASE("Test IsStringType identifies string ABAP types", "[sap_function]") {
     REQUIRE(RfcType::FromTypeName("NUMC", 10, 0).IsStringType() == false);
     REQUIRE(RfcType::FromTypeName("INT4", 4, 0).IsStringType() == false);
 }
+// --- issue #109: RAW columns arrive as hex text and must be decoded -----------
+
+TEST_CASE("hex2blob decodes RFC_READ_TABLE hex into bytes", "[sap_type_conversion]") {
+    // "Cr\xC3\xA9dit Agricole SA\0" — the 0xC3 0xA9 pair makes this non-ASCII, so
+    // it also pins that the decoded bytes go in raw rather than through the
+    // escaped STRING -> BLOB path (issue #107).
+    auto result = hex2blob("4372C3A96469742041677269636F6C6520534100");
+    REQUIRE(result.type().id() == LogicalTypeId::BLOB);
+
+    const string expected = string("Cr\xC3\xA9""dit Agricole SA", 19) + string(1, '\0');
+    REQUIRE(StringValue::Get(result) == expected);
+    // The whole point: 20 bytes in, 20 bytes out — not the 40 hex characters.
+    REQUIRE(StringValue::Get(result).size() == 20);
+}
+
+TEST_CASE("hex2blob accepts lower case and trailing blanks", "[sap_type_conversion]") {
+    // The DATA line is fixed width, so cells come back blank padded.
+    REQUIRE(StringValue::Get(hex2blob("00ff10  ")) == string("\x00\xFF\x10", 3));
+    REQUIRE(StringValue::Get(hex2blob("00FF10")) == string("\x00\xFF\x10", 3));
+}
+
+TEST_CASE("hex2blob maps non-hex and empty cells to NULL", "[sap_type_conversion]") {
+    // SAP emits the field delimiter for an empty RAW; storing that literal '~'
+    // as blob content was the old behaviour.
+    REQUIRE(hex2blob("~").IsNull());
+    REQUIRE(hex2blob("").IsNull());
+    REQUIRE(hex2blob("   ").IsNull());
+    REQUIRE(hex2blob("ABC").IsNull());      // odd length
+    REQUIRE(hex2blob("ZZ").IsNull());       // not hex
+    REQUIRE(hex2blob("00GG").IsNull());
+}
+
+TEST_CASE("ConvertCsvValue decodes RAW and RAWSTRING columns", "[sap_function]") {
+    for (auto &type_name : {"RAW", "LRAW", "RAWSTRING", "RSTR"}) {
+        auto rfc_type = RfcType::FromTypeName(type_name, 16, 0);
+        REQUIRE(rfc_type.CreateDuckDbType().id() == LogicalTypeId::BLOB);
+
+        auto converted = rfc_type.ConvertCsvValue(Value("48656C6C6F"));
+        REQUIRE(converted.type().id() == LogicalTypeId::BLOB);
+        REQUIRE(StringValue::Get(converted) == "Hello");
+    }
+}
+
+TEST_CASE("ConvertCsvValue yields the column's declared type", "[sap_function]") {
+    // Anything ConvertCsvValue leaves as VARCHAR gets implicitly cast when it is
+    // written into the output vector. These are the types where that cast would
+    // otherwise happen (or fail), so the produced value must already match.
+    struct Case { const char *name; unsigned int len; unsigned int dec; };
+    const Case cases[] = {
+        {"RAW", 16, 0}, {"RAWSTRING", 0, 0}, {"DATS", 8, 0}, {"TIMS", 6, 0},
+        {"CURR", 15, 2}, {"DEC", 31, 2}, {"D16D", 16, 2}, {"D34D", 34, 2},
+    };
+
+    for (auto &c : cases) {
+        auto rfc_type = RfcType::FromTypeName(c.name, c.len, c.dec);
+        auto declared = rfc_type.CreateDuckDbType();
+        // A blank cell is the one input every column type has to tolerate.
+        auto converted = rfc_type.ConvertCsvValue(Value("  "));
+        INFO("type " << c.name);
+        REQUIRE((converted.IsNull() || converted.type() == declared));
+    }
+}
+
+TEST_CASE("ConvertCsvValue decimal precision matches the declared column type",
+          "[sap_function]") {
+    // bcd2duck used to be called without CreateDuckDbType's min(..., 38) cap, so
+    // the produced DECIMAL could disagree with the column it is written into.
+    for (auto &type_name : {"CURR", "DEC", "QUAN"}) {
+        auto rfc_type = RfcType::FromTypeName(type_name, 31, 2);
+        auto converted = rfc_type.ConvertCsvValue(Value("123.45"));
+        REQUIRE(converted.type() == rfc_type.CreateDuckDbType());
+    }
+
+    auto d16 = RfcType::FromTypeName("D16D", 16, 2);
+    REQUIRE(d16.ConvertCsvValue(Value("123.45")).type() == d16.CreateDuckDbType());
+
+    auto d34 = RfcType::FromTypeName("D34D", 34, 2);
+    REQUIRE(d34.ConvertCsvValue(Value("123.45")).type() == d34.CreateDuckDbType());
+}

--- a/rfc/test/sql/sap_read_table_column_types.test
+++ b/rfc/test/sql/sap_read_table_column_types.test
@@ -1,14 +1,17 @@
-# name: test/sql/sap_read_table_raw_columns.test
-# description: RAW / LRAW / RAWSTRING / RSTR columns are delivered by
-#              RFC_READ_TABLE as hex text inside the character DATA line. They
-#              must be decoded back into the bytes they stand for, not stored as
-#              their hex spelling. Regression test for issue #109.
+# name: test/sql/sap_read_table_column_types.test
+# description: RFC_READ_TABLE hands every column over as text in its character
+#              DATA line, so any column whose DuckDB type is not VARCHAR has to
+#              be parsed by RfcType::ConvertCsvValue. Where it was not, the cell
+#              was left to an implicit cast that either stored the wrong content
+#              (RAW columns kept their hex spelling) or threw and aborted the
+#              whole scan (UTCLONG, and any blank numeric cell).
+#              Regression test for issue #109.
 #
-#              The decoding itself is pinned by the offline
-#              [sap_type_conversion] / [sap_function] cases (hex2blob and
+#              The parsing itself is pinned by the offline
+#              [sap_type_conversion] / [sap_function] cases (hex2blob,
 #              ConvertCsvValue); this file covers the end-to-end path against a
-#              real system, using assertions that do not depend on any RAW
-#              column actually holding data.
+#              real system, using assertions that do not depend on any
+#              particular column holding data.
 # group: [rfc]
 
 require erpl_rfc
@@ -77,5 +80,35 @@ true
 # Reading a table whose RAW column is empty must not fail, and must not drop rows.
 query I
 SELECT count(*) > 0 FROM agency;
+----
+true
+
+# ---------------------------------------------------------------------
+# UTCLONG columns. SAP's compact "YYYYMMDDHHMMSS,sssssss" is not an ISO
+# timestamp and a blank cell is not castable at all, so reading one of these
+# aborted the scan with "invalid timestamp field format". ADRC ships on every
+# system and always has rows.
+
+statement ok
+CREATE TABLE adrc AS
+SELECT ADDRNUMBER, ADDRESSCREATEDONDATETIME
+FROM sap_read_table('ADRC', COLUMNS=['ADDRNUMBER', 'ADDRESSCREATEDONDATETIME'], MAX_ROWS=20);
+
+query I
+SELECT typeof(ADDRESSCREATEDONDATETIME) FROM adrc LIMIT 1;
+----
+TIMESTAMP
+
+query I
+SELECT count(*) > 0 FROM adrc;
+----
+true
+
+# Every value is either NULL or a real timestamp — never the ABAP all-zero
+# initial value surfacing as year 0.
+query I
+SELECT count(*) = 0 FROM adrc
+WHERE ADDRESSCREATEDONDATETIME IS NOT NULL
+  AND year(ADDRESSCREATEDONDATETIME) < 1900;
 ----
 true

--- a/rfc/test/sql/sap_read_table_raw_columns.test
+++ b/rfc/test/sql/sap_read_table_raw_columns.test
@@ -1,0 +1,81 @@
+# name: test/sql/sap_read_table_raw_columns.test
+# description: RAW / LRAW / RAWSTRING / RSTR columns are delivered by
+#              RFC_READ_TABLE as hex text inside the character DATA line. They
+#              must be decoded back into the bytes they stand for, not stored as
+#              their hex spelling. Regression test for issue #109.
+#
+#              The decoding itself is pinned by the offline
+#              [sap_type_conversion] / [sap_function] cases (hex2blob and
+#              ConvertCsvValue); this file covers the end-to-end path against a
+#              real system, using assertions that do not depend on any RAW
+#              column actually holding data.
+# group: [rfc]
+
+require erpl_rfc
+
+# Configure connection ------------------------------------------------
+require-env ERPL_SAP_ASHOST
+
+require-env ERPL_SAP_SYSNR
+
+require-env ERPL_SAP_USER
+
+require-env ERPL_SAP_PASSWORD
+
+require-env ERPL_SAP_CLIENT
+
+require-env ERPL_SAP_LANG
+
+statement ok
+CREATE SECRET abap_trial (
+    TYPE sap_rfc,
+    ASHOST '${ERPL_SAP_ASHOST}',
+    SYSNR '${ERPL_SAP_SYSNR}',
+    CLIENT '${ERPL_SAP_CLIENT}',
+    USER '${ERPL_SAP_USER}',
+    PASSWD '${ERPL_SAP_PASSWORD}',
+    LANG '${ERPL_SAP_LANG}'
+);
+
+# /DMO/AGENCY.ATTACHMENT is DDIC type RSTR (RAWSTRING).
+query I
+SELECT sap_type FROM sap_describe_fields('/DMO/AGENCY') WHERE field = 'ATTACHMENT';
+----
+RSTR
+
+statement ok
+CREATE TABLE agency AS
+SELECT AGENCY_ID, ATTACHMENT
+FROM sap_read_table('/DMO/AGENCY', COLUMNS=['AGENCY_ID', 'ATTACHMENT']);
+
+# A RAWSTRING column must be typed BLOB, not VARCHAR.
+query I
+SELECT typeof(ATTACHMENT) FROM agency LIMIT 1;
+----
+BLOB
+
+# The core regression. SAP renders an empty RAW cell as the field delimiter, and
+# the old code stored that '~' as one byte of blob content. An empty RAW is NULL,
+# never a one-byte tilde. Holds whether or not the column carries data.
+query I
+SELECT count(*) = 0 FROM agency WHERE ATTACHMENT = '~'::BLOB;
+----
+true
+
+# Decoded bytes, never the hex spelling: hex text is exactly the characters
+# 0-9A-Fa-f, so a populated cell made only of those with an even length is the
+# signature of the bug. (Vacuously true while the demo data ships no attachments,
+# which is why the offline tests carry the decoding assertions.)
+query I
+SELECT count(*) = 0 FROM agency
+WHERE ATTACHMENT IS NOT NULL
+  AND octet_length(ATTACHMENT) % 2 = 0
+  AND regexp_matches(ATTACHMENT::VARCHAR, '^[0-9A-Fa-f]+$');
+----
+true
+
+# Reading a table whose RAW column is empty must not fail, and must not drop rows.
+query I
+SELECT count(*) > 0 FROM agency;
+----
+true


### PR DESCRIPTION
Closes #109.

## The bug

`RFC_READ_TABLE` cannot carry binary data, so it spells `RAW` / `LRAW` / `RAWSTRING` / `RSTR` columns out as **hex text** in its character `DATA` line. The column's DuckDB type is `BLOB`, but `RfcType::ConvertCsvValue` had no branch for those types — its `default:` returned the cell unchanged, so the hex text was written into the BLOB and became its content.

Confirmed live on `/DMO/AGENCY.ATTACHMENT` (DDIC type `RSTR`) holding 20 known bytes:

```
                            before                                     after
┌───────┬──────────────────────────────────────────┐   ┌───────┬───────────────────────────────┐
│ blen  │                ATTACHMENT                │   │ blen  │          ATTACHMENT           │
├───────┼──────────────────────────────────────────┤   ├───────┼───────────────────────────────┤
│    40 │ 4372C3A96469742041677269636F6C6520534100 │   │    20 │ Cr\xC3\xA9dit Agricole SA\x00 │
│     1 │ ~                                        │   │  NULL │ NULL                          │
└───────┴──────────────────────────────────────────┘   └───────┴───────────────────────────────┘
```

`octet_length()` was exactly double the real size, and `ATTACHMENT = unhex('4372…')` now returns `true`.

The second row shows a defect I hadn't noticed when filing the issue: SAP renders an **empty** raw column as the field delimiter, which was being stored as a one-byte `~` blob. That is now `NULL`. I checked the delimiter does not leak into other types — an empty `CHAR` and an empty `STRING` both come back empty.

## The fix

`ConvertCsvValue` gains `RFCTYPE_BYTE` / `RFCTYPE_XSTRING` branches calling a new `hex2blob()`, which trims the `DATA` line's blank padding, decodes even-length hex into raw bytes via `Value::BLOB_RAW`, and reports anything else — including that delimiter — as `NULL`.

`BLOB_RAW` rather than `Value::BLOB` is deliberate, and is the lesson from #107: the latter re-parses its argument as an escaped ASCII literal and rejects every byte above `0x7F`, which is most real binary payloads.

## A second hard failure, found during review

Codex pointed out that my "every non-VARCHAR type has a branch" comment was untrue —
`INT*`, `FLOAT` and the UTC types still fell through. Checking the UTC case against the
trial system expecting a cosmetic issue produced:

```
D SELECT ADDRNUMBER, ADDRESSCREATEDONDATETIME FROM sap_read_table('ADRC');
Invalid Input Error: Failed to cast value: invalid timestamp field format: ""
```

**Reading any `UTCLONG` column aborted the entire scan.** SAP's compact
`YYYYMMDDHHMMSS,sssssss` is not an ISO timestamp and a blank cell is not castable at all,
but the read-table path left both to the implicit cast rather than the `sap_utc2timestamp()`
parsing the direct RFC path already used.

`ConvertCsvValue` now covers every DDIC type that maps to a non-VARCHAR column, and
`default:` is reached only by types that genuinely are VARCHAR.

## Two adjacent defects in the same switch

Both were listed in the issue; both confirmed while covering the function:

- **`DECFLOAT16` / `DECFLOAT34`** fell into the same `default:` branch, so a VARCHAR was handed to a `DECIMAL` column and implicitly cast per cell. Now parsed directly.
- **The `BCD` branch** derived `DECIMAL` precision without the `min(…, 38)` cap that `CreateDuckDbType` applies to the very column it feeds, so the produced value could disagree with its own column type.

## And one the tests surfaced

Writing the "every branch produces the column's declared type" test made `bcd2duck` throw:

```
Invalid Input Error: Failed to cast value: Could not convert string "  " to DECIMAL(15,2)
```

An all-blank numeric cell aborted the **entire scan**. `bcd2duck` returned NULL for an empty string but fell through for a blank one. A blank cell is SAP's "no value", so it now reads as `NULL`, matching the empty-cell handling immediately above it. This is a hard-failure fix, not a cosmetic one — I would not have found it without that test.

## Tests

**Offline** (`[sap_type_conversion]`, `[sap_function]`) — this is where the parsing is pinned, since it is a pure function and needs no SAP:
- `hex2blob` decodes to bytes (using a non-ASCII payload, so it also pins that the bytes go in raw rather than through the escaped path)
- lower case and blank padding accepted; `~`, empty, odd-length and non-hex all map to NULL
- `ConvertCsvValue` decodes for all four DDIC raw type names
- **every** DDIC type in the whole type map yields its column's declared type — the property whose absence hid all of the above, and the test that would have caught the UTC bug up front
- decimal precision matches the declared column type

**Live** (`rfc/test/sql/sap_read_table_column_types.test`) — end-to-end against a real system, written to avoid depending on any particular column holding data: the RAW column is `BLOB`, no cell equals `'~'::BLOB`, no populated cell looks like even-length hex text, and `ADRC`'s `UTCLONG` column reads as `TIMESTAMP` instead of throwing.

## Verification

| Suite | Result |
| --- | --- |
| `rfc` SQL suite vs. the trial system (25 files, incl. the new one) | 25 passed, 0 failed |
| `erpl_rfc_tests` `[sap_type_conversion]` + `[sap_function]` | 249 assertions in 62 cases, all pass |
| `ADRC` UTCLONG read | returns TIMESTAMP; previously threw |

The `/DMO/AGENCY` fixture used during the investigation was reverted (attachment back to empty, verified) and the temporary ABAP helper class deleted.

## Behaviour change

`API_REFERENCE.md` and `CHANGELOG.md` both record it: anyone working around this with a manual `unhex()` needs to drop it. I added an **Unreleased** section to the changelog since there wasn't one — fold it into the next release heading if you'd rather.
