### PR TITLE
fix(ci): let successful platforms publish when one platform's build fails

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -24,9 +24,22 @@ jobs:
       extension_name: erpl
       exclude_archs: linux_arm64;windows_amd64_rtools;wasm_mvp;wasm_eh;wasm_threads;
 
+  # A deploy job depends on its build job, and `needs` normally requires that job
+  # to have succeeded outright. Because the build is a matrix over platforms, a
+  # single broken platform made the whole build job "failure" and skipped deploy
+  # for *every* platform. That is how a Windows-only outage (msys2 purging a pinned
+  # runtime, issue #115) silently stopped all publishing to get.erpl.io for ten
+  # days, across Linux and macOS too.
+  #
+  # `!cancelled()` lets deploy run when the build job did not succeed outright. The
+  # deploy job is itself a matrix over architectures and each leg downloads only its
+  # own artifact, so the platforms that built still publish. A platform whose build
+  # failed has no artifact, so its deploy leg fails at download — which is the
+  # honest signal, and keeps the broken platform visible in CI rather than hiding it.
   duckdb-stable-deploy-v145:
     name: Deploy extension binaries
     needs: duckdb-stable-build-v145
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/_extension_deploy.yml
     secrets: inherit
     with:
@@ -48,6 +61,8 @@ jobs:
   duckdb-stable-deploy-v154:
     name: Deploy extension binaries
     needs: duckdb-stable-build-v154
+    # See the note above duckdb-stable-deploy-v145.
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/_extension_deploy.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Second half of #115, split out from #116 as requested.

## The problem

Deploy jobs depend on their build job via `needs`, which requires that job to have **succeeded outright**. The build is a matrix over platforms, so one broken platform makes the whole build job `failure` and skips deploy for *every* platform.

That is how a **Windows-only** outage stopped all publishing to get.erpl.io for ten days:

```
failure  2026-08-18  fix: exit cleanly on the SAP SDK teardown fault...   (#113)
failure  2026-08-18  fix: parse RAW, UTC and numeric columns...           (#111)
failure  2026-08-18  test: assert invariants instead of catalog counts... (#110)
failure  2026-08-18  fix: harden non-ascii text handling...               (#108)
success  2026-08-08  fix(ci): force the tag fetch in the deploy workflow
```

Linux and macOS built fine throughout. Nothing shipped anyway.

## The change

`if: ${{ !cancelled() }}` on both deploy jobs, so deploy runs when the build job did not succeed outright.

This works because **the deploy job is already a matrix over architectures**, and each leg downloads only its own artifact (`_extension_deploy.yml`, `actions/download-artifact` keyed on `matrix.duckdb_arch`). So:

- platforms that built → publish as normal
- a platform whose build failed → no artifact → its deploy leg fails at download

That last part is deliberate. The broken platform stays visibly red in CI rather than being silently skipped; what changes is that it no longer takes the working platforms down with it.

## Trade-off worth naming

With this, `latest` can hold a newer binary for some platforms than others — e.g. Windows stale while Linux advances. That is a real downside, and I would still take it over a total ten-day outage where nobody gets anything and nothing signals that releases have stopped. The per-arch deploy failures make the skew visible.

## Not included

The actual Windows fix is #116 (Windows-scoped vcpkg pin bump). This PR is only about making one platform's breakage non-fatal to the rest.

Credit to @rafael-tesseralabs, who diagnosed the outage and suggested this in #115 alongside the pin fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789662410&installation_model_id=425457&pr_number=117&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F117&signature=78499d1d17c5957f3c8b7028be5ab69f041e6a33ea9a3855f7ba049f7593fca8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->