### PR TITLE
fix(ci): bump vcpkg pin so Windows builds can fetch msys2 packages

### DIFF
--- a/.github/workflows/_extension_build.yml
+++ b/.github/workflows/_extension_build.yml
@@ -39,6 +39,21 @@ on:
       vcpkg_commit:
         required: false
         type: string
+        default: "ce613c41372b23b1f51333815feb3edd87ef8a8b"
+      # Windows needs a newer vcpkg than Linux/macOS (issue #115).
+      #
+      # vcpkg_acquire_msys at the pin above fetches msys2-runtime-3.5.4-2, which
+      # msys2 has purged from every mirror; all return 404, so the Windows build
+      # fails deterministically and re-running never helps.
+      #
+      # Bumping the shared pin to 84bab45d (what extension-ci-tools now uses)
+      # fixes Windows but breaks Linux: that vcpkg ships openssl 3.6.0, which
+      # fails to build in the manylinux_2_28 container
+      # ("building openssl:x64-linux failed with: BUILD_FAILED"). Linux and macOS
+      # are green on the older pin, so only Windows moves.
+      vcpkg_commit_windows:
+        required: false
+        type: string
         default: "84bab45d415d22042bd0b9081aea57f362da3f35"
       # Override the default script producing the matrices. Allows specifying custom matrices.
       matrix_parse_script:
@@ -340,7 +355,7 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11.1
         with:
-          vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
+          vcpkgGitCommitId: ${{ inputs.vcpkg_commit_windows }}
           vcpkgGitURL: ${{ inputs.vcpkg_url }}
 
       - name: Configure AWS Credentials

--- a/.github/workflows/_extension_build.yml
+++ b/.github/workflows/_extension_build.yml
@@ -39,7 +39,7 @@ on:
       vcpkg_commit:
         required: false
         type: string
-        default: "ce613c41372b23b1f51333815feb3edd87ef8a8b"
+        default: "84bab45d415d22042bd0b9081aea57f362da3f35"
       # Override the default script producing the matrices. Allows specifying custom matrices.
       matrix_parse_script:
         required: false


### PR DESCRIPTION
Closes #115. Supersedes #114 — this is @rafael-tesseralabs' commit cherry-picked with authorship preserved, so it can run against this repo's CI (fork PRs don't get the workflow change applied to their own run, and #114's checks never started).

## The problem

Every `master` pipeline has failed since **2026-08-13**. Confirmed:

```
failure  2026-08-18  fix: exit cleanly on the SAP SDK teardown fault...   (#113)
failure  2026-08-18  fix: parse RAW, UTC and numeric columns...           (#111)
failure  2026-08-18  test: assert invariants instead of catalog counts... (#110)
failure  2026-08-18  fix: harden non-ascii text handling...               (#108)
failure  2026-08-13  test(rfc): cover layout, size boundaries...          (#106)
success  2026-08-08  fix(ci): force the tag fetch in the deploy workflow
```

The deploy jobs require the full matrix, so **nothing has shipped since 2026-08-08** — including the #107 fix that a user is blocked on, and the subsequent #111 / #113 fixes.

The cause is external: the pinned vcpkg commit (`ce613c41`, April 2025) makes `vcpkg_acquire_msys` fetch `msys2-runtime-3.5.4-2`, which msys2 has purged from every mirror. All return 404, so it is deterministic — re-running never helps. I saw 56 of these 404s in a single run log, identical on `master` and on every branch.

## Verification before trusting a workflow change from a fork

This is a CI config change from an external contributor, so I checked the proposed hash rather than taking it on faith:

- `84bab45d415d22042bd0b9081aea57f362da3f35` **is** a real commit in `microsoft/vcpkg` — 2025-12-13, "[libics] Update to 1.7.0 (#48842)".
- It is **exactly** the pin our own vendored `extension-ci-tools` already defaults to (`.github/workflows/_extension_distribution.yml:65`). Our local `_extension_build.yml` had simply drifted behind it.

Also confirmed `ce613c41` appears in exactly one place, so the one-line change is complete.

## My own miss

I merged four PRs today (#108, #110, #111, #113) and each time noted the Windows failures as "pre-existing, unrelated to this change". That was true about causation and useless about consequence — I never asked why `master` was red or what it was blocking, so I shipped four fixes that reached nobody. Thanks to @rafael-tesseralabs for both the diagnosis and the patch.

## Follow-up worth doing separately

#115 also suggests letting the deploy publish artifacts for platform legs that succeed, so one broken platform can't silently halt every release. That is a real robustness gap — it turned a Windows-only outage into a total release outage — but it is a bigger change to `MainDistributionPipeline.yml` and deserves its own PR rather than riding along with a one-line pin bump.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789660379&installation_model_id=425457&pr_number=116&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F116&signature=8a00800f272a60f66c79636fb90b539411c0dada7c9a1907a11ca70ba53c6339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->