### PR TITLE
fix(ci): bump vcpkg pin so Windows builds can fetch msys2 packages

### DIFF
--- a/.github/docker/linux_amd64/Dockerfile
+++ b/.github/docker/linux_amd64/Dockerfile
@@ -4,6 +4,8 @@ FROM quay.io/pypa/manylinux_2_28_x86_64
 RUN yum install -y curl zip unzip tar autoconf libtool
 RUN yum install -y ninja-build
 RUN yum install -y perl-IPC-Cmd
+# openssl >= 3.6 (pulled in by the current vcpkg pin) needs Time::Piece from perl-core
+RUN yum install -y perl-core
 RUN yum install -y ccache
 RUN yum install -y java-11-openjdk-devel maven
 RUN yum install -y wget

--- a/.github/workflows/_extension_build.yml
+++ b/.github/workflows/_extension_build.yml
@@ -39,7 +39,7 @@ on:
       vcpkg_commit:
         required: false
         type: string
-        default: "ce613c41372b23b1f51333815feb3edd87ef8a8b"
+        default: "84bab45d415d22042bd0b9081aea57f362da3f35"
       # Override the default script producing the matrices. Allows specifying custom matrices.
       matrix_parse_script:
         required: false


### PR DESCRIPTION
## Problem

Every Windows build on `master` has failed since **2026-08-13** (e.g. [this run](https://github.com/DataZooDE/erpl/actions/runs/32149956836/job/95753321195)), and because the deploy jobs `need` the full build matrix, **no binaries have been published to get.erpl.io since 2026-08-08** — the fix from #108 (non-ASCII BICS results, #107) is merged but not yet downloadable.

The root cause is external: the pinned vcpkg commit (`ce613c41`, April 2025) makes `vcpkg_acquire_msys` fetch `msys2-runtime-3.5.4-2`, which msys2 has since purged from all of its mirrors — every mirror returns 404, so the failure is deterministic and re-runs won't help:

```
error: https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.5.4-2-x86_64.pkg.tar.zst: failed: status code 404
error: https://repo.msys2.org/msys/x86_64/msys2-runtime-3.5.4-2-x86_64.pkg.tar.zst: failed: status code 404
...
error: building zlib:x64-windows failed with: BUILD_FAILED
```

## Fix

Bump the default `vcpkg_commit` in `_extension_build.yml` to `84bab45d415d22042bd0b9081aea57f362da3f35` — the pin currently used by [duckdb/extension-ci-tools](https://github.com/duckdb/extension-ci-tools/blob/main/.github/workflows/_extension_distribution.yml), so it is known-good for DuckDB extension builds.

## Verification

- Checked all 75 msys2/mingw package URLs referenced by `vcpkg_acquire_msys.cmake` at the new pin: **all resolve** (HTTP 200 after the mirror redirect).
- The only remaining 404 at that pin is `msys2-runtime-3.4-3.4.10-2`, which sits behind the Windows 7/8-only `X_VCPKG_USE_MSYS2_RUNTIME_3.4` flag and is never fetched on GitHub runners.
- Linux and macOS legs were already green with the old pin; this PR's CI run should confirm they stay green with the new one.

## Note

You may also want to consider deploying `latest` from the platform legs that succeed (or an `if: always()`-style deploy gated per-artifact) so a single broken platform can't silently halt all releases — happy to open a follow-up issue if useful.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789657120&installation_model_id=425457&pr_number=114&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F114&signature=956ee3073e74a1a2fc3d43ea9138036da94be955b772551d286d07cb9f901a34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->