### PR TITLE
feat: run erpl on either SAP's RFC SDK or the pure-Rust erpl-proto, chosen at runtime

### DIFF
--- a/.github/workflows/_extension_build.yml
+++ b/.github/workflows/_extension_build.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           app-id: ${{ secrets.REPO_READONLY_GITHUB_APP_ID }}
           private-key: ${{ secrets.REPO_READONLY_GITHUB_APP_KEY }}
-          repositories: "erpl,erpl-bics,erpl-odp"
+          repositories: "erpl,erpl-bics,erpl-odp,erpl-proto"
           
       - uses: actions/checkout@v4
         with:
@@ -112,6 +112,79 @@ jobs:
           windows_matrix="`cat windows_matrix.json`"
           echo windows_matrix=$windows_matrix >> $GITHUB_OUTPUT
           echo `cat $GITHUB_OUTPUT`
+  # -----------------------------------------------------------------------------------------------------------------------------------------------
+  # The alternative pure-Rust RFC backend. erpl can be served by SAP's SDK or by
+  # erpl-proto, chosen at runtime (see ERPL_PROTO_INTEGRATION_PLAN.md), and this leg
+  # guards the contract between the two repositories: that the shim still builds, and
+  # that it still exports every RFC entry point erpl dispatches through. A gap here
+  # would otherwise surface at runtime, on whichever SAP call needed it first.
+  #
+  # The SQL suites are not run here -- they need a live ABAP system, which CI has no
+  # access to; they run on both backends locally via `make sql_tests_all_backends`.
+  #
+  # erpl-proto is a private submodule. A fork without access simply has no proto/
+  # directory, and this job reports that and succeeds rather than failing on something
+  # the contributor cannot fix.
+  erpl_proto_backend:
+    name: erpl-proto backend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub token
+        id: generate_token
+        uses: tibdex/github-app-token@v1.8.2
+        continue-on-error: true
+        with:
+          app_id: ${{ secrets.REPO_READONLY_GITHUB_APP_ID }}
+          private_key: ${{ secrets.REPO_READONLY_GITHUB_APP_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+          token: ${{ steps.generate_token.outputs.token || github.token }}
+        continue-on-error: true
+
+      - name: Checkout without submodules (fork fallback)
+        if: ${{ failure() }}
+        uses: actions/checkout@v4
+
+      - name: Check whether erpl-proto is available
+        id: availability
+        run: |
+          if [ -f proto/Cargo.toml ]; then
+            echo "available=true" >> $GITHUB_OUTPUT
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+            echo "::notice::erpl-proto submodule not available (private repository); skipping the proto backend checks."
+          fi
+
+      - name: Install Rust
+        if: steps.availability.outputs.available == 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        if: steps.availability.outputs.available == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            proto/target
+          key: erpl-proto-cargo-${{ hashFiles('proto/Cargo.lock') }}
+
+      - name: Build the nwrfc ABI shim
+        if: steps.availability.outputs.available == 'true'
+        run: cargo build --release --manifest-path proto/Cargo.toml -p erpl-proto-nwrfc
+
+      - name: Check the entry-point contract
+        if: steps.availability.outputs.available == 'true'
+        run: ./scripts/check_proto_backend_symbols.sh proto/target/release/libsapnwrfc.so
+
+      - name: erpl-proto sans-IO codec tests
+        if: steps.availability.outputs.available == 'true'
+        # The wire crate is self-contained and needs no SAP system -- these tests are the
+        # protocol's executable specification.
+        run: cargo test --release --manifest-path proto/Cargo.toml -p erpl-proto-wire
+
   # -----------------------------------------------------------------------------------------------------------------------------------------------
   linux:
     name: Linux

--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           app-id: ${{ secrets.REPO_READONLY_GITHUB_APP_ID }}
           private-key: ${{ secrets.REPO_READONLY_GITHUB_APP_KEY }}
-          repositories: "erpl,erpl-bics,erpl-odp"
+          repositories: "erpl,erpl-bics,erpl-odp,erpl-proto"
           
       - uses: actions/checkout@v4
         with:
@@ -97,7 +97,7 @@ jobs:
         with:
           app-id: ${{ secrets.REPO_READONLY_GITHUB_APP_ID }}
           private-key: ${{ secrets.REPO_READONLY_GITHUB_APP_KEY }}
-          repositories: "erpl,erpl-bics,erpl-odp"
+          repositories: "erpl,erpl-bics,erpl-odp,erpl-proto"
 
       - uses: actions/checkout@v4
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "datazoo-banner"]
 	path = datazoo-banner
 	url = https://github.com/DataZooDE/duckdb-extension-banner.git
+[submodule "proto"]
+	path = proto
+	url = https://github.com/DataZooDE/erpl-proto.git

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -272,6 +272,17 @@ PRAGMA sap_rfc_ping(secret='my_sap');
 
 ---
 
+#### `sap_rfc_backend()`
+
+Which implementation is serving SAP RFC calls: `'nwrfc'` or `'proto'`. Resolves the backend
+if that has not happened yet. See [Selecting the RFC backend](#selecting-the-rfc-backend).
+
+```sql
+SELECT sap_rfc_backend();
+```
+
+---
+
 #### `PRAGMA sap_rfc_set_trace_level(level)`
 
 Set SAP NetWeaver RFC SDK trace level.
@@ -1312,12 +1323,35 @@ Notes:
 | `erpl_rfc_persistent_connections` | BOOLEAN | `true` | Cache one RFC connection + function descriptor per column for a `sap_read_table` scan instead of reopening per batch |
 | `erpl_rfc_max_persistent_connections` | UINTEGER | 16 | Upper bound on RFC connections a scan caches concurrently (issue #67); columns past the cap use per-batch open/close |
 | `erpl_rfc_read_table_batch_budget` | UINTEGER | 1310720 | Target max concurrent result rows (projected columns × per-column batch) for `sap_read_table`; bounds peak memory on wide tables (issue #69). Lower = less memory but more RFC round-trips; `0` disables the cap |
+| `erpl_rfc_backend` | VARCHAR | `'nwrfc'` | Which implementation serves RFC calls: `'nwrfc'` (SAP's NetWeaver RFC SDK) or `'proto'` (the pure-Rust erpl-proto implementation). Must be set **before the first SAP call**; frozen for the life of the process once resolved. Environment override: `ERPL_RFC_BACKEND` |
+| `erpl_rfc_backend_path` | VARCHAR | `''` | Explicit path to the RFC backend shared library, overriding the search. Empty means: next to the extension, then the loader's library path. Environment override: `ERPL_RFC_BACKEND_PATH` |
 
 ```sql
 SET erpl_trace_enabled = TRUE;
 SET erpl_trace_level = 'DEBUG';
 SET erpl_trace_output = 'both';
 ```
+
+##### Selecting the RFC backend
+
+erpl does not link the SAP SDK. It resolves the RFC entry points at runtime, so the
+implementation behind them is a runtime choice:
+
+```sql
+-- Must come before any SAP call in this process.
+SET erpl_rfc_backend = 'proto';
+SELECT sap_rfc_backend();          -- 'proto'
+```
+
+The backend freezes at the first SAP call. Connections and function descriptors belong to
+one implementation, so a later `SET` is refused rather than allowed to hand a handle from
+one library to the other — start a new process to switch.
+
+If `'proto'` is selected and its library cannot be found, the call fails. erpl never falls
+back to the SDK, because a silent downgrade would leave you believing you had tested a
+backend you had not.
+
+---
 
 #### erpl_bics
 

--- a/ERPL_PROTO_INTEGRATION_PLAN.md
+++ b/ERPL_PROTO_INTEGRATION_PLAN.md
@@ -1,0 +1,159 @@
+# Integrating erpl-proto into erpl
+
+Plan for putting [`erpl-proto`](https://github.com/DataZooDE/erpl-proto) — the pure-Rust
+implementation of SAP's classic RFC protocol — underneath `erpl`, selectable at runtime
+against the stock SAP NW RFC SDK.
+
+**`nwrfc` stays the default.** `proto` is opt-in until its test legs are green.
+
+## The seam: the nwrfc C ABI
+
+`erpl-proto-cxx` exposes a narrow, high-level API (`invoke` / `describe` / `read_table`).
+That is nowhere near erpl's surface — `bics/` and `odp/` reach deep into containers, rows
+and field descriptors. `erpl-proto-nwrfc`, by contrast, builds a `libsapnwrfc.so` that
+exports the full SDK symbol set.
+
+Measured against this tree, `rfc/`, `bics/` and `odp/` together call **54 SDK entry
+points**, and the shim implements all 54:
+
+```
+RfcAppendNewRow RfcCloseConnection RfcCreateFunction RfcDestroyFunction RfcGetBytes
+RfcGetChars RfcGetConnectionAttributes RfcGetCurrentRow RfcGetDate RfcGetDirectionAsString
+RfcGetFieldCount RfcGetFieldDescByIndex RfcGetFloat RfcGetFunctionDesc RfcGetInt RfcGetInt1
+RfcGetInt2 RfcGetInt8 RfcGetNum RfcGetParameterCount RfcGetParameterDescByIndex
+RfcGetRcAsString RfcGetRowCount RfcGetString RfcGetStringLength RfcGetStructure RfcGetTable
+RfcGetTime RfcGetTypeAsString RfcGetTypeName RfcGetXString RfcInvoke RfcMoveTo
+RfcOpenConnection RfcPing RfcReloadIniFile RfcSAPUCToUTF8 RfcSetBytes RfcSetDate RfcSetFloat
+RfcSetIniPath RfcSetInt RfcSetInt1 RfcSetInt2 RfcSetInt8 RfcSetNum RfcSetParameterActive
+RfcSetString RfcSetTime RfcSetTraceDir RfcSetTraceLevel RfcSetMaximumStoredTraceFiles
+RfcSetMaximumTraceFileSize RfcSetXString
+```
+
+So this is a link/load change, not a source port.
+
+## The selection mechanism: runtime dispatch
+
+Both libraries export the same symbols, so only one can be *linked* — whichever the loader
+resolves first wins for the whole process. erpl therefore stops linking `libsapnwrfc`
+altogether and resolves the 54 entry points through a function-pointer table filled by
+`dlopen` + `dlsym` (`LoadLibrary` / `GetProcAddress` on Windows) at first RFC use.
+
+Two facts make this safe:
+
+- The Rust cdylib carries **no SONAME** (verified with `objdump -p`), so it can be renamed
+  and loaded by absolute path with no chance of SONAME-based resolution picking the wrong one.
+- Loading with `RTLD_LOCAL` keeps its symbols out of the global table, so the two libraries
+  cannot interpose on each other even if both are ever resident.
+
+`sapnwrfc.h` remains a **compile-time** dependency for types, structs and enums. Phase 7
+removes even that.
+
+### Why not a build-time switch
+
+`-DERPL_RFC_BACKEND=proto` would mean two full build trees to test both backends: slow
+locally, doubled CI, and impossible to flip for a single test file. Runtime dispatch gives
+one binary, both backends, and a dual-leg test matrix off a single build.
+
+## Repository layout
+
+`erpl-proto` stays private. It is added as a submodule at `proto/`, following the exact
+pattern `bics/` and `odp/` already use — `extension_config.cmake` and the RFC build guard on
+`if(EXISTS ...)`, so a clone without access builds precisely as it does today, with the
+nwrfc backend and no Rust toolchain required.
+
+The submodule uses an HTTPS remote (like `duckdb/`) rather than the `git@` form `bics/` and
+`odp/` use, because HTTPS + the `gh` credential helper is what authenticates in practice.
+
+## Phases
+
+Each phase is a self-contained PR.
+
+### Phase 0 — decisions
+
+- [x] Seam is the nwrfc C ABI, not the cxx bridge.
+- [x] Selection is runtime `dlopen` dispatch, not a configure-time switch.
+- [x] `proto/` is a private submodule, conditionally built.
+- [x] SDK headers stay a compile-time dependency for now; vendoring is Phase 7.
+- [x] Rust becomes a build prerequisite *only* when `proto/` is present.
+
+### Phase 1 — build plumbing, no behaviour change
+
+- Add the `proto/` submodule.
+- CMake: when `proto/Cargo.toml` exists, a custom target runs
+  `cargo build --release -p erpl-proto-nwrfc` and copies the artifact to
+  `build/<cfg>/liberpl_proto_nwrfc.so` — **renamed**, so it can never be found by SONAME or
+  by a stray `-lsapnwrfc`.
+- Nothing links or loads it yet. All suites stay green, unchanged.
+
+### Phase 2 — the dispatch layer (riskiest step; its own PR)
+
+- New `rfc/src/sap_rfc_api.{hpp,cpp}`: an X-macro list of the 54 entry points generating a
+  `RfcApi` function-pointer struct, populated on first use.
+- The header includes `sapnwrfc.h` for types, then `#define`s each entry point to the
+  dispatch call. Every consumer includes this instead of `sapnwrfc.h` directly — that is
+  53 headers and sources across `rfc/`, `bics/` and `odp/`.
+- Drop `${SAPNWRFC_LIB_FILES}` from `target_link_libraries`; add `${CMAKE_DL_LIBS}`.
+- **Backend is still nwrfc**, now reached by dlopen. Full RFC + BICS + ODP suites must be
+  green before merge.
+- `bics/` and `odp/` changes ship as submodule commits plus a parent pointer-bump PR.
+
+### Phase 3 — the toggle
+
+- Extension option `erpl_rfc_backend`: `'nwrfc'` (default) or `'proto'`. Env override
+  `ERPL_RFC_BACKEND`.
+- `erpl_rfc_backend_path` / `ERPL_RFC_PROTO_LIB` for an explicit library path.
+- Resolved once and frozen at first RFC use. Changing it afterwards raises a clear error
+  rather than silently mixing backends within a process.
+- Search order: explicit path → alongside the extension → build dir → loader path. A
+  missing library when `proto` was requested is a hard error — **never** a silent fallback
+  to nwrfc, which would make a green proto test leg meaningless.
+
+### Phase 4 — tests on both backends
+
+- Parameterise `RUN_SQL_TESTS` in the `Makefile` with a backend argument.
+- New targets: `sql_tests_rfc_proto`, `sql_tests_bics_proto`, `sql_tests_odp_proto`, and
+  `sql_tests_all_backends`. Existing targets keep their current meaning (nwrfc).
+- `test/proto_known_failures.txt`, checked in: the proto leg fails on anything not listed,
+  and warns loudly when a listed test unexpectedly passes. This keeps the proto leg
+  meaningfully green while gaps close, rather than permanently red and ignored.
+  **Seed it from a measured run** — erpl-proto's own sources disagree about the current
+  state (`README.md` says 13 of 20, `docs/spec/15-nwrfc-abi.md` ABI-4 says 18 of 20 with
+  `sap_rfc_invoke_fuzz` and `sap_rfc_type_coverage` failing), so trust neither.
+- C++ unit tests: `test_type_conversion` is backend-independent; `test_connection_close`
+  and `test_sap_secret` run per backend.
+- The SAP SDK exit-abort tolerance (erpl#112) is gated to the nwrfc leg. Under proto there
+  is no SDK static destructor, so an abort there is a real failure.
+
+### Phase 5 — CI
+
+Add a proto leg to `.github/workflows/_extension_build.yml`, gated on submodule
+availability so fork PRs skip it instead of failing.
+
+### Phase 6 — close the gaps
+
+Work `proto_known_failures.txt` down: deep tables (`STFC_DEEP_TABLE`), `RSTR` columns typed
+`VARCHAR` where they should be `BLOB`, and whatever the BICS and ODP suites surface. These
+are fixes in erpl-proto, reaching erpl by submodule pointer bump.
+
+### Phase 7 — release packaging
+
+The payoff. `trampoline/` currently embeds `libsapnwrfc` + `libsapucum` + three ICU
+libraries, roughly 30 MB. A proto build embeds one ~1 MB Rust `.so` and needs no
+post-install extraction of the SDK. This is also where a vendored `erpl_sapnwrfc.h` lands in
+erpl-proto, removing the SDK from the build entirely.
+
+## Known risks
+
+- **Phase 2 spans three repositories.** `bics/` and `odp/` include `sapnwrfc.h` from 31 of
+  their headers between them; all must move to the dispatch header in lockstep.
+- **Windows and macOS** need their own dispatch back end (`LoadLibrary`, and dlopen with
+  `.dylib` naming). Linux lands first.
+- **`scripts/lsan_suppress.txt`** and the `LD_LIBRARY_PATH` plumbing in
+  `scripts/start-duckdb-debug.sh` and the `Makefile`'s `COMMON_TEST_ENV` are SDK-specific
+  and need proto variants.
+- **The OpenSSL/telemetry conflict** (SAP SDK's `RTLD_GLOBAL` shadowing OpenSSL, worked
+  around with `DATAZOO_DISABLE_TELEMETRY=1` in smoke tests) may behave differently — or
+  disappear — under `RTLD_LOCAL` and no SDK. Re-measure rather than assume.
+- **Debug builds statically link the extensions** into the DuckDB binary; the SDK is
+  currently linked in with them. Dispatch removes that link, which changes what
+  `build/debug/duckdb` depends on at load time.

--- a/ERPL_PROTO_INTEGRATION_PLAN.md
+++ b/ERPL_PROTO_INTEGRATION_PLAN.md
@@ -13,8 +13,8 @@ That is nowhere near erpl's surface — `bics/` and `odp/` reach deep into conta
 and field descriptors. `erpl-proto-nwrfc`, by contrast, builds a `libsapnwrfc.so` that
 exports the full SDK symbol set.
 
-Measured against this tree, `rfc/`, `bics/` and `odp/` together call **54 SDK entry
-points**, and the shim implements all 54:
+Measured against this tree, `rfc/`, `bics/` and `odp/` together call **55 SDK entry
+points**, and the shim implements all 55:
 
 ```
 RfcAppendNewRow RfcCloseConnection RfcCreateFunction RfcDestroyFunction RfcGetBytes
@@ -35,7 +35,7 @@ So this is a link/load change, not a source port.
 
 Both libraries export the same symbols, so only one can be *linked* — whichever the loader
 resolves first wins for the whole process. erpl therefore stops linking `libsapnwrfc`
-altogether and resolves the 54 entry points through a function-pointer table filled by
+altogether and resolves the 55 entry points through a function-pointer table filled by
 `dlopen` + `dlsym` (`LoadLibrary` / `GetProcAddress` on Windows) at first RFC use.
 
 Two facts make this safe:
@@ -76,7 +76,7 @@ Each phase is a self-contained PR.
 - [x] SDK headers stay a compile-time dependency for now; vendoring is Phase 7.
 - [x] Rust becomes a build prerequisite *only* when `proto/` is present.
 
-### Phase 1 — build plumbing, no behaviour change
+### Phase 1 — build plumbing, no behaviour change *(done)*
 
 - Add the `proto/` submodule.
 - CMake: when `proto/Cargo.toml` exists, a custom target runs
@@ -85,30 +85,41 @@ Each phase is a self-contained PR.
   by a stray `-lsapnwrfc`.
 - Nothing links or loads it yet. All suites stay green, unchanged.
 
-### Phase 2 — the dispatch layer (riskiest step; its own PR)
+### Phase 2 — the dispatch layer *(done, landed with Phase 3)*
 
-- New `rfc/src/sap_rfc_api.{hpp,cpp}`: an X-macro list of the 54 entry points generating a
+- New `rfc/src/sap_rfc_api.{hpp,cpp}`: an X-macro list of the 55 entry points generating a
   `RfcApi` function-pointer struct, populated on first use.
 - The header includes `sapnwrfc.h` for types, then `#define`s each entry point to the
   dispatch call. Every consumer includes this instead of `sapnwrfc.h` directly — that is
-  53 headers and sources across `rfc/`, `bics/` and `odp/`.
+  48 headers and sources across `rfc/`, `bics/` and `odp/`.
+
+  One collision had to be resolved first: `duckdb::RfcPing`, the `sap_rfc_ping` pragma
+  handler, shares its name with the SDK's `RfcPing` and is renamed `RfcPingPragma`.
+
+  `strlenU16` turned out to be the only symbol erpl needed from `libsapucum`. It is a
+  four-line loop, now supplied in the dispatch header, which lets that library leave the
+  link line too — so the SDK is gone from the link entirely, not merely reduced.
 - Drop `${SAPNWRFC_LIB_FILES}` from `target_link_libraries`; add `${CMAKE_DL_LIBS}`.
 - **Backend is still nwrfc**, now reached by dlopen. Full RFC + BICS + ODP suites must be
   green before merge.
 - `bics/` and `odp/` changes ship as submodule commits plus a parent pointer-bump PR.
 
-### Phase 3 — the toggle
+### Phase 3 — the toggle *(done)*
+
+Landed together with Phase 2: separating them would have meant committing a dispatch
+layer hardcoded to one backend and then immediately rewriting it.
+
 
 - Extension option `erpl_rfc_backend`: `'nwrfc'` (default) or `'proto'`. Env override
   `ERPL_RFC_BACKEND`.
-- `erpl_rfc_backend_path` / `ERPL_RFC_PROTO_LIB` for an explicit library path.
+- `erpl_rfc_backend_path` / `ERPL_RFC_BACKEND_PATH` for an explicit library path.
 - Resolved once and frozen at first RFC use. Changing it afterwards raises a clear error
   rather than silently mixing backends within a process.
-- Search order: explicit path → alongside the extension → build dir → loader path. A
+- Search order: explicit path → alongside the extension → loader path. A
   missing library when `proto` was requested is a hard error — **never** a silent fallback
   to nwrfc, which would make a green proto test leg meaningless.
 
-### Phase 4 — tests on both backends
+### Phase 4 — tests on both backends *(done)*
 
 - Parameterise `RUN_SQL_TESTS` in the `Makefile` with a backend argument.
 - New targets: `sql_tests_rfc_proto`, `sql_tests_bics_proto`, `sql_tests_odp_proto`, and
@@ -124,10 +135,19 @@ Each phase is a self-contained PR.
 - The SAP SDK exit-abort tolerance (erpl#112) is gated to the nwrfc leg. Under proto there
   is no SDK static destructor, so an abort there is a real failure.
 
-### Phase 5 — CI
+### Phase 5 — CI *(done)*
 
-Add a proto leg to `.github/workflows/_extension_build.yml`, gated on submodule
-availability so fork PRs skip it instead of failing.
+Added an `erpl_proto_backend` job: it builds the shim, runs erpl-proto's sans-IO codec
+tests, and gates the entry-point contract with `scripts/check_proto_backend_symbols.sh`.
+Gated on submodule availability so fork PRs skip it instead of failing.
+
+The SQL suites cannot run in CI — they need a live ABAP system — so both backends are
+covered locally through `make sql_tests_all_backends`.
+
+`erpl-proto` was added to the scoped token used by the matrix job. The platform build jobs
+use an *unscoped* app token, so the GitHub App must additionally be installed on
+`DataZooDE/erpl-proto` before their submodule checkout will succeed. That is a repository
+admin action, not a code change.
 
 ### Phase 6 — close the gaps
 
@@ -135,12 +155,46 @@ Work `proto_known_failures.txt` down: deep tables (`STFC_DEEP_TABLE`), `RSTR` co
 `VARCHAR` where they should be `BLOB`, and whatever the BICS and ODP suites surface. These
 are fixes in erpl-proto, reaching erpl by submodule pointer bump.
 
-### Phase 7 — release packaging
+### Phase 7 — release packaging *(partly done)*
 
-The payoff. `trampoline/` currently embeds `libsapnwrfc` + `libsapucum` + three ICU
-libraries, roughly 30 MB. A proto build embeds one ~1 MB Rust `.so` and needs no
-post-install extraction of the SDK. This is also where a vendored `erpl_sapnwrfc.h` lands in
-erpl-proto, removing the SDK from the build entirely.
+The trampoline now also embeds the proto shim and extracts it next to the other
+extensions, where the dispatch layer finds it without any search path or environment
+variable. It is shipped **alongside** the SDK, not instead of it: nwrfc stays the default,
+and carrying both means a released build can be flipped with `SET erpl_rfc_backend =
+'proto'` and flipped straight back. That costs about 1 MB against the SDK + ICU's ~30 MB.
+
+It is extracted but deliberately **not** loaded. The trampoline loads its libraries
+`RTLD_GLOBAL`; doing that to a library exporting the same `Rfc*` symbols as the SDK would
+have the two interposing on each other. erpl_rfc opens it on demand, `RTLD_LOCAL`, and only
+if the backend is actually selected.
+
+Still outstanding, and only worth doing once proto has proven itself in the field:
+
+- Drop the SDK + ICU from the trampoline in a proto-only build. That is what actually makes
+  the artifact small; shipping both cannot.
+- Vendor a minimal `erpl_sapnwrfc.h` into erpl-proto, removing the SDK from the build
+  entirely. Today `sapnwrfc.h` is still needed at compile time for its types.
+
+## Measured state
+
+Both backends run the full suites against the a4h trial. Measured on this branch, not
+assumed:
+
+| Suite | nwrfc | proto |
+|---|---|---|
+| `rfc` (27 files) | 27 pass | 27 pass |
+| `odp` (24 files) | 24 pass | 24 pass |
+| `bics` (43 files) | *measuring* | *measuring* |
+
+The proto leg was additionally run with the SAP SDK **removed from the library path
+entirely**, and stayed green — which is what rules out a silent fallback. The same run on
+the nwrfc backend fails immediately with "Could not load the SAP NW RFC SDK", so the check
+is not vacuous.
+
+This is well ahead of what erpl-proto's own documentation claims: its `README.md` says 13
+of erpl's 20 tests pass and `docs/spec/15-nwrfc-abi.md` (ABI-4) says 18 of 20, naming
+`sap_rfc_invoke_fuzz` and `sap_rfc_type_coverage` as failures. Both are stale — the suite
+is 27 files now, and both named tests pass. Worth correcting in erpl-proto.
 
 ## Known risks
 

--- a/ERPL_PROTO_INTEGRATION_PLAN.md
+++ b/ERPL_PROTO_INTEGRATION_PLAN.md
@@ -4,7 +4,8 @@ Plan for putting [`erpl-proto`](https://github.com/DataZooDE/erpl-proto) — the
 implementation of SAP's classic RFC protocol — underneath `erpl`, selectable at runtime
 against the stock SAP NW RFC SDK.
 
-**`nwrfc` stays the default.** `proto` is opt-in until its test legs are green.
+**`nwrfc` stays the default.** `proto` is opt-in — its test legs are green (see
+[Measured state](#measured-state)), but the default does not move on one machine's results.
 
 ## The seam: the nwrfc C ABI
 
@@ -149,11 +150,15 @@ use an *unscoped* app token, so the GitHub App must additionally be installed on
 `DataZooDE/erpl-proto` before their submodule checkout will succeed. That is a repository
 admin action, not a code change.
 
-### Phase 6 — close the gaps
+### Phase 6 — close the gaps *(nothing to close)*
 
-Work `proto_known_failures.txt` down: deep tables (`STFC_DEEP_TABLE`), `RSTR` columns typed
-`VARCHAR` where they should be `BLOB`, and whatever the BICS and ODP suites surface. These
-are fixes in erpl-proto, reaching erpl by submodule pointer bump.
+The gaps this phase existed to work down were not there. Every suite passes on both
+backends and all three `proto_known_failures.txt` files are empty — including the deep
+tables (`STFC_DEEP_TABLE`) and `RSTR` typing that ABI-4 named. The one defect that did
+turn up was the `RFC_RC` ordinal set above, fixed in erpl-proto and gated here.
+
+Keep the mechanism: the lists and the unexpected-pass check cost nothing while empty, and
+they are what will make the next regression legible.
 
 ### Phase 7 — release packaging *(partly done)*
 
@@ -177,16 +182,21 @@ Still outstanding, and only worth doing once proto has proven itself in the fiel
 
 ## Measured state
 
-Both backends run the full suites against the a4h trial. Measured on this branch, not
+Every suite runs against the a4h trial on both backends. Measured on this branch, not
 assumed:
 
 | Suite | nwrfc | proto |
 |---|---|---|
 | `rfc` (27 files) | 27 pass | 27 pass |
 | `odp` (24 files) | 24 pass | 24 pass |
-| `bics` (43 files) | *measuring* | *measuring* |
+| `bics` (43 files) | 43 pass | 43 pass |
+| `tunnel` (3 files) | 3 pass | n/a (no RFC) |
+| C++ (121 cases) | 3210 assertions | 3212 assertions |
 
-The proto leg was additionally run with the SAP SDK **removed from the library path
+`proto_known_failures.txt` is empty in all three suites. There was nothing to put in it,
+which is not what Phase 4 expected.
+
+The proto legs were additionally run with the SAP SDK **removed from the library path
 entirely**, and stayed green — which is what rules out a silent fallback. The same run on
 the nwrfc backend fails immediately with "Could not load the SAP NW RFC SDK", so the check
 is not vacuous.
@@ -196,18 +206,55 @@ of erpl's 20 tests pass and `docs/spec/15-nwrfc-abi.md` (ABI-4) says 18 of 20, n
 `sap_rfc_invoke_fuzz` and `sap_rfc_type_coverage` as failures. Both are stale — the suite
 is 27 files now, and both named tests pass. Worth correcting in erpl-proto.
 
+### What the dual-backend matrix caught
+
+One real defect, and it is the argument for running both legs rather than trusting one.
+
+`sapnwrfc.h`'s `RFC_RC` is an unnumbered enum, so every value is an ordinal you can only
+get right by counting declarations. Five of the shim's were wrong:
+
+| Constant | shim had | SDK | what the shim's value actually means |
+|---|---|---|---|
+| `RFC_INVALID_HANDLE` | 8 | 13 | `RFC_TIMEOUT` |
+| `RFC_EXTERNAL_FAILURE` | 20 | 15 | `RFC_INVALID_PARAMETER` |
+| `RFC_NOT_FOUND` | 23 | 17 | `RFC_BUFFER_TOO_SMALL` |
+| `RFC_NOT_SUPPORTED` | 21 | 18 | `RFC_CODEPAGE_CONVERSION_FAILURE` |
+| `RFC_INVALID_PARAMETER` | 12 | 20 | `RFC_SERIALIZATION_FAILURE` |
+
+None of this is visible from inside erpl-proto: its own tests compare against the same
+constants, so they agreed with themselves. It only surfaces in a consumer that *branches*
+on a return code. `RfcConnection::Close` treats `RFC_INVALID_HANDLE` as benign — a handle
+already gone is nothing left to close (erpl#78) — so receiving 8 turned every close of a
+stale connection into a thrown `IOException`, caught only by the destructor's catch-all,
+which exists because an escaping exception there would `std::terminate` the process.
+`RFC_NOT_SUPPORTED` matters as much: it is what all 177 unimplemented entry points report.
+
+Note *which* leg caught it. The SQL suites never exercise a stale-handle close and were
+green throughout; the C++ suite found it the first time it ran on proto.
+`scripts/check_proto_backend_symbols.sh` now gates every `RFC_RC` constant against the SDK
+header so it cannot come back.
+
 ## Known risks
 
-- **Phase 2 spans three repositories.** `bics/` and `odp/` include `sapnwrfc.h` from 31 of
-  their headers between them; all must move to the dispatch header in lockstep.
-- **Windows and macOS** need their own dispatch back end (`LoadLibrary`, and dlopen with
-  `.dylib` naming). Linux lands first.
+- **This spans four repositories.** `bics/`, `odp/` and `proto/` all carry commits that
+  the parent's submodule pointers must be bumped to. Push the submodule branches before
+  the parent PR, or CI resolves pointers that do not exist on the remote.
+- **Windows and macOS are written but unexercised.** The dispatch layer has
+  `LoadLibrary`/`GetProcAddress` and `.dylib`/`.dll` naming, and the trampoline embeds the
+  shim as a resource / Mach-O object, but only Linux has been run. CI builds all three;
+  nothing has *tested* the other two.
 - **`scripts/lsan_suppress.txt`** and the `LD_LIBRARY_PATH` plumbing in
   `scripts/start-duckdb-debug.sh` and the `Makefile`'s `COMMON_TEST_ENV` are SDK-specific
   and need proto variants.
 - **The OpenSSL/telemetry conflict** (SAP SDK's `RTLD_GLOBAL` shadowing OpenSSL, worked
   around with `DATAZOO_DISABLE_TELEMETRY=1` in smoke tests) may behave differently — or
-  disappear — under `RTLD_LOCAL` and no SDK. Re-measure rather than assume.
-- **Debug builds statically link the extensions** into the DuckDB binary; the SDK is
-  currently linked in with them. Dispatch removes that link, which changes what
-  `build/debug/duckdb` depends on at load time.
+  disappear — under `RTLD_LOCAL` and no SDK. The smoke test still passes with the
+  workaround in place; nobody has checked whether it is still needed on the proto backend.
+- **The SDK is no longer linked anywhere**, in either build type or in any test binary.
+  `build/debug/duckdb` and the released extensions all resolve it at runtime instead, so
+  a machine that used to fail at link time for a missing SDK now fails at the first SAP
+  call — with a message naming the search path, but later than before.
+
+- **The GitHub App must be installed on `DataZooDE/erpl-proto`.** The platform build jobs
+  use an unscoped app token; without the installation their submodule checkout fails. This
+  is repository-admin work, not a code change.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
-.PHONY: all clean format debug release pull update wasm_mvp wasm_eh wasm_threads sql_tests_rfc sql_tests_bics sql_tests_odp sql_tests_tunnel smoke_test smoke_test_musl
+.PHONY: all clean format debug debug_tests release pull update wasm_mvp wasm_eh wasm_threads sql_tests_rfc sql_tests_bics sql_tests_odp sql_tests_tunnel sql_tests_rfc_proto sql_tests_bics_proto sql_tests_odp_proto sql_tests_all_backends smoke_test smoke_test_musl
 
 # Test file argument - if provided, run only that specific test
 TEST_FILE ?=
@@ -86,6 +86,16 @@ endif
 configure_ci:
 	@echo "configure_ci step is skipped for this extension build..."
 
+#### Build target for the SQL suites
+# Builds only the unittest binary (and, through it, the extensions and the erpl-proto
+# shim).  The full `debug` target additionally links tools/plan_serializer, which fails
+# under GNU ld for reasons unrelated to erpl -- depending on it would make every SQL
+# suite unrunnable.
+debug_tests:
+	mkdir -p ./build/debug/
+	cmake $(GENERATOR) $(BUILD_FLAGS) -DBUILD_UNITTESTS=ON -DCMAKE_BUILD_TYPE=Debug -S ./duckdb/ -B ./build/debug/
+	cmake --build ./build/debug/ --config Debug --target unittest
+
 #### SQL Test Configuration
 # Common environment variables for all test targets
 COMMON_TEST_ENV = RFC_TRACE=0 \
@@ -102,6 +112,18 @@ SAP_COMMON_VARS = ERPL_SAP_ASHOST=localhost \
                   ERPL_SAP_USER=DEVELOPER \
                   ERPL_SAP_PASSWORD=$(SAP_PASSWORD)
 
+#### RFC backend selection
+# The suites run twice: once on SAP's SDK, once on the pure-Rust erpl-proto shim.  nwrfc
+# is the default and needs no variables at all -- the proto legs point the extension at
+# the library the build staged.  See ERPL_PROTO_INTEGRATION_PLAN.md.
+PROTO_BACKEND_VARS = ERPL_RFC_BACKEND=proto \
+                     ERPL_RFC_BACKEND_PATH=$(PROJ_DIR)build/debug/liberpl_proto_nwrfc.so
+
+# Tests known to fail on the proto backend.  A listed test that fails is reported as a
+# known gap; a listed test that PASSES fails the run, so the list cannot silently rot.
+# Override with ALLOW_UNEXPECTED_PASS=1 while working through the list.
+ALLOW_UNEXPECTED_PASS ?= 0
+
 # SSH tunnel variables
 SSH_VARS = ERPL_SSH_HOST=localhost \
            ERPL_SSH_PORT=2222 \
@@ -109,76 +131,59 @@ SSH_VARS = ERPL_SSH_HOST=localhost \
            ERPL_SSH_PASSWORD=testpass \
            ERPL_SSH_PRIVATE_KEY_PATH=test/integration/test_key
 
-# Common test execution logic.
-#
-# Every test's exit status is checked and failures are aggregated. The previous
-# version ran the files in a bare loop and returned only the *last* test's
-# status, so a failure anywhere else was reported as success — the ODP suite was
-# silently green while five of its files were failing.
-#
-# One narrow exception: the SAP NW RFC SDK aborts inside its own static
-# destructor at process exit ("pure virtual method called", issue #112) on
-# roughly 10% of runs, after every assertion has already passed. That is
-# third-party teardown, not a test result, so it is surfaced as a warning. It is
-# matched on both the pass marker and the SDK signature, so any other abort —
-# including a crash that loses assertions — still fails the run.
+# Common test execution logic lives in scripts/run_sql_tests.sh -- it grew past what is
+# readable inlined in a make recipe once it had to handle two backends and per-backend
+# expected failures.  See that script for the rules it applies.
 define RUN_SQL_TESTS
-	cd $(1) && $(COMMON_TEST_ENV) $(2) bash -c ' \
-		set -u; \
-		failed=0; sdk_aborts=0; \
-		run_one() { \
-			local f="$$1" log rc; \
-			log=$$(mktemp); \
-			echo "Running test: $$f"; \
-			../build/debug/test/unittest --test-dir . "$$f" >"$$log" 2>&1; rc=$$?; \
-			if [ $$rc -ne 0 ] && grep -q "All tests passed" "$$log" \
-					&& grep -q "pure virtual method called" "$$log"; then \
-				echo "  WARN: assertions passed, SAP SDK aborted at exit (erpl#112)"; \
-				sdk_aborts=$$((sdk_aborts+1)); rc=0; \
-			fi; \
-			if [ $$rc -ne 0 ]; then \
-				echo "  FAIL: $$f"; cat "$$log"; failed=$$((failed+1)); \
-			fi; \
-			rm -f "$$log"; \
-		}; \
-		if [ -n "$(TEST_FILE)" ]; then \
-			run_one "test/sql/$(TEST_FILE)"; \
-		else \
-			for test_file in test/sql/*.test; do run_one "$$test_file"; done; \
-		fi; \
-		if [ $$sdk_aborts -gt 0 ]; then \
-			echo "$$sdk_aborts test(s) hit the SAP SDK exit abort (issue #112)"; \
-		fi; \
-		if [ $$failed -gt 0 ]; then echo "$$failed test(s) FAILED"; exit 1; fi; \
-		echo "All SQL tests passed"'
+	ALLOW_UNEXPECTED_PASS=$(ALLOW_UNEXPECTED_PASS) $(COMMON_TEST_ENV) $(2) $(3) \
+		$(PROJ_DIR)scripts/run_sql_tests.sh $(1) \
+		$(if $(4),--backend $(4)) \
+		$(if $(5),--known-failures $(PROJ_DIR)$(5)) \
+		$(if $(TEST_FILE),--test-file $(TEST_FILE))
 endef
 
 #### SQL Test targets
+#
+# Each suite runs on both RFC backends.  The bare targets are the nwrfc (SAP SDK) legs and
+# keep their previous meaning; the _proto targets run the same files against erpl-proto.
 
-sql_tests_rfc: debug
-	$(call RUN_SQL_TESTS,./rfc,$(SAP_COMMON_VARS))
+sql_tests_rfc: debug_tests
+	$(call RUN_SQL_TESTS,rfc,$(SAP_COMMON_VARS),,nwrfc,)
 
-sql_tests_bics: debug
-	$(call RUN_SQL_TESTS,./bics,$(SAP_COMMON_VARS))
+sql_tests_bics: debug_tests
+	$(call RUN_SQL_TESTS,bics,$(SAP_COMMON_VARS),,nwrfc,)
 
-sql_tests_odp: debug
-	$(call RUN_SQL_TESTS,./odp,$(SAP_COMMON_VARS))
+sql_tests_odp: debug_tests
+	$(call RUN_SQL_TESTS,odp,$(SAP_COMMON_VARS),,nwrfc,)
 
-sql_tests_tunnel: debug
+sql_tests_rfc_proto: debug_tests
+	$(call RUN_SQL_TESTS,rfc,$(SAP_COMMON_VARS),$(PROTO_BACKEND_VARS),proto,rfc/test/proto_known_failures.txt)
+
+sql_tests_bics_proto: debug_tests
+	$(call RUN_SQL_TESTS,bics,$(SAP_COMMON_VARS),$(PROTO_BACKEND_VARS),proto,bics/test/proto_known_failures.txt)
+
+sql_tests_odp_proto: debug_tests
+	$(call RUN_SQL_TESTS,odp,$(SAP_COMMON_VARS),$(PROTO_BACKEND_VARS),proto,odp/test/proto_known_failures.txt)
+
+# Every suite on every backend.  Serial on purpose: the suites share one SAP system and
+# one unittest binary, and running them concurrently corrupts both.
+sql_tests_all_backends:
+	$(MAKE) sql_tests_rfc
+	$(MAKE) sql_tests_bics
+	$(MAKE) sql_tests_odp
+	$(MAKE) sql_tests_rfc_proto
+	$(MAKE) sql_tests_bics_proto
+	$(MAKE) sql_tests_odp_proto
+
+sql_tests_tunnel: debug_tests
 	@echo "Starting SSH mock server via docker-compose..."
 	cd ./tunnel/test/integration && docker-compose up -d
 	@echo "Waiting for SSH server to be ready..."
 	@sleep 15
-	@echo "Using static SSH keypairs for testing..."
-	@cd ./tunnel/test/integration && echo "Static keys are already generated and mounted"
-	@echo "Static SSH public keys are already mounted in the container..."
-	@echo "Waiting for SSH key setup..."
-	@sleep 5
 	@echo "Running tunnel SQL tests..."
-	$(call RUN_SQL_TESTS,./tunnel,$(SSH_VARS))
+	$(call RUN_SQL_TESTS,tunnel,$(SSH_VARS),,nwrfc,)
 	@echo "Stopping SSH mock server..."
 	cd ./tunnel/test/integration && docker-compose down
-	@echo "Static SSH keys are preserved for future tests..."
 
 # Usage examples:
 #   make sql_tests_bics                    # Run all BICS tests
@@ -186,7 +191,8 @@ sql_tests_tunnel: debug
 #   make sql_tests_rfc TEST_FILE=sap_rfc_invoke.test       # Run only RFC invoke test
 #   make sql_tests_odp TEST_FILE=sap_odp_describe.test     # Run only ODP describe test
 #   make sql_tests_tunnel                  # Run all tunnel tests
-#   make sql_tests_tunnel TEST_FILE=sap_tunnel_basic.test  # Run only basic tunnel test
+#   make sql_tests_rfc_proto               # Same RFC files, on the erpl-proto backend
+#   make sql_tests_all_backends            # Every suite on both backends
 
 #### Smoke test — verifies the release extension installs and loads correctly
 # Downloads the official DuckDB CLI for the built version; no SAP connection required.

--- a/rfc/CMakeLists.txt
+++ b/rfc/CMakeLists.txt
@@ -63,6 +63,7 @@ set(EXTENSION_SOURCES
       src/sap_secret.cpp
       src/erpl_tracing.cpp
       src/sap_connection.cpp
+      src/sap_rfc_api.cpp
       src/sap_function.cpp
       src/sap_type_conversion.cpp
       src/sap_rfc.cpp
@@ -88,6 +89,14 @@ build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 set(PARAMETERS "-warnings")
 build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES})
 
+if(ERPL_PROTO_AVAILABLE)
+      # So that building the extension -- or the unittest binary, which links it -- also
+      # stages the shim. Without this only the `all` target would build it, and the SQL
+      # suites build a narrower target than that.
+      add_dependencies(${EXTENSION_NAME} erpl_proto_backend)
+      add_dependencies(${LOADABLE_EXTENSION_NAME} erpl_proto_backend)
+endif()
+
 if(WIN32)
       default_win32_definitions(${EXTENSION_NAME})
       default_win32_definitions(${LOADABLE_EXTENSION_NAME})
@@ -103,8 +112,11 @@ if(UNIX AND APPLE)
       default_osx_definitions(${LOADABLE_EXTENSION_NAME})
 endif()
 
-target_link_libraries(${EXTENSION_NAME} ${SAPNWRFC_LIB_FILES} ${OPENSSL_LIBRARIES} posthog_telemetry)
-target_link_libraries(${LOADABLE_EXTENSION_NAME} ${SAPNWRFC_LIB_FILES} ${OPENSSL_LIBRARIES} posthog_telemetry)
+# The SAP SDK is deliberately NOT linked: both it and the erpl-proto shim export the same
+# symbols, so the backend is opened with dlopen/RTLD_LOCAL at runtime instead. Only the
+# headers are used at compile time. See src/sap_rfc_api.hpp.
+target_link_libraries(${EXTENSION_NAME} ${OPENSSL_LIBRARIES} posthog_telemetry ${CMAKE_DL_LIBS})
+target_link_libraries(${LOADABLE_EXTENSION_NAME} ${OPENSSL_LIBRARIES} posthog_telemetry ${CMAKE_DL_LIBS})
 
 if(MINGW)
    target_link_libraries(${EXTENSION_NAME} -lcrypt32)

--- a/rfc/CMakeLists.txt
+++ b/rfc/CMakeLists.txt
@@ -27,6 +27,10 @@ endif()
 
 find_package(OpenSSL REQUIRED)
 
+# The alternative pure-Rust RFC backend, when the private erpl-proto submodule is present.
+# Phase 1: built and staged only -- nothing links or loads it yet.
+add_erpl_proto_backend()
+
 # Add posthog-telemetry submodule
 # Disable posthog-telemetry's own tests - we use erpl's tests instead
 set(POSTHOG_BUILD_UNITTESTS_SAVED ${BUILD_UNITTESTS})

--- a/rfc/src/erpl_rfc_extension.cpp
+++ b/rfc/src/erpl_rfc_extension.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 
 #include "erpl_rfc_extension.hpp"
 #include "pragma_ping.hpp"
@@ -18,6 +19,7 @@
 #include "scanner_describe_fields.hpp"
 #include "scanner_read_table.hpp"
 #include "scanner_rfc_authorizations.hpp"
+#include "sap_rfc_api.hpp"
 #include "sap_rfc.hpp"
 
 #include "telemetry.hpp"
@@ -154,6 +156,24 @@ namespace duckdb {
         SetRfcReadTableBatchBudget(parameter.GetValue<unsigned int>());
     }
 
+    static void OnRfcBackend(ClientContext &, SetScope, Value &parameter) {
+        SetRfcBackend(parameter.GetValue<string>());
+    }
+
+    static void OnRfcBackendPath(ClientContext &, SetScope, Value &parameter) {
+        SetRfcBackendLibraryPath(parameter.GetValue<string>());
+    }
+
+    // Reports which implementation is serving RFC calls, resolving the backend if that
+    // has not happened yet.  Deliberately returns the bare name rather than the library
+    // path, so a test can assert on it without depending on where the build put things.
+    static void RfcBackendFunction(DataChunk &args, ExpressionState &, Vector &result) {
+        const auto name = string(RfcBackendName(GetResolvedRfcBackend()));
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+        ConstantVector::GetData<string_t>(result)[0] = StringVector::AddString(result, name);
+        D_ASSERT(args.size() >= 0);
+    }
+
     static void RegisterConfiguration(ExtensionLoader &loader)
     {
         auto &instance = loader.GetDatabaseInstance();
@@ -208,6 +228,26 @@ namespace duckdb {
             OnMaxPersistentConnections);
 
         config.AddExtensionOption(
+            "erpl_rfc_backend",
+            "Which implementation serves SAP RFC calls: 'nwrfc' (SAP's NetWeaver RFC SDK, "
+            "the default) or 'proto' (the pure-Rust erpl-proto implementation).  Must be "
+            "set before the first SAP call; the backend is frozen for the life of the "
+            "process once resolved.  Also settable with the ERPL_RFC_BACKEND environment "
+            "variable, which an explicit SET overrides.",
+            LogicalType::VARCHAR,
+            Value("nwrfc"),
+            OnRfcBackend);
+
+        config.AddExtensionOption(
+            "erpl_rfc_backend_path",
+            "Explicit path to the RFC backend shared library, overriding the search.  "
+            "Empty (the default) means search: next to the extension, then the loader's "
+            "library path.  Also settable with ERPL_RFC_BACKEND_PATH.",
+            LogicalType::VARCHAR,
+            Value(""),
+            OnRfcBackendPath);
+
+        config.AddExtensionOption(
             "erpl_rfc_read_table_batch_budget",
             "Target upper bound on concurrent result rows (projected columns x "
             "per-column batch size) held by a sap_read_table scan (issue #69).  "
@@ -231,6 +271,20 @@ namespace duckdb {
     static void RegisterRfcFunctions(ExtensionLoader &loader)
     {
         loader.RegisterFunction(CreateRfcPingPragma());
+
+        {
+            ScalarFunction backend_function("sap_rfc_backend", {}, LogicalType::VARCHAR, RfcBackendFunction);
+            // The answer depends on process-wide state, not on the arguments, so it must
+            // not be folded at bind time or cached across statements.
+            backend_function.stability = FunctionStability::VOLATILE;
+            CreateScalarFunctionInfo info(backend_function);
+            FunctionDescription desc;
+            desc.description = "Returns which implementation is serving SAP RFC calls: 'nwrfc' or 'proto'.";
+            desc.examples    = {"SELECT sap_rfc_backend()"};
+            desc.categories  = {"sap"};
+            info.descriptions.push_back(std::move(desc));
+            loader.RegisterFunction(std::move(info));
+        }
 
         {
             CreateTableFunctionInfo info(CreateRfcReadTableScanFunction());

--- a/rfc/src/erpl_rfc_extension.cpp
+++ b/rfc/src/erpl_rfc_extension.cpp
@@ -305,7 +305,7 @@ namespace duckdb {
             // named parameters this function takes are `path` and `secret`, so
             // REQUTEXT='Hello' is rejected by the binder.
             desc.examples    = {"SELECT * FROM sap_rfc_invoke('STFC_CONNECTION', {'REQUTEXT': 'Hello'})",
-                                "SELECT * FROM sap_rfc_invoke('RFC_READ_TABLE', {'QUERY_TABLE': 'SFLIGHT', 'DELIMITER': '|'})"};
+                                "SELECT * FROM sap_rfc_invoke('BAPI_FLIGHT_GETLIST', path='/FLIGHT_LIST')"};
             desc.categories  = {"sap"};
             desc.parameter_names = {"function_name"};
             info.descriptions.push_back(std::move(desc));

--- a/rfc/src/erpl_rfc_extension.cpp
+++ b/rfc/src/erpl_rfc_extension.cpp
@@ -300,9 +300,12 @@ namespace duckdb {
         {
             CreateTableFunctionInfo info(CreateRfcInvokeScanFunction());
             FunctionDescription desc;
-            desc.description = "Call any RFC-enabled SAP function module and return its result as a table. Additional named arguments are forwarded as function parameters.";
-            desc.examples    = {"SELECT * FROM sap_rfc_invoke('STFC_CONNECTION', REQUTEXT='Hello')",
-                                "SELECT * FROM sap_rfc_invoke('RFC_READ_TABLE', QUERY_TABLE='SFLIGHT', DELIMITER='|')"};
+            desc.description = "Call any RFC-enabled SAP function module and return its result as a table. Function parameters are passed as STRUCT values, e.g. {'REQUTEXT': 'Hello'}.";
+            // Function parameters travel as a STRUCT, not as named arguments: the only
+            // named parameters this function takes are `path` and `secret`, so
+            // REQUTEXT='Hello' is rejected by the binder.
+            desc.examples    = {"SELECT * FROM sap_rfc_invoke('STFC_CONNECTION', {'REQUTEXT': 'Hello'})",
+                                "SELECT * FROM sap_rfc_invoke('RFC_READ_TABLE', {'QUERY_TABLE': 'SFLIGHT', 'DELIMITER': '|'})"};
             desc.categories  = {"sap"};
             desc.parameter_names = {"function_name"};
             info.descriptions.push_back(std::move(desc));

--- a/rfc/src/erpl_rfc_extension.cpp
+++ b/rfc/src/erpl_rfc_extension.cpp
@@ -167,11 +167,10 @@ namespace duckdb {
     // Reports which implementation is serving RFC calls, resolving the backend if that
     // has not happened yet.  Deliberately returns the bare name rather than the library
     // path, so a test can assert on it without depending on where the build put things.
-    static void RfcBackendFunction(DataChunk &args, ExpressionState &, Vector &result) {
+    static void RfcBackendFunction(DataChunk &, ExpressionState &, Vector &result) {
         const auto name = string(RfcBackendName(GetResolvedRfcBackend()));
         result.SetVectorType(VectorType::CONSTANT_VECTOR);
         ConstantVector::GetData<string_t>(result)[0] = StringVector::AddString(result, name);
-        D_ASSERT(args.size() >= 0);
     }
 
     static void RegisterConfiguration(ExtensionLoader &loader)

--- a/rfc/src/include/pragma_ini.hpp
+++ b/rfc/src/include/pragma_ini.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 #include "sap_rfc.hpp"
 
 namespace duckdb {

--- a/rfc/src/include/pragma_ping.hpp
+++ b/rfc/src/include/pragma_ping.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "duckdb.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 #include "sap_rfc.hpp"
 
 namespace duckdb {
-    string RfcPing(ClientContext &context, const FunctionParameters &parameters);
+    string RfcPingPragma(ClientContext &context, const FunctionParameters &parameters);
     PragmaFunction CreateRfcPingPragma();
 }

--- a/rfc/src/include/pragma_set_trace.hpp
+++ b/rfc/src/include/pragma_set_trace.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 #include "sap_rfc.hpp"
 
 namespace duckdb {

--- a/rfc/src/include/sap_connection.hpp
+++ b/rfc/src/include/sap_connection.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 #include "sap_secret.hpp"
 
 namespace duckdb 

--- a/rfc/src/include/sap_function.hpp
+++ b/rfc/src/include/sap_function.hpp
@@ -3,7 +3,7 @@
 #include <set>
 
 #include "duckdb.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 
 #include "sap_connection.hpp"
 #include "sap_type_conversion.hpp"

--- a/rfc/src/include/sap_rfc.hpp
+++ b/rfc/src/include/sap_rfc.hpp
@@ -8,7 +8,7 @@
 #include "duckdb.hpp"
 #include "duckdb/parallel/base_pipeline_event.hpp"
 #include "duckdb/parallel/task_executor.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 
 #include "sap_function.hpp"
 

--- a/rfc/src/include/sap_rfc_api.hpp
+++ b/rfc/src/include/sap_rfc_api.hpp
@@ -1,0 +1,209 @@
+#pragma once
+
+// Runtime dispatch over the SAP RFC C ABI.
+//
+// erpl no longer links libsapnwrfc. Every SDK entry point it uses is resolved at
+// runtime through the table below, so which implementation actually serves a call --
+// SAP's SDK or the pure-Rust erpl-proto shim -- is a runtime decision rather than a
+// link-time one. See ERPL_PROTO_INTEGRATION_PLAN.md.
+//
+// Both libraries export the same symbol names, so at most one of them can ever be
+// linked or loaded into the global symbol scope; whichever the loader reaches first
+// would silently serve every call. That is why this header exists, why the library is
+// opened with RTLD_LOCAL, and why nothing here is resolved through RTLD_DEFAULT unless
+// the SDK was deliberately preloaded (which the trampoline extension does).
+//
+// sapnwrfc.h is still included, for its types, structs and enums -- it is a
+// compile-time dependency only. The slots below take their signatures from it via
+// decltype, so a slot cannot drift from the declaration it stands in for.
+//
+// A translation unit that needs the real symbols rather than the dispatch macros --
+// only sap_rfc_api.cpp does -- defines ERPL_RFC_API_IMPLEMENTATION before including.
+
+#include "duckdb.hpp"
+#include "sapnwrfc.h"
+
+namespace duckdb {
+
+#ifndef strlenU16
+// The single symbol erpl needs from libsapucum -- a UTF-16 strlen. Supplying it here is
+// what lets that library leave the link line as well; keeping a whole shared library of
+// the SDK's for one four-line loop would defeat the point of the exercise. Declared in
+// namespace duckdb so it shadows the SDK's declaration at every call site, which are all
+// inside this namespace. On Windows sapucrfc.h macro-defines strlenU16 to wcslen, so
+// there the SDK's own definition stands and this is skipped.
+inline size_t strlenU16(const SAP_UTF16 *s) {
+	const SAP_UTF16 *cursor = s;
+	while (*cursor) {
+		cursor++;
+	}
+	return static_cast<size_t>(cursor - s);
+}
+#endif
+
+// Every SDK entry point erpl, bics and odp call between them. Adding a call to an entry
+// point that is not listed here fails to link, which is the intended safety net: the
+// missing name is named, rather than resolving to whatever the loader happens to hold.
+#define ERPL_RFC_API_ENTRY_POINTS(X) \
+	X(RfcAppendNewRow) \
+	X(RfcCloseConnection) \
+	X(RfcCreateFunction) \
+	X(RfcDestroyFunction) \
+	X(RfcGetBytes) \
+	X(RfcGetChars) \
+	X(RfcGetConnectionAttributes) \
+	X(RfcGetCurrentRow) \
+	X(RfcGetDate) \
+	X(RfcGetDirectionAsString) \
+	X(RfcGetFieldCount) \
+	X(RfcGetFieldDescByIndex) \
+	X(RfcGetFloat) \
+	X(RfcGetFunctionDesc) \
+	X(RfcGetInt) \
+	X(RfcGetInt1) \
+	X(RfcGetInt2) \
+	X(RfcGetInt8) \
+	X(RfcGetNum) \
+	X(RfcGetParameterCount) \
+	X(RfcGetParameterDescByIndex) \
+	X(RfcGetRcAsString) \
+	X(RfcGetRowCount) \
+	X(RfcGetString) \
+	X(RfcGetStringLength) \
+	X(RfcGetStructure) \
+	X(RfcGetTable) \
+	X(RfcGetTime) \
+	X(RfcGetTypeAsString) \
+	X(RfcGetTypeName) \
+	X(RfcGetXString) \
+	X(RfcInvoke) \
+	X(RfcMoveTo) \
+	X(RfcOpenConnection) \
+	X(RfcPing) \
+	X(RfcReloadIniFile) \
+	X(RfcSAPUCToUTF8) \
+	X(RfcSetBytes) \
+	X(RfcSetDate) \
+	X(RfcSetFloat) \
+	X(RfcSetIniPath) \
+	X(RfcSetInt) \
+	X(RfcSetInt1) \
+	X(RfcSetInt2) \
+	X(RfcSetInt8) \
+	X(RfcSetMaximumStoredTraceFiles) \
+	X(RfcSetMaximumTraceFileSize) \
+	X(RfcSetNum) \
+	X(RfcSetParameterActive) \
+	X(RfcSetString) \
+	X(RfcSetTime) \
+	X(RfcSetTraceDir) \
+	X(RfcSetTraceLevel) \
+	X(RfcSetXString) \
+	X(RfcUTF8ToSAPUC)
+
+// The resolved entry points. Signatures come from sapnwrfc.h, never from transcription.
+struct RfcApi {
+#define ERPL_RFC_API_DECLARE_SLOT(name) decltype(&::name) name;
+	ERPL_RFC_API_ENTRY_POINTS(ERPL_RFC_API_DECLARE_SLOT)
+#undef ERPL_RFC_API_DECLARE_SLOT
+};
+
+// Which implementation serves RFC calls.
+enum class RfcBackend : uint8_t {
+	// SAP's own libsapnwrfc from the NetWeaver RFC SDK. The default, and what every
+	// released build has used to date.
+	NWRFC,
+	// The pure-Rust erpl-proto shim. Opt-in while its test legs are still being closed.
+	PROTO
+};
+
+const char *RfcBackendName(RfcBackend backend);
+
+// Selects the backend, by the name RfcBackendName returns. Backed by the
+// erpl_rfc_backend setting and the ERPL_RFC_BACKEND environment variable.
+//
+// A backend can only be chosen before the first RFC call. Once resolved it is frozen for
+// the life of the process: connections, function descriptors and cached handles all
+// belong to one implementation, and letting a later SET redirect calls half-way through
+// would hand a handle from one library to the other. Selecting the backend that is
+// already active is accepted, so re-running a SET is not an error.
+void SetRfcBackend(const string &name);
+
+// An explicit path to the backend library, overriding the search. Backed by the
+// erpl_rfc_backend_path setting and ERPL_RFC_BACKEND_PATH.
+void SetRfcBackendLibraryPath(const string &path);
+
+// Resolves the backend library on first call and fills the table. Throws if the library
+// cannot be opened or an entry point is missing -- a half-filled table would fail later,
+// at a call site with no clue as to why.
+const RfcApi &GetRfcApi();
+
+// The backend actually serving calls, resolving it if that has not happened yet.
+RfcBackend GetResolvedRfcBackend();
+
+// Human-readable description of what is serving RFC calls, including which library file
+// it came from. For tracing and diagnostics; sap_rfc_backend() reports the bare name,
+// which is stable enough to assert on in tests.
+const string &GetRfcBackendDescription();
+
+} // namespace duckdb
+
+#ifndef ERPL_RFC_API_IMPLEMENTATION
+// Call sites are left verbatim: the macro expands to a call through a pointer of exactly
+// the declared type, so overload resolution and implicit conversions behave as before.
+#define RfcAppendNewRow (::duckdb::GetRfcApi().RfcAppendNewRow)
+#define RfcCloseConnection (::duckdb::GetRfcApi().RfcCloseConnection)
+#define RfcCreateFunction (::duckdb::GetRfcApi().RfcCreateFunction)
+#define RfcDestroyFunction (::duckdb::GetRfcApi().RfcDestroyFunction)
+#define RfcGetBytes (::duckdb::GetRfcApi().RfcGetBytes)
+#define RfcGetChars (::duckdb::GetRfcApi().RfcGetChars)
+#define RfcGetConnectionAttributes (::duckdb::GetRfcApi().RfcGetConnectionAttributes)
+#define RfcGetCurrentRow (::duckdb::GetRfcApi().RfcGetCurrentRow)
+#define RfcGetDate (::duckdb::GetRfcApi().RfcGetDate)
+#define RfcGetDirectionAsString (::duckdb::GetRfcApi().RfcGetDirectionAsString)
+#define RfcGetFieldCount (::duckdb::GetRfcApi().RfcGetFieldCount)
+#define RfcGetFieldDescByIndex (::duckdb::GetRfcApi().RfcGetFieldDescByIndex)
+#define RfcGetFloat (::duckdb::GetRfcApi().RfcGetFloat)
+#define RfcGetFunctionDesc (::duckdb::GetRfcApi().RfcGetFunctionDesc)
+#define RfcGetInt (::duckdb::GetRfcApi().RfcGetInt)
+#define RfcGetInt1 (::duckdb::GetRfcApi().RfcGetInt1)
+#define RfcGetInt2 (::duckdb::GetRfcApi().RfcGetInt2)
+#define RfcGetInt8 (::duckdb::GetRfcApi().RfcGetInt8)
+#define RfcGetNum (::duckdb::GetRfcApi().RfcGetNum)
+#define RfcGetParameterCount (::duckdb::GetRfcApi().RfcGetParameterCount)
+#define RfcGetParameterDescByIndex (::duckdb::GetRfcApi().RfcGetParameterDescByIndex)
+#define RfcGetRcAsString (::duckdb::GetRfcApi().RfcGetRcAsString)
+#define RfcGetRowCount (::duckdb::GetRfcApi().RfcGetRowCount)
+#define RfcGetString (::duckdb::GetRfcApi().RfcGetString)
+#define RfcGetStringLength (::duckdb::GetRfcApi().RfcGetStringLength)
+#define RfcGetStructure (::duckdb::GetRfcApi().RfcGetStructure)
+#define RfcGetTable (::duckdb::GetRfcApi().RfcGetTable)
+#define RfcGetTime (::duckdb::GetRfcApi().RfcGetTime)
+#define RfcGetTypeAsString (::duckdb::GetRfcApi().RfcGetTypeAsString)
+#define RfcGetTypeName (::duckdb::GetRfcApi().RfcGetTypeName)
+#define RfcGetXString (::duckdb::GetRfcApi().RfcGetXString)
+#define RfcInvoke (::duckdb::GetRfcApi().RfcInvoke)
+#define RfcMoveTo (::duckdb::GetRfcApi().RfcMoveTo)
+#define RfcOpenConnection (::duckdb::GetRfcApi().RfcOpenConnection)
+#define RfcPing (::duckdb::GetRfcApi().RfcPing)
+#define RfcReloadIniFile (::duckdb::GetRfcApi().RfcReloadIniFile)
+#define RfcSAPUCToUTF8 (::duckdb::GetRfcApi().RfcSAPUCToUTF8)
+#define RfcSetBytes (::duckdb::GetRfcApi().RfcSetBytes)
+#define RfcSetDate (::duckdb::GetRfcApi().RfcSetDate)
+#define RfcSetFloat (::duckdb::GetRfcApi().RfcSetFloat)
+#define RfcSetIniPath (::duckdb::GetRfcApi().RfcSetIniPath)
+#define RfcSetInt (::duckdb::GetRfcApi().RfcSetInt)
+#define RfcSetInt1 (::duckdb::GetRfcApi().RfcSetInt1)
+#define RfcSetInt2 (::duckdb::GetRfcApi().RfcSetInt2)
+#define RfcSetInt8 (::duckdb::GetRfcApi().RfcSetInt8)
+#define RfcSetMaximumStoredTraceFiles (::duckdb::GetRfcApi().RfcSetMaximumStoredTraceFiles)
+#define RfcSetMaximumTraceFileSize (::duckdb::GetRfcApi().RfcSetMaximumTraceFileSize)
+#define RfcSetNum (::duckdb::GetRfcApi().RfcSetNum)
+#define RfcSetParameterActive (::duckdb::GetRfcApi().RfcSetParameterActive)
+#define RfcSetString (::duckdb::GetRfcApi().RfcSetString)
+#define RfcSetTime (::duckdb::GetRfcApi().RfcSetTime)
+#define RfcSetTraceDir (::duckdb::GetRfcApi().RfcSetTraceDir)
+#define RfcSetTraceLevel (::duckdb::GetRfcApi().RfcSetTraceLevel)
+#define RfcSetXString (::duckdb::GetRfcApi().RfcSetXString)
+#define RfcUTF8ToSAPUC (::duckdb::GetRfcApi().RfcUTF8ToSAPUC)
+#endif

--- a/rfc/src/include/sap_type_conversion.hpp
+++ b/rfc/src/include/sap_type_conversion.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 #include "sap_function.hpp"
 
 #include "duckdb/common/types/time.hpp"

--- a/rfc/src/include/scanner_describe_fields.hpp
+++ b/rfc/src/include/scanner_describe_fields.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 

--- a/rfc/src/include/scanner_describe_function.hpp
+++ b/rfc/src/include/scanner_describe_function.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 

--- a/rfc/src/include/scanner_describe_references.hpp
+++ b/rfc/src/include/scanner_describe_references.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 

--- a/rfc/src/include/scanner_invoke.hpp
+++ b/rfc/src/include/scanner_invoke.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 

--- a/rfc/src/include/scanner_read_table.hpp
+++ b/rfc/src/include/scanner_read_table.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 

--- a/rfc/src/include/scanner_show_functions.hpp
+++ b/rfc/src/include/scanner_show_functions.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 

--- a/rfc/src/include/scanner_show_groups.hpp
+++ b/rfc/src/include/scanner_show_groups.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 

--- a/rfc/src/include/scanner_show_tables.hpp
+++ b/rfc/src/include/scanner_show_tables.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 

--- a/rfc/src/pragma_ini.cpp
+++ b/rfc/src/pragma_ini.cpp
@@ -1,6 +1,6 @@
 #include "pragma_ini.hpp"
 #include "duckdb/parser/parsed_data/create_pragma_function_info.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 #include "telemetry.hpp"
 
 namespace duckdb 

--- a/rfc/src/pragma_ping.cpp
+++ b/rfc/src/pragma_ping.cpp
@@ -3,7 +3,7 @@
 #include "telemetry.hpp"
 
 namespace duckdb {
-    string RfcPing(ClientContext &context, const FunctionParameters &parameters) 
+    string RfcPingPragma(ClientContext &context, const FunctionParameters &parameters) 
     {
         PostHogTelemetry::Instance().RecordFunctionCall("sap_rfc_ping");
 
@@ -18,7 +18,7 @@ namespace duckdb {
 
     PragmaFunction CreateRfcPingPragma() 
     {
-        auto rfc_ping_pragma = PragmaFunction::PragmaCall("sap_rfc_ping", RfcPing, {});
+        auto rfc_ping_pragma = PragmaFunction::PragmaCall("sap_rfc_ping", RfcPingPragma, {});
         rfc_ping_pragma.named_parameters["secret"] = LogicalType::VARCHAR;
 
         return rfc_ping_pragma;

--- a/rfc/src/pragma_set_trace.cpp
+++ b/rfc/src/pragma_set_trace.cpp
@@ -1,6 +1,6 @@
 #include "pragma_set_trace.hpp"
 #include "duckdb/parser/parsed_data/create_pragma_function_info.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 #include "telemetry.hpp"
 
 namespace duckdb 

--- a/rfc/src/sap_function.cpp
+++ b/rfc/src/sap_function.cpp
@@ -5,7 +5,7 @@
 #include <set>
 #include <stdexcept>
 
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 #include "duckdb.hpp"
 #include "duckdb_argument_helper.hpp"
 #include "sap_function.hpp"

--- a/rfc/src/sap_rfc_api.cpp
+++ b/rfc/src/sap_rfc_api.cpp
@@ -1,0 +1,342 @@
+// Resolution of the SAP RFC C ABI at runtime. See sap_rfc_api.hpp for why.
+
+#define ERPL_RFC_API_IMPLEMENTATION
+#include "sap_rfc_api.hpp"
+
+#include "erpl_tracing.hpp"
+
+#include <cstdlib>
+#include <mutex>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+namespace duckdb {
+
+namespace {
+
+// The SDK's own library, under each platform's spelling. Opened through the loader's
+// search path, so LD_LIBRARY_PATH (or the equivalent) keeps working exactly as it did
+// when erpl linked the library directly.
+#ifdef _WIN32
+constexpr const char *NWRFC_LIBRARY_NAME = "sapnwrfc.dll";
+#elif defined(__APPLE__)
+constexpr const char *NWRFC_LIBRARY_NAME = "libsapnwrfc.dylib";
+#else
+constexpr const char *NWRFC_LIBRARY_NAME = "libsapnwrfc.so";
+#endif
+
+// The erpl-proto shim, staged under its own name rather than libsapnwrfc's. See
+// add_erpl_proto_backend() in scripts/functions.cmake for why it is renamed.
+#ifdef _WIN32
+constexpr const char *PROTO_LIBRARY_NAME = "erpl_proto_nwrfc.dll";
+#elif defined(__APPLE__)
+constexpr const char *PROTO_LIBRARY_NAME = "liberpl_proto_nwrfc.dylib";
+#else
+constexpr const char *PROTO_LIBRARY_NAME = "liberpl_proto_nwrfc.so";
+#endif
+
+// A witness that the SDK is already mapped into the global symbol scope. The trampoline
+// extension extracts the SDK and dlopens it RTLD_GLOBAL before erpl_rfc loads, and it
+// extracts to a directory that is on no search path -- so in a released build this is
+// the only way to reach it. Same probe the trampoline itself uses.
+constexpr const char *NWRFC_PRELOAD_WITNESS = "RfcGetVersion";
+
+struct LibraryHandle {
+	// Null means "resolve against the process's global scope" rather than "not loaded".
+	void *handle = nullptr;
+	string description;
+};
+
+string LastLibraryError() {
+#ifdef _WIN32
+	const auto code = GetLastError();
+	if (code == 0) {
+		return "unknown error";
+	}
+	char *buffer = nullptr;
+	const auto length =
+	    FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+	                   nullptr, code, 0, reinterpret_cast<char *>(&buffer), 0, nullptr);
+	string message = length && buffer ? string(buffer, length) : StringUtil::Format("error %lu", (unsigned long)code);
+	if (buffer) {
+		LocalFree(buffer);
+	}
+	return StringUtil::Trim(message);
+#else
+	const char *error = dlerror();
+	return error ? string(error) : string("unknown error");
+#endif
+}
+
+void *OpenLibrary(const string &path) {
+#ifdef _WIN32
+	return reinterpret_cast<void *>(LoadLibraryA(path.c_str()));
+#else
+	// RTLD_LOCAL is the load-bearing flag. The SDK and the erpl-proto shim export the
+	// same symbol names, so a library brought in with RTLD_GLOBAL would interpose on
+	// anything loaded after it -- including the other backend -- and calls would be
+	// served by whichever won that race rather than by the one that was selected.
+	//
+	// RTLD_NODELETE keeps it mapped for the life of the process: the SDK registers
+	// static destructors and atexit handlers, and unmapping it while DuckDB still holds
+	// connection state has no safe ordering.
+	return dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL | RTLD_NODELETE);
+#endif
+}
+
+void *FindSymbol(const LibraryHandle &library, const char *name) {
+#ifdef _WIN32
+	if (!library.handle) {
+		return reinterpret_cast<void *>(GetProcAddress(GetModuleHandleA(nullptr), name));
+	}
+	return reinterpret_cast<void *>(GetProcAddress(reinterpret_cast<HMODULE>(library.handle), name));
+#else
+	return dlsym(library.handle ? library.handle : RTLD_DEFAULT, name);
+#endif
+}
+
+bool IsPreloadedInGlobalScope() {
+#ifdef _WIN32
+	return GetProcAddress(GetModuleHandleA(nullptr), NWRFC_PRELOAD_WITNESS) != nullptr;
+#else
+	return dlsym(RTLD_DEFAULT, NWRFC_PRELOAD_WITNESS) != nullptr;
+#endif
+}
+
+LibraryHandle OpenNwRfcLibrary(const string &explicit_path) {
+	if (!explicit_path.empty()) {
+		auto *handle = OpenLibrary(explicit_path);
+		if (!handle) {
+			throw IOException("Could not load the SAP NW RFC SDK from the configured path '%s': %s", explicit_path,
+			                  LastLibraryError());
+		}
+		return {handle, StringUtil::Format("nwrfc (%s)", explicit_path)};
+	}
+
+	// A deliberately preloaded SDK wins over a search-path lookup. In a released build
+	// the trampoline has already extracted and loaded it from a private directory, and
+	// opening a second copy from the search path would give two SDK instances with
+	// separate static state in one process.
+	if (IsPreloadedInGlobalScope()) {
+		ERPL_TRACE_INFO("RfcApi", "SAP NW RFC SDK already present in the global symbol scope, using it");
+		return {nullptr, "nwrfc (preloaded)"};
+	}
+
+	auto *handle = OpenLibrary(NWRFC_LIBRARY_NAME);
+	if (!handle) {
+		throw IOException("Could not load the SAP NW RFC SDK (%s): %s. The SDK is not linked into erpl; it is "
+		                  "loaded at runtime, so its directory must be reachable through the library search path "
+		                  "(LD_LIBRARY_PATH on Linux, DYLD_LIBRARY_PATH on macOS, PATH on Windows).",
+		                  NWRFC_LIBRARY_NAME, LastLibraryError());
+	}
+	return {handle, StringUtil::Format("nwrfc (%s)", NWRFC_LIBRARY_NAME)};
+}
+
+// Fills the table, failing on the first missing entry point rather than leaving a null
+// slot to be discovered later at a call site.
+RfcApi ResolveApi(const LibraryHandle &library) {
+	RfcApi api {};
+	idx_t resolved = 0;
+
+#define ERPL_RFC_API_RESOLVE_SLOT(name)                                                                                \
+	{                                                                                                                  \
+		auto *symbol = FindSymbol(library, #name);                                                                     \
+		if (!symbol) {                                                                                                 \
+			throw IOException("The RFC backend '%s' does not provide the entry point %s, which erpl requires.",        \
+			                  library.description, #name);                                                             \
+		}                                                                                                              \
+		api.name = reinterpret_cast<decltype(api.name)>(symbol);                                                       \
+		resolved++;                                                                                                    \
+	}
+	ERPL_RFC_API_ENTRY_POINTS(ERPL_RFC_API_RESOLVE_SLOT)
+#undef ERPL_RFC_API_RESOLVE_SLOT
+
+	ERPL_TRACE_INFO("RfcApi", StringUtil::Format("Resolved %llu RFC entry points from %s", (uint64_t)resolved,
+	                                             library.description));
+	return api;
+}
+
+// The directory holding the binary this code is linked into: the erpl_rfc extension in a
+// released build, the duckdb executable in a statically linked debug build. The proto
+// shim is staged next to both, so one lookup covers both layouts.
+string OwnModuleDirectory() {
+#ifdef _WIN32
+	HMODULE module = nullptr;
+	if (!GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+	                        reinterpret_cast<LPCSTR>(&OwnModuleDirectory), &module)) {
+		return string();
+	}
+	char path[MAX_PATH];
+	const auto length = GetModuleFileNameA(module, path, MAX_PATH);
+	if (length == 0 || length == MAX_PATH) {
+		return string();
+	}
+	const string full(path, length);
+	const auto slash = full.find_last_of("\\/");
+	return slash == string::npos ? string() : full.substr(0, slash);
+#else
+	Dl_info info;
+	if (!dladdr(reinterpret_cast<void *>(&OwnModuleDirectory), &info) || !info.dli_fname) {
+		return string();
+	}
+	const string full(info.dli_fname);
+	const auto slash = full.find_last_of('/');
+	return slash == string::npos ? string() : full.substr(0, slash);
+#endif
+}
+
+string EnvironmentValue(const char *name) {
+	const char *value = std::getenv(name);
+	return value ? string(value) : string();
+}
+
+LibraryHandle OpenProtoLibrary(const string &explicit_path) {
+	vector<string> candidates;
+	if (!explicit_path.empty()) {
+		// An explicitly named library is the only candidate. Falling back to a search
+		// after the caller named a file would run a different build than the one asked
+		// for, which is exactly the confusion a dual-backend setup must not create.
+		candidates.push_back(explicit_path);
+	} else {
+		const auto own_directory = OwnModuleDirectory();
+		if (!own_directory.empty()) {
+			candidates.push_back(own_directory + "/" + PROTO_LIBRARY_NAME);
+		}
+		candidates.push_back(PROTO_LIBRARY_NAME);
+	}
+
+	for (const auto &candidate : candidates) {
+		auto *handle = OpenLibrary(candidate);
+		if (handle) {
+			return {handle, StringUtil::Format("proto (%s)", candidate)};
+		}
+		ERPL_TRACE_DEBUG("RfcApi", StringUtil::Format("erpl-proto backend not at %s: %s", candidate,
+		                                              LastLibraryError()));
+	}
+
+	// Never fall back to the SDK. A silent downgrade would make a green proto test run
+	// meaningless -- it would be reporting on nwrfc.
+	throw IOException("The 'proto' RFC backend was requested but %s could not be loaded. Tried: %s. Set "
+	                  "erpl_rfc_backend_path (or ERPL_RFC_BACKEND_PATH) to point at the library, or build erpl "
+	                  "with the erpl-proto submodule present.",
+	                  PROTO_LIBRARY_NAME, StringUtil::Join(candidates, ", "));
+}
+
+// The requested configuration, and whether it has been acted on yet. Guarded because a
+// SET on one connection can race the first RFC call on another.
+std::mutex &SelectionLock() {
+	static std::mutex lock;
+	return lock;
+}
+
+RfcBackend g_requested_backend = RfcBackend::NWRFC;
+bool g_backend_explicitly_requested = false;
+string g_requested_library_path;
+bool g_backend_resolved = false;
+
+RfcBackend ParseBackendName(const string &name) {
+	auto normalized = StringUtil::Lower(name);
+	StringUtil::Trim(normalized);
+	if (normalized == "nwrfc" || normalized == "sdk") {
+		return RfcBackend::NWRFC;
+	}
+	if (normalized == "proto" || normalized == "erpl-proto" || normalized == "erpl_proto") {
+		return RfcBackend::PROTO;
+	}
+	throw InvalidInputException("Unknown RFC backend '%s'. Valid backends are 'nwrfc' (SAP's NetWeaver RFC SDK, "
+	                            "the default) and 'proto' (the pure-Rust erpl-proto implementation).",
+	                            name);
+}
+
+struct ResolvedBackend {
+	RfcApi api;
+	RfcBackend backend;
+	string description;
+};
+
+const ResolvedBackend &Resolve() {
+	// Function-local static: initialised once, thread-safely, on first RFC use. Doing
+	// this at load time instead would turn a missing SDK into a failure to load the
+	// extension at all, with no room for a diagnostic.
+	static ResolvedBackend resolved = [] {
+		RfcBackend backend;
+		string library_path;
+		{
+			std::lock_guard<std::mutex> guard(SelectionLock());
+			// An explicit SET outranks the environment; the environment exists so a test
+			// run or a container can pick a backend without editing SQL.
+			backend = g_backend_explicitly_requested ? g_requested_backend
+			                                         : [] {
+				                                           const auto from_env = EnvironmentValue("ERPL_RFC_BACKEND");
+				                                           return from_env.empty() ? RfcBackend::NWRFC
+				                                                                   : ParseBackendName(from_env);
+			                                           }();
+			library_path = g_requested_library_path.empty() ? EnvironmentValue("ERPL_RFC_BACKEND_PATH")
+			                                                : g_requested_library_path;
+			g_requested_backend = backend;
+			g_backend_resolved = true;
+		}
+
+		auto library = backend == RfcBackend::PROTO ? OpenProtoLibrary(library_path)
+		                                            : OpenNwRfcLibrary(library_path);
+		ERPL_TRACE_INFO("RfcApi", StringUtil::Format("RFC backend: %s", library.description));
+		return ResolvedBackend {ResolveApi(library), backend, library.description};
+	}();
+	return resolved;
+}
+
+} // namespace
+
+const char *RfcBackendName(RfcBackend backend) {
+	return backend == RfcBackend::PROTO ? "proto" : "nwrfc";
+}
+
+void SetRfcBackend(const string &name) {
+	const auto requested = ParseBackendName(name);
+
+	std::lock_guard<std::mutex> guard(SelectionLock());
+	if (g_backend_resolved) {
+		if (requested == g_requested_backend) {
+			// Idempotent: re-asserting the active backend is how a test file states its
+			// precondition, and refusing that would make every such file order-dependent.
+			return;
+		}
+		throw InvalidInputException(
+		    "The RFC backend is already resolved as '%s' and cannot be changed to '%s' in this process. Connections "
+		    "and function descriptors belong to one implementation, so switching mid-flight would hand a handle from "
+		    "one library to the other. Set erpl_rfc_backend before the first SAP call, or start a new process.",
+		    RfcBackendName(g_requested_backend), RfcBackendName(requested));
+	}
+	g_requested_backend = requested;
+	g_backend_explicitly_requested = true;
+}
+
+void SetRfcBackendLibraryPath(const string &path) {
+	std::lock_guard<std::mutex> guard(SelectionLock());
+	// Deliberately does not report the loaded path here: reading it means calling
+	// Resolve(), which takes this same lock.
+	if (g_backend_resolved && path != g_requested_library_path) {
+		throw InvalidInputException("The RFC backend library is already loaded, so setting erpl_rfc_backend_path "
+		                            "now would have no effect. Set it before the first SAP call, or start a new "
+		                            "process.");
+	}
+	g_requested_library_path = path;
+}
+
+const RfcApi &GetRfcApi() {
+	return Resolve().api;
+}
+
+RfcBackend GetResolvedRfcBackend() {
+	return Resolve().backend;
+}
+
+const string &GetRfcBackendDescription() {
+	return Resolve().description;
+}
+
+} // namespace duckdb

--- a/rfc/src/sap_rfc_api.cpp
+++ b/rfc/src/sap_rfc_api.cpp
@@ -67,7 +67,9 @@ string LastLibraryError() {
 	if (buffer) {
 		LocalFree(buffer);
 	}
-	return StringUtil::Trim(message);
+	// StringUtil::Trim mutates in place and returns void.
+	StringUtil::Trim(message);
+	return message;
 #else
 	const char *error = dlerror();
 	return error ? string(error) : string("unknown error");

--- a/rfc/src/sap_rfc_api.cpp
+++ b/rfc/src/sap_rfc_api.cpp
@@ -39,11 +39,13 @@ constexpr const char *PROTO_LIBRARY_NAME = "liberpl_proto_nwrfc.dylib";
 constexpr const char *PROTO_LIBRARY_NAME = "liberpl_proto_nwrfc.so";
 #endif
 
+#ifndef _WIN32
 // A witness that the SDK is already mapped into the global symbol scope. The trampoline
 // extension extracts the SDK and dlopens it RTLD_GLOBAL before erpl_rfc loads, and it
 // extracts to a directory that is on no search path -- so in a released build this is
 // the only way to reach it. Same probe the trampoline itself uses.
 constexpr const char *NWRFC_PRELOAD_WITNESS = "RfcGetVersion";
+#endif
 
 struct LibraryHandle {
 	// Null means "resolve against the process's global scope" rather than "not loaded".
@@ -90,9 +92,7 @@ void *OpenLibrary(const string &path) {
 
 void *FindSymbol(const LibraryHandle &library, const char *name) {
 #ifdef _WIN32
-	if (!library.handle) {
-		return reinterpret_cast<void *>(GetProcAddress(GetModuleHandleA(nullptr), name));
-	}
+	// handle is never null on Windows -- see IsPreloadedInGlobalScope.
 	return reinterpret_cast<void *>(GetProcAddress(reinterpret_cast<HMODULE>(library.handle), name));
 #else
 	return dlsym(library.handle ? library.handle : RTLD_DEFAULT, name);
@@ -101,7 +101,12 @@ void *FindSymbol(const LibraryHandle &library, const char *name) {
 
 bool IsPreloadedInGlobalScope() {
 #ifdef _WIN32
-	return GetProcAddress(GetModuleHandleA(nullptr), NWRFC_PRELOAD_WITNESS) != nullptr;
+	// Windows has no RTLD_DEFAULT: there is no process-wide symbol scope to search, so
+	// there is nothing for a "preloaded" handle to mean. It needs none either --
+	// LoadLibrary resolves a DLL that is already loaded to the same module and simply
+	// increments its reference count, so the ordinary path below already picks up the
+	// copy the trampoline loaded.
+	return false;
 #else
 	return dlsym(RTLD_DEFAULT, NWRFC_PRELOAD_WITNESS) != nullptr;
 #endif
@@ -277,14 +282,25 @@ const ResolvedBackend &Resolve() {
 			                                           }();
 			library_path = g_requested_library_path.empty() ? EnvironmentValue("ERPL_RFC_BACKEND_PATH")
 			                                                : g_requested_library_path;
-			g_requested_backend = backend;
-			g_backend_resolved = true;
 		}
 
 		auto library = backend == RfcBackend::PROTO ? OpenProtoLibrary(library_path)
 		                                            : OpenNwRfcLibrary(library_path);
+		auto api = ResolveApi(library);
+
+		// Marked resolved only once a backend is actually serving calls. Setting it before
+		// the load would mean a failed load still froze the selection, and the obvious
+		// recovery -- correct the path, SET again -- would be refused for a backend that
+		// was never loaded. Static initialisation is serialised, so this cannot race, and
+		// throwing above leaves the static uninitialised so the next call retries.
+		{
+			std::lock_guard<std::mutex> guard(SelectionLock());
+			g_requested_backend = backend;
+			g_backend_resolved = true;
+		}
+
 		ERPL_TRACE_INFO("RfcApi", StringUtil::Format("RFC backend: %s", library.description));
-		return ResolvedBackend {ResolveApi(library), backend, library.description};
+		return ResolvedBackend {std::move(api), backend, library.description};
 	}();
 	return resolved;
 }

--- a/rfc/test/cpp/CMakeLists.txt
+++ b/rfc/test/cpp/CMakeLists.txt
@@ -24,11 +24,15 @@ set(TEST_SOURCES
     test_connection_close.cpp
     test_sap_secret.cpp
     test_select_supported_args.cpp
+    test_rfc_api_dispatch.cpp
     test_main.cpp
 )
 
 add_executable(erpl_rfc_tests ${TEST_SOURCES})
-target_link_libraries(erpl_rfc_tests ${EXTENSION_NAME} duckdb_static test_helpers ${SAPNWRFC_LIB_FILES} ${OPENSSL_LIBRARIES})
+# The SAP SDK is not linked here either: erpl resolves the RFC entry points at runtime, and
+# linking the SDK into the test binary would put it in the global scope, so the tests would
+# exercise a resolution path the extension itself never takes.
+target_link_libraries(erpl_rfc_tests ${EXTENSION_NAME} duckdb_static test_helpers ${OPENSSL_LIBRARIES} ${CMAKE_DL_LIBS})
 # DuckDB v1.5+ requires dummy_static_extension_loader for LoadAllExtensions.
 # The target is defined in duckdb/extension/CMakeLists.txt which is processed
 # AFTER this file due to cmake ordering, so defer the link to the top-level scope.

--- a/rfc/test/cpp/test_connection_close.cpp
+++ b/rfc/test/cpp/test_connection_close.cpp
@@ -1,7 +1,7 @@
 #include "catch.hpp"
 #include "duckdb.hpp"
 
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 #include "sap_connection.hpp"
 
 #include <cstdlib>

--- a/rfc/test/cpp/test_rfc_api_dispatch.cpp
+++ b/rfc/test/cpp/test_rfc_api_dispatch.cpp
@@ -1,0 +1,127 @@
+// Tests for the runtime RFC dispatch layer. No SAP system is involved: resolving a
+// backend is a dlopen and a table of dlsyms, so all of this runs offline.
+//
+// ERPL_RFC_API_IMPLEMENTATION suppresses the dispatch macros, so this file can name the
+// entry points as plain tokens.
+#define ERPL_RFC_API_IMPLEMENTATION
+#include "sap_rfc_api.hpp"
+
+#include "catch.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#ifndef _WIN32
+#include <dlfcn.h>
+#endif
+
+using namespace duckdb;
+
+namespace {
+
+// The entry points erpl dispatches through, taken from the header itself so this cannot
+// drift from what the extension actually calls.
+std::vector<std::string> EntryPointNames() {
+	return {
+#define ERPL_RFC_API_NAME(name) #name,
+	    ERPL_RFC_API_ENTRY_POINTS(ERPL_RFC_API_NAME)
+#undef ERPL_RFC_API_NAME
+	};
+}
+
+} // namespace
+
+TEST_CASE("The dispatch table covers a plausible entry-point set", "[rfc_api]") {
+	const auto names = EntryPointNames();
+
+	// A guard against the X-macro list being silently emptied or mangled by an edit: the
+	// table would then resolve nothing and every RFC call would go through a null pointer.
+	REQUIRE(names.size() > 40);
+
+	// One name from each family, so a partial deletion is caught rather than only a total one.
+	for (const auto &expected : {"RfcOpenConnection", "RfcInvoke", "RfcGetTable", "RfcSetString",
+	                             "RfcGetFunctionDesc", "RfcUTF8ToSAPUC"}) {
+		REQUIRE(std::find(names.begin(), names.end(), expected) != names.end());
+	}
+}
+
+TEST_CASE("Every dispatch slot is filled after resolution", "[rfc_api]") {
+	// Resolves the default backend (nwrfc). A missing entry point throws during
+	// resolution rather than leaving a null slot, so reaching here at all is most of the
+	// assertion; the loop covers the case of the table being filled but incompletely.
+	const auto &api = GetRfcApi();
+
+	idx_t null_slots = 0;
+#define ERPL_RFC_API_CHECK_SLOT(name)                                                                                  \
+	if (api.name == nullptr) {                                                                                         \
+		null_slots++;                                                                                                  \
+	}
+	ERPL_RFC_API_ENTRY_POINTS(ERPL_RFC_API_CHECK_SLOT)
+#undef ERPL_RFC_API_CHECK_SLOT
+
+	REQUIRE(null_slots == 0);
+	REQUIRE_FALSE(GetRfcBackendDescription().empty());
+}
+
+TEST_CASE("An unknown backend name is rejected", "[rfc_api]") {
+	// Rejected before any state is touched, so this cannot disturb the backend the rest
+	// of the suite is using.
+	REQUIRE_THROWS_AS(SetRfcBackend("libsapnwrfc"), InvalidInputException);
+	REQUIRE_THROWS_AS(SetRfcBackend(""), InvalidInputException);
+}
+
+TEST_CASE("Backend names are accepted case- and alias-insensitively", "[rfc_api]") {
+	// Naming the backend that is already active must succeed: a caller stating its
+	// precondition should not depend on whether something else resolved it first.
+	const auto active = std::string(RfcBackendName(GetResolvedRfcBackend()));
+	REQUIRE_NOTHROW(SetRfcBackend(active));
+	REQUIRE_NOTHROW(SetRfcBackend(StringUtil::Upper(active)));
+	REQUIRE_NOTHROW(SetRfcBackend("  " + active + "  "));
+}
+
+TEST_CASE("Switching backend after resolution is refused", "[rfc_api]") {
+	const auto active = GetResolvedRfcBackend();
+	const auto other = active == RfcBackend::PROTO ? "nwrfc" : "proto";
+
+	// Handles and function descriptors belong to one implementation. Silently switching
+	// would hand a handle from one library to the other, which is why this is an error
+	// and not a best-effort reconfiguration.
+	REQUIRE_THROWS_AS(SetRfcBackend(other), InvalidInputException);
+
+	// And the refusal must not have changed anything.
+	REQUIRE(GetResolvedRfcBackend() == active);
+}
+
+#ifndef _WIN32
+TEST_CASE("The proto backend provides every entry point erpl needs", "[rfc_api]") {
+	// The contract between erpl and erpl-proto. Skipped when the private submodule was
+	// not part of this build; failing here would only punish a contributor without access.
+	const char *proto_path = std::getenv("ERPL_RFC_BACKEND_PATH");
+	std::string path = proto_path ? proto_path : "";
+	if (path.empty() || path.find("erpl_proto") == std::string::npos) {
+		WARN("ERPL_RFC_BACKEND_PATH does not point at the proto shim; skipping the contract check");
+		return;
+	}
+
+	// RTLD_LOCAL matters even here: the SDK may already be resident, and a global load of
+	// a library exporting the same names would have the two interposing.
+	void *handle = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);
+	REQUIRE(handle != nullptr);
+
+	std::vector<std::string> missing;
+	for (const auto &name : EntryPointNames()) {
+		if (!dlsym(handle, name.c_str())) {
+			missing.push_back(name);
+		}
+	}
+
+	std::string missing_list;
+	for (const auto &name : missing) {
+		missing_list += (missing_list.empty() ? "" : ", ") + name;
+	}
+	INFO("missing from the proto backend: " << missing_list);
+	REQUIRE(missing.empty());
+}
+#endif

--- a/rfc/test/cpp/test_sap_secret.cpp
+++ b/rfc/test/cpp/test_sap_secret.cpp
@@ -1,7 +1,7 @@
 #include "catch.hpp"
 #include "duckdb.hpp"
 
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 #include "sap_secret.hpp"
 #include "sap_connection.hpp"
 

--- a/rfc/test/cpp/test_type_conversion.cpp
+++ b/rfc/test/cpp/test_type_conversion.cpp
@@ -2,7 +2,7 @@
 #include "catch.hpp"
 #include "test_helpers.hpp"
 #include "duckdb.hpp"
-#include "sapnwrfc.h"
+#include "sap_rfc_api.hpp"
 #include "sap_type_conversion.hpp"
 #include "sap_function.hpp"
 

--- a/rfc/test/proto_known_failures.txt
+++ b/rfc/test/proto_known_failures.txt
@@ -1,0 +1,8 @@
+# Tests in this suite known to fail on the erpl-proto backend.
+#
+# One test filename per line; blank lines and # comments ignored. A listed test that
+# fails is reported as a known gap rather than a failure. A listed test that PASSES fails
+# the run -- the list is a record of real gaps, not a place for entries to accumulate
+# unchallenged. Remove a line as soon as its gap closes.
+#
+# See ERPL_PROTO_INTEGRATION_PLAN.md, Phase 6.

--- a/rfc/test/sql/sap_rfc_backend.test
+++ b/rfc/test/sql/sap_rfc_backend.test
@@ -1,0 +1,47 @@
+# name: test/sql/sap_rfc_backend.test
+# description: Backend selection on the nwrfc (SAP SDK) leg
+# group: [erpl_rfc]
+#
+# Runs only on the nwrfc leg; the proto leg is covered by sap_rfc_backend_proto.test.
+# Resolving the backend needs no SAP system -- it is a dlopen and a table of dlsyms -- so
+# these assertions hold whether or not a4h is reachable.
+
+require erpl_rfc
+
+require-env ERPL_RFC_BACKEND nwrfc
+
+# The default, and what every released build has used to date.
+query I
+SELECT sap_rfc_backend()
+----
+nwrfc
+
+# Naming the active backend again is accepted: a test file stating its own precondition
+# must not depend on whether something already resolved the backend.
+statement ok
+SET erpl_rfc_backend = 'nwrfc'
+
+query I
+SELECT sap_rfc_backend()
+----
+nwrfc
+
+# Switching after the backend is resolved is refused. Connections and function
+# descriptors belong to one implementation; redirecting calls mid-process would hand a
+# handle from one library to the other.
+statement error
+SET erpl_rfc_backend = 'proto'
+----
+already resolved
+
+# An unknown name is rejected outright rather than falling back to a default.
+statement error
+SET erpl_rfc_backend = 'libsapnwrfc'
+----
+Unknown RFC backend
+
+# The path setting cannot retroactively move a library that is already loaded.
+statement error
+SET erpl_rfc_backend_path = '/nonexistent/libsapnwrfc.so'
+----
+already loaded

--- a/rfc/test/sql/sap_rfc_backend_proto.test
+++ b/rfc/test/sql/sap_rfc_backend_proto.test
@@ -1,0 +1,29 @@
+# name: test/sql/sap_rfc_backend_proto.test
+# description: Backend selection on the erpl-proto leg
+# group: [erpl_rfc]
+#
+# The mirror of sap_rfc_backend.test. Skipped on the nwrfc leg. Its real job is to prove
+# the proto leg is genuinely running on erpl-proto: without this, a proto suite that
+# silently fell back to the SDK would report a full row of green while testing nothing.
+
+require erpl_rfc
+
+require-env ERPL_RFC_BACKEND proto
+
+query I
+SELECT sap_rfc_backend()
+----
+proto
+
+statement ok
+SET erpl_rfc_backend = 'proto'
+
+query I
+SELECT sap_rfc_backend()
+----
+proto
+
+statement error
+SET erpl_rfc_backend = 'nwrfc'
+----
+already resolved

--- a/scripts/check_proto_backend_symbols.sh
+++ b/scripts/check_proto_backend_symbols.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Checks that the erpl-proto backend exports every RFC entry point erpl dispatches
+# through. This is the contract between the two repositories, and it is worth a gate of
+# its own: a missing entry point is otherwise found at runtime, on whichever SAP call
+# happens to need it first, on whichever test happens to run first.
+#
+# The expected list is read from rfc/src/include/sap_rfc_api.hpp rather than kept here,
+# so the two cannot drift.
+#
+# Usage: check_proto_backend_symbols.sh [path-to-liberpl_proto_nwrfc.so]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+HEADER="$REPO_DIR/rfc/src/include/sap_rfc_api.hpp"
+LIBRARY="${1:-$REPO_DIR/build/debug/liberpl_proto_nwrfc.so}"
+
+[[ -f "$HEADER" ]]  || { echo "ERROR: $HEADER not found" >&2; exit 1; }
+[[ -f "$LIBRARY" ]] || { echo "ERROR: $LIBRARY not found. Build it first (GEN=ninja make debug_tests)." >&2; exit 1; }
+
+# The X(...) entries of ERPL_RFC_API_ENTRY_POINTS, and nothing else in the file.
+expected="$(sed -n '/#define ERPL_RFC_API_ENTRY_POINTS/,/^$/p' "$HEADER" \
+	| grep -oE '^\s*X\([A-Za-z0-9_]+\)' | grep -oE '\(.*\)' | tr -d '()' | sort -u)"
+
+expected_count="$(wc -l <<< "$expected")"
+if [[ "$expected_count" -lt 2 ]]; then
+	echo "ERROR: could not parse the entry-point list out of $HEADER (got $expected_count)." >&2
+	exit 1
+fi
+
+# SAP's own library versions its symbols (RfcOpenConnection@@libsapnwrfc.so), so the
+# version suffix is stripped -- dlsym resolves the default version under the bare name,
+# which is how erpl reaches them. The proto shim carries no version suffix.
+exported="$(nm -D --defined-only "$LIBRARY" | awk '$2 == "T" { sub(/@.*/, "", $3); print $3 }' | sort -u)"
+
+missing="$(comm -23 <(echo "$expected") <(echo "$exported"))"
+
+echo "erpl dispatches $expected_count RFC entry points"
+echo "$(basename "$LIBRARY") exports $(wc -l <<< "$exported")"
+
+if [[ -n "$missing" ]]; then
+	echo
+	echo "MISSING from the proto backend:"
+	sed 's/^/  /' <<< "$missing"
+	echo
+	echo "erpl would fail at runtime on the first call to any of these. Either implement"
+	echo "them in erpl-proto, or stop calling them from erpl."
+	exit 1
+fi
+
+echo "OK: the proto backend provides every entry point erpl needs."

--- a/scripts/check_proto_backend_symbols.sh
+++ b/scripts/check_proto_backend_symbols.sh
@@ -51,3 +51,55 @@ if [[ -n "$missing" ]]; then
 fi
 
 echo "OK: the proto backend provides every entry point erpl needs."
+
+# ---------------------------------------------------------------------------------------
+# Return codes.
+#
+# sapnwrfc.h's RFC_RC is an unnumbered enum, so every value is an ordinal you can only get
+# right by counting declarations -- and five of the shim's were once wrong. Nothing about
+# that is visible at a call site: the consumer branches on a code that means something
+# else. erpl's RfcConnection::Close treats RFC_INVALID_HANDLE as benign, so receiving 8
+# (RFC_TIMEOUT) instead of 13 turned every close of a stale handle into a thrown
+# IOException. Worth a permanent gate.
+PROTO_ABI="$REPO_DIR/proto/crates/erpl-proto-nwrfc/src/abi.rs"
+SDK_HEADER="$REPO_DIR/nwrfcsdk/linux/include/sapnwrfc.h"
+
+if [[ ! -f "$PROTO_ABI" || ! -f "$SDK_HEADER" ]]; then
+	echo "NOTE: skipping the return-code check (needs both proto/ and the SDK headers)."
+	exit 0
+fi
+
+python3 - "$SDK_HEADER" "$PROTO_ABI" <<'PYTHON'
+import re, sys
+
+header, abi = open(sys.argv[1]).read(), open(sys.argv[2]).read()
+
+body = re.search(r'typedef enum _RFC_RC\s*\{(.*?)\}\s*RFC_RC;', header, re.S).group(1)
+names = []
+for line in body.splitlines():
+    line = re.sub(r'///<.*|/\*.*?\*/', '', line).strip().rstrip(',').strip()
+    if line and not line.startswith('/'):
+        names.append(line)
+sdk = {name: ordinal for ordinal, name in enumerate(names)}
+
+shim = {m.group(1): int(m.group(2))
+        for m in re.finditer(r'pub const (RFC_[A-Z0-9_]+):\s*RFC_RC\s*=\s*(\d+);', abi)}
+
+mismatches = []
+for name, value in sorted(shim.items(), key=lambda kv: kv[1]):
+    expected = sdk.get(name)
+    if expected is None:
+        print(f"  ?  {name} = {value} is not an RFC_RC enumerator in the SDK header")
+    elif expected != value:
+        collision = next((k for k, v in sdk.items() if v == value), '?')
+        mismatches.append(f"{name}: shim says {value} ({collision}), SDK says {expected}")
+
+print(f"checked {len(shim)} RFC_RC constants against the SDK enum")
+if mismatches:
+    print("\nRETURN CODE MISMATCHES:")
+    for m in mismatches:
+        print(f"  {m}")
+    print("\nA consumer branching on one of these takes one error for another.")
+    sys.exit(1)
+print("OK: every RFC_RC constant the shim defines matches the SDK enum.")
+PYTHON

--- a/scripts/functions.cmake
+++ b/scripts/functions.cmake
@@ -310,6 +310,81 @@ endfunction()
 
 #---------------------------------------------------------------------------------------
 
+# Builds the erpl-proto nwrfc ABI shim -- a pure-Rust libsapnwrfc replacement -- and stages
+# it in the build tree as the alternative RFC backend. See ERPL_PROTO_INTEGRATION_PLAN.md.
+#
+# erpl-proto lives in a private repository, so `proto/` is absent from clones without
+# access. That is not an error: the build then simply offers the nwrfc backend only, exactly
+# as it did before this existed. Same conditional pattern as `bics/` and `odp/`.
+#
+# The artifact is deliberately RENAMED on the way in. Cargo names it `libsapnwrfc.so`,
+# because an SDK consumer that links `-lsapnwrfc` has to resolve it by that name -- but in
+# this build the two libraries coexist and are chosen between at runtime, so a second file
+# called `libsapnwrfc.so` in the build tree is a loaded gun. Under its own name it can only
+# ever be loaded deliberately, by absolute path.
+#
+# Sets ERPL_PROTO_AVAILABLE and ERPL_PROTO_BACKEND_LIB in the caller's scope.
+function(add_erpl_proto_backend)
+    set(ERPL_PROTO_AVAILABLE FALSE PARENT_SCOPE)
+
+    get_filename_component(proto_dir "${CMAKE_CURRENT_SOURCE_DIR}/../proto" ABSOLUTE)
+    if(NOT EXISTS "${proto_dir}/Cargo.toml")
+        message(STATUS "erpl-proto not present at ${proto_dir} -- building with the nwrfc backend only")
+        return()
+    endif()
+
+    find_program(CARGO_EXECUTABLE cargo)
+    if(NOT CARGO_EXECUTABLE)
+        message(WARNING
+            "erpl-proto is present at ${proto_dir} but `cargo` was not found, so the proto "
+            "backend will not be built. Install a Rust toolchain, or remove the submodule.")
+        return()
+    endif()
+
+    # A dedicated target directory: sharing the submodule's own `target/` would have this
+    # build contend with cargo's lock against interactive work in erpl-proto.
+    set(cargo_target_dir "${CMAKE_BINARY_DIR}/erpl-proto-target")
+
+    if(WIN32)
+        set(cargo_artifact "sapnwrfc.dll")
+        set(staged_name "erpl_proto_nwrfc.dll")
+    elseif(APPLE)
+        set(cargo_artifact "libsapnwrfc.dylib")
+        set(staged_name "liberpl_proto_nwrfc.dylib")
+    else()
+        set(cargo_artifact "libsapnwrfc.so")
+        set(staged_name "liberpl_proto_nwrfc.so")
+    endif()
+
+    # Always a release build. This is a dependency, not code under debug here, and a debug
+    # cdylib of the shim is ~30x the size for no diagnostic benefit on the erpl side.
+    set(cargo_artifact_path "${cargo_target_dir}/release/${cargo_artifact}")
+    set(staged_path "${CMAKE_BINARY_DIR}/${staged_name}")
+
+    file(GLOB_RECURSE proto_sources CONFIGURE_DEPENDS
+        "${proto_dir}/crates/*.rs"
+        "${proto_dir}/crates/*/Cargo.toml"
+        "${proto_dir}/Cargo.toml")
+
+    add_custom_command(
+        OUTPUT "${staged_path}"
+        COMMAND ${CMAKE_COMMAND} -E env "CARGO_TARGET_DIR=${cargo_target_dir}"
+                ${CARGO_EXECUTABLE} build --release --manifest-path "${proto_dir}/Cargo.toml"
+                -p erpl-proto-nwrfc
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${cargo_artifact_path}" "${staged_path}"
+        DEPENDS ${proto_sources}
+        COMMENT "Building erpl-proto nwrfc ABI shim (${staged_name})"
+        VERBATIM)
+
+    add_custom_target(erpl_proto_backend ALL DEPENDS "${staged_path}")
+
+    message(STATUS "erpl-proto backend enabled: ${staged_path}")
+    set(ERPL_PROTO_AVAILABLE TRUE PARENT_SCOPE)
+    set(ERPL_PROTO_BACKEND_LIB "${staged_path}" PARENT_SCOPE)
+endfunction()
+
+#---------------------------------------------------------------------------------------
+
 function(enable_mold_linker)
     # Try to find mold binary
     find_program(MOLD_LINKER mold)

--- a/scripts/functions.cmake
+++ b/scripts/functions.cmake
@@ -361,22 +361,29 @@ function(add_erpl_proto_backend)
     set(cargo_artifact_path "${cargo_target_dir}/release/${cargo_artifact}")
     set(staged_path "${CMAKE_BINARY_DIR}/${staged_name}")
 
-    file(GLOB_RECURSE proto_sources CONFIGURE_DEPENDS
-        "${proto_dir}/crates/*.rs"
-        "${proto_dir}/crates/*/Cargo.toml"
-        "${proto_dir}/Cargo.toml")
-
-    add_custom_command(
-        OUTPUT "${staged_path}"
+    # Cargo decides whether anything needs rebuilding, so this target always runs and
+    # no-ops in a fraction of a second when the shim is current.
+    #
+    # The obvious alternative -- a file(GLOB_RECURSE ... CONFIGURE_DEPENDS) over the Rust
+    # sources feeding an OUTPUT-producing command -- is worse in two ways, and was tried
+    # first. CONFIGURE_DEPENDS makes CMake re-verify the glob on *every* ninja invocation,
+    # which costs a full re-configure of this (large) project before any build can start.
+    # And a glob would have to enumerate what cargo already tracks far better: not just
+    # .rs files and manifests but Cargo.lock, build scripts, `include_str!` data, and the
+    # toolchain file. Duplicating a build system's change detection in another build
+    # system is how the two come to disagree.
+    #
+    # copy_if_different is what keeps this cheap for dependents: the staged file's
+    # timestamp only moves when the bytes actually change, so an unchanged shim does not
+    # drag the trampoline through a relink of a ~290 MB artifact.
+    add_custom_target(erpl_proto_backend ALL
         COMMAND ${CMAKE_COMMAND} -E env "CARGO_TARGET_DIR=${cargo_target_dir}"
                 ${CARGO_EXECUTABLE} build --release --manifest-path "${proto_dir}/Cargo.toml"
                 -p erpl-proto-nwrfc
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "${cargo_artifact_path}" "${staged_path}"
-        DEPENDS ${proto_sources}
+        BYPRODUCTS "${staged_path}"
         COMMENT "Building erpl-proto nwrfc ABI shim (${staged_name})"
         VERBATIM)
-
-    add_custom_target(erpl_proto_backend ALL DEPENDS "${staged_path}")
 
     message(STATUS "erpl-proto backend enabled: ${staged_path}")
     set(ERPL_PROTO_AVAILABLE TRUE PARENT_SCOPE)

--- a/scripts/run_sql_tests.sh
+++ b/scripts/run_sql_tests.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# Runs a suite's SQLLogicTest files against one RFC backend.
+#
+# erpl can be served by either SAP's NetWeaver RFC SDK or the pure-Rust erpl-proto
+# implementation, and both are expected to pass the same suites. The proto backend is
+# still closing gaps, so each suite may carry a list of tests known to fail there; a
+# listed test that fails is reported as a known gap rather than a failure, and a listed
+# test that *passes* fails the run, so the list cannot quietly rot into a blanket excuse.
+#
+# Usage: run_sql_tests.sh <suite-dir> [options]
+#   --backend nwrfc|proto     which implementation to test (default: nwrfc)
+#   --known-failures <file>   expected-failure list, one test filename per line
+#   --test-file <name>        run a single file from the suite's test/sql/
+#
+# The caller supplies SAP credentials and LD_LIBRARY_PATH through the environment; see
+# the Makefile.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+UNITTEST="$REPO_DIR/build/debug/test/unittest"
+
+suite_dir=""
+backend="nwrfc"
+known_failures_file=""
+test_file=""
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--backend)        backend="$2"; shift 2 ;;
+		--known-failures) known_failures_file="$2"; shift 2 ;;
+		--test-file)      test_file="$2"; shift 2 ;;
+		*)                suite_dir="$1"; shift ;;
+	esac
+done
+
+if [[ -z "$suite_dir" ]]; then
+	echo "usage: run_sql_tests.sh <suite-dir> [--backend nwrfc|proto] [--known-failures <file>] [--test-file <name>]" >&2
+	exit 2
+fi
+
+cd "$REPO_DIR/$suite_dir" || exit 1
+
+if [[ ! -x "$UNITTEST" ]]; then
+	echo "ERROR: $UNITTEST not found. Run 'GEN=ninja make debug_tests' first." >&2
+	exit 1
+fi
+
+# The proto backend is selected through the extension's own settings, which read these.
+# Deliberately no fallback: if the library is missing the extension raises, rather than
+# quietly serving the run from the SDK and reporting a green proto leg that never ran.
+if [[ "$backend" == "proto" ]]; then
+	export ERPL_RFC_BACKEND=proto
+	proto_lib="${ERPL_RFC_BACKEND_PATH:-$REPO_DIR/build/debug/liberpl_proto_nwrfc.so}"
+	if [[ ! -f "$proto_lib" ]]; then
+		echo "ERROR: proto backend requested but $proto_lib does not exist." >&2
+		echo "       The erpl-proto submodule must be present and the build must have staged it." >&2
+		exit 1
+	fi
+	export ERPL_RFC_BACKEND_PATH="$proto_lib"
+else
+	export ERPL_RFC_BACKEND=nwrfc
+fi
+
+declare -A known_failure=()
+if [[ -n "$known_failures_file" && -f "$known_failures_file" ]]; then
+	while IFS= read -r line; do
+		line="${line%%#*}"
+		line="$(echo -n "$line" | tr -d '[:space:]')"
+		[[ -n "$line" ]] && known_failure["$line"]=1
+	done < "$known_failures_file"
+fi
+
+passed=0 failed=0 sdk_aborts=0 known_gaps=0 unexpected_passes=0
+failed_names=() unexpected_names=()
+
+run_one() {
+	local path="$1" name log rc
+	name="$(basename "$path")"
+	log="$(mktemp)"
+	echo "Running test: $path"
+	"$UNITTEST" --test-dir . "$path" > "$log" 2>&1
+	rc=$?
+
+	# The SAP SDK aborts inside its own static destructor at process exit ("pure virtual
+	# method called", erpl#112) on roughly 10% of runs, after every assertion has already
+	# passed. Third-party teardown, not a test result. Matched on both the pass marker and
+	# the SDK signature so any other abort -- including one that loses assertions -- still
+	# fails. The proto backend has no SDK static destructor, so there this tolerance does
+	# not apply and an abort is a real failure.
+	if [[ $rc -ne 0 && "$backend" == "nwrfc" ]] \
+		&& grep -q "All tests passed" "$log" && grep -q "pure virtual method called" "$log"; then
+		echo "  WARN: assertions passed, SAP SDK aborted at exit (erpl#112)"
+		sdk_aborts=$((sdk_aborts + 1))
+		rc=0
+	fi
+
+	if [[ -n "${known_failure[$name]:-}" ]]; then
+		if [[ $rc -eq 0 ]]; then
+			echo "  UNEXPECTED PASS: $name is listed as a known $backend failure but passed."
+			echo "                   Remove it from $known_failures_file."
+			unexpected_passes=$((unexpected_passes + 1))
+			unexpected_names+=("$name")
+		else
+			echo "  known $backend gap: $name"
+			known_gaps=$((known_gaps + 1))
+		fi
+		rm -f "$log"
+		return
+	fi
+
+	if [[ $rc -ne 0 ]]; then
+		echo "  FAIL: $path"
+		cat "$log"
+		failed=$((failed + 1))
+		failed_names+=("$name")
+	else
+		passed=$((passed + 1))
+	fi
+	rm -f "$log"
+}
+
+if [[ -n "$test_file" ]]; then
+	run_one "test/sql/$test_file"
+else
+	for f in test/sql/*.test; do
+		run_one "$f"
+	done
+fi
+
+echo
+echo "=== $suite_dir on the $backend backend ==="
+echo "    passed:            $passed"
+echo "    failed:            $failed"
+echo "    known gaps:        $known_gaps"
+echo "    unexpected passes: $unexpected_passes"
+[[ $sdk_aborts -gt 0 ]] && echo "    SDK exit aborts:   $sdk_aborts (erpl#112, assertions had passed)"
+
+if [[ $failed -gt 0 ]]; then
+	echo "FAILED: ${failed_names[*]}"
+	exit 1
+fi
+if [[ $unexpected_passes -gt 0 && "${ALLOW_UNEXPECTED_PASS:-0}" != "1" ]]; then
+	echo "FAILED: these are listed as known $backend failures but passed: ${unexpected_names[*]}"
+	echo "        Remove them from $known_failures_file, or re-run with ALLOW_UNEXPECTED_PASS=1."
+	exit 1
+fi
+echo "All SQL tests passed"

--- a/trampoline/CMakeLists.txt
+++ b/trampoline/CMakeLists.txt
@@ -124,6 +124,45 @@ if(UNIX AND APPLE)
     endforeach()
 endif()
 
+# The alternative pure-Rust RFC backend, when the private erpl-proto submodule is present.
+#
+# It is shipped ALONGSIDE the SAP SDK rather than instead of it: nwrfc remains the default,
+# and carrying both means a released build can be flipped to the proto backend with
+# `SET erpl_rfc_backend = 'proto'` and flipped straight back if anything misbehaves. It
+# costs about 1 MB against the SDK + ICU's ~30 MB. Once proto has proven itself in the
+# field, dropping the SDK is what actually makes the artifact small.
+#
+# The extension resolves it from its own directory, which is where the trampoline extracts
+# everything, so no search path or environment variable is involved.
+if(TARGET erpl_proto_backend)
+    if(WIN32)
+        set(ERPL_PROTO_STAGED_NAME "erpl_proto_nwrfc.dll")
+    elseif(APPLE)
+        set(ERPL_PROTO_STAGED_NAME "liberpl_proto_nwrfc.dylib")
+    else()
+        set(ERPL_PROTO_STAGED_NAME "liberpl_proto_nwrfc.so")
+    endif()
+    set(ERPL_PROTO_STAGED_PATH "${CMAKE_BINARY_DIR}/${ERPL_PROTO_STAGED_NAME}")
+
+    message(STATUS "Attaching ${ERPL_PROTO_STAGED_NAME} to the trampoline")
+    if(WIN32)
+        file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/resources.rc"
+             "erpl_proto_nwrfc RCDATA \"${ERPL_PROTO_STAGED_PATH}\"\n")
+    elseif(APPLE)
+        convert_dylib_to_object("liberpl_proto_nwrfc" "${ERPL_PROTO_STAGED_PATH}"
+                                "liberpl_proto_nwrfc.o"
+                                "${CMAKE_CURRENT_BINARY_DIR}/liberpl_proto_nwrfc.o" ON)
+        list(APPEND SAPNWRFC_LIB_OBJECTS "liberpl_proto_nwrfc.o")
+    else()
+        embed_binary_to_object("${CMAKE_BINARY_DIR}" "${ERPL_PROTO_STAGED_NAME}"
+                               "${CMAKE_CURRENT_BINARY_DIR}/liberpl_proto_nwrfc.o"
+                               "${ERPL_PROTO_STAGED_PATH}")
+        list(APPEND SAPNWRFC_LIB_OBJECTS "liberpl_proto_nwrfc.o")
+    endif()
+
+    add_compile_definitions(WITH_ERPL_PROTO)
+endif()
+
 # Feedback banner (header-only). Telemetry OFF: the trampoline does not link
 # posthog-telemetry -- that lives in erpl_rfc, which this extension merely
 # extracts and loads.
@@ -144,6 +183,11 @@ set(EXTENSION_SOURCES
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 set(PARAMETERS "-warnings")
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
+
+if(TARGET erpl_proto_backend)
+    add_dependencies(${EXTENSION_NAME} erpl_proto_backend)
+    add_dependencies(${LOADABLE_EXTENSION_NAME} erpl_proto_backend)
+endif()
 
 add_dependencies(${EXTENSION_NAME} erpl_rfc_loadable_extension)
 add_dependencies(${LOADABLE_EXTENSION_NAME} erpl_rfc_loadable_extension)

--- a/trampoline/CMakeLists.txt
+++ b/trampoline/CMakeLists.txt
@@ -149,9 +149,13 @@ if(TARGET erpl_proto_backend)
         file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/resources.rc"
              "erpl_proto_nwrfc RCDATA \"${ERPL_PROTO_STAGED_PATH}\"\n")
     elseif(APPLE)
+        # change_rpath OFF, unlike the SDK libraries. Nothing links against this one --
+        # erpl_rfc dlopens it by absolute path -- so its install name is irrelevant, and
+        # rewriting it would mutate the staged file in place on every build, which fights
+        # the copy_if_different that keeps this cheap.
         convert_dylib_to_object("liberpl_proto_nwrfc" "${ERPL_PROTO_STAGED_PATH}"
                                 "liberpl_proto_nwrfc.o"
-                                "${CMAKE_CURRENT_BINARY_DIR}/liberpl_proto_nwrfc.o" ON)
+                                "${CMAKE_CURRENT_BINARY_DIR}/liberpl_proto_nwrfc.o" OFF)
         # The staged shim is a BYPRODUCT of a custom target, not the output of a custom
         # command, so name the target too or nothing orders the two.
         add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/liberpl_proto_nwrfc.o"

--- a/trampoline/CMakeLists.txt
+++ b/trampoline/CMakeLists.txt
@@ -152,11 +152,19 @@ if(TARGET erpl_proto_backend)
         convert_dylib_to_object("liberpl_proto_nwrfc" "${ERPL_PROTO_STAGED_PATH}"
                                 "liberpl_proto_nwrfc.o"
                                 "${CMAKE_CURRENT_BINARY_DIR}/liberpl_proto_nwrfc.o" ON)
+        # The staged shim is a BYPRODUCT of a custom target, not the output of a custom
+        # command, so name the target too or nothing orders the two.
+        add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/liberpl_proto_nwrfc.o"
+                           DEPENDS erpl_proto_backend APPEND)
         list(APPEND SAPNWRFC_LIB_OBJECTS "liberpl_proto_nwrfc.o")
     else()
         embed_binary_to_object("${CMAKE_BINARY_DIR}" "${ERPL_PROTO_STAGED_NAME}"
                                "${CMAKE_CURRENT_BINARY_DIR}/liberpl_proto_nwrfc.o"
                                "${ERPL_PROTO_STAGED_PATH}")
+        # The staged shim is a BYPRODUCT of a custom target, not the output of a custom
+        # command, so name the target too or nothing orders the two.
+        add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/liberpl_proto_nwrfc.o"
+                           DEPENDS erpl_proto_backend APPEND)
         list(APPEND SAPNWRFC_LIB_OBJECTS "liberpl_proto_nwrfc.o")
     endif()
 

--- a/trampoline/src/erpl_extension.cpp
+++ b/trampoline/src/erpl_extension.cpp
@@ -22,6 +22,11 @@ extern const char _binary_libsapnwrfc_so_end[];
 extern const char _binary_libsapucum_so_start[];
 extern const char _binary_libsapucum_so_end[];
 
+#ifdef WITH_ERPL_PROTO
+extern const char _binary_liberpl_proto_nwrfc_so_start[];
+extern const char _binary_liberpl_proto_nwrfc_so_end[];
+#endif
+
 extern const char _binary_libicudata_so_50_start[];
 extern const char _binary_libicudata_so_50_end[];
 
@@ -204,6 +209,16 @@ namespace duckdb
 
             SaveToFile(_binary_libsapucum_so_start, _binary_libsapucum_so_end, StringUtil::Format("%s/libsapucum.so", ext_path));
             LoadLibraryFromFile(StringUtil::Format("%s/libsapucum.so", ext_path));
+
+            #ifdef WITH_ERPL_PROTO
+            // The alternative pure-Rust RFC backend.  Written out but deliberately NOT
+            // loaded: it exports the same Rfc* symbols as the SDK above, and this
+            // extension loads its libraries RTLD_GLOBAL, so loading it here would have
+            // the two interposing on each other and calls served by whichever won.
+            // erpl_rfc opens it on demand, RTLD_LOCAL, and only if the backend is
+            // actually selected -- it finds it here, next to the extension.
+            SaveToFile(_binary_liberpl_proto_nwrfc_so_start, _binary_liberpl_proto_nwrfc_so_end, StringUtil::Format("%s/liberpl_proto_nwrfc.so", ext_path));
+            #endif
             
             std::cout << "done" << std::endl;
 

--- a/trampoline/src/erpl_extension.cpp
+++ b/trampoline/src/erpl_extension.cpp
@@ -70,6 +70,11 @@ extern const unsigned int libsapnwrfc_dylib_len;
 extern const char libsapucum_dylib[];
 extern const unsigned int libsapucum_dylib_len;
 
+#ifdef WITH_ERPL_PROTO
+extern const char liberpl_proto_nwrfc_dylib[];
+extern const unsigned int liberpl_proto_nwrfc_dylib_len;
+#endif
+
 extern const char libicudata_50_dylib[];
 extern const unsigned int libicudata_50_dylib_len;
 
@@ -359,6 +364,10 @@ namespace duckdb
             SaveResourceToFile(TEXT("ICUUC57"), StringUtil::Format("%s\\icuuc57.dll", ext_path));
             SaveResourceToFile(TEXT("SAPNWRFC"), StringUtil::Format("%s\\sapnwrfc.dll", ext_path));
             SaveResourceToFile(TEXT("LIBSAPUCUM"), StringUtil::Format("%s\\libsapucum.dll", ext_path));
+            #ifdef WITH_ERPL_PROTO
+            // Written out but deliberately NOT loaded -- see the note on the Linux path.
+            SaveResourceToFile(TEXT("ERPL_PROTO_NWRFC"), StringUtil::Format("%s\\erpl_proto_nwrfc.dll", ext_path));
+            #endif
             SaveResourceToFile(TEXT("LIBCRYPTO-3-x64"), StringUtil::Format("%s\\libcrypto-3-x64.dll", ext_path));
             SaveResourceToFile(TEXT("LIBSSL-3-x64"), StringUtil::Format("%s\\libssl-3-x64.dll", ext_path));
             SaveResourceToFile(TEXT("LIBSSH2"), StringUtil::Format("%s\\libssh2.dll", ext_path));
@@ -494,6 +503,11 @@ static void ExtractExtensionsAndSapLibs()
 
         SaveToFile(libsapucum_dylib, libsapucum_dylib_len, ext_path + "/libsapucum.dylib");
         LoadLibraryFromFile(ext_path + "/libsapucum.dylib");
+
+        #ifdef WITH_ERPL_PROTO
+        // Written out but deliberately NOT loaded -- see the note on the Linux path.
+        SaveToFile(liberpl_proto_nwrfc_dylib, liberpl_proto_nwrfc_dylib_len, ext_path + "/liberpl_proto_nwrfc.dylib");
+        #endif
 
         std::cout << "done" << std::endl;
 


### PR DESCRIPTION
Puts [erpl-proto](https://github.com/DataZooDE/erpl-proto) — the pure-Rust implementation of SAP's classic RFC protocol — underneath erpl, selectable at runtime against the stock SAP NW RFC SDK. **`nwrfc` remains the default.**

Full design and phase record: `ERPL_PROTO_INTEGRATION_PLAN.md`.

## What changes

erpl no longer links `libsapnwrfc` — not in either build type, not in any test binary. The 55 SDK entry points that `rfc`, `bics` and `odp` call between them resolve through a dispatch table filled by `dlopen`/`dlsym` on first RFC use:

```sql
SET erpl_rfc_backend = 'proto';   -- or 'nwrfc' (default), or ERPL_RFC_BACKEND
SELECT sap_rfc_backend();         -- 'proto'
```

Both libraries export the same `Rfc*` symbols, so only one could ever be *linked*: whichever the loader reached first would silently serve everything. That is the whole reason for the indirection. The library is opened `RTLD_LOCAL` so the two can never interpose, and `RTLD_NODELETE` because the SDK's static destructors have no safe unmap ordering against DuckDB's connection state.

The backend freezes at first use — handles and function descriptors belong to one implementation, so a later `SET` is refused rather than allowed to hand a handle across. A missing proto library is a hard error, never a fallback: a silent downgrade would make a green proto run a report about nwrfc.

Signatures come from `sapnwrfc.h` via `decltype`, never transcription, so a slot cannot drift from the declaration it stands for. `strlenU16` turned out to be the only symbol needed from `libsapucum`; it is a four-line loop now, so that library leaves the link line too.

## Results

Every suite, both backends, against the a4h trial:

| Suite | nwrfc | proto |
|---|---|---|
| `rfc` (27) | 27/27 | 27/27 |
| `bics` (43) | 43/43 | 43/43 |
| `odp` (24) | 24/24 | 24/24 |
| `tunnel` (3) | 3/3 | — |
| C++ (121 cases) | 3210 assertions | 3212 assertions |

All three `proto_known_failures.txt` files are **empty**. The proto legs were additionally run with the SDK removed from the library path entirely and stayed green; the same run on nwrfc fails immediately with "Could not load the SAP NW RFC SDK", so the check is not vacuous.

This is well ahead of erpl-proto's own docs, which claim 13/20 (`README.md`) and 18/20 (ABI-4, naming `sap_rfc_invoke_fuzz` and `sap_rfc_type_coverage` as failures). Both are stale; both named tests pass.

## What the dual-backend matrix caught

Five wrong `RFC_RC` ordinals in the shim — `sapnwrfc.h`'s enum is unnumbered, so every value is a position you can only get right by counting:

| Constant | shim had | SDK | what the shim's value means |
|---|---|---|---|
| `RFC_INVALID_HANDLE` | 8 | 13 | `RFC_TIMEOUT` |
| `RFC_EXTERNAL_FAILURE` | 20 | 15 | `RFC_INVALID_PARAMETER` |
| `RFC_NOT_FOUND` | 23 | 17 | `RFC_BUFFER_TOO_SMALL` |
| `RFC_NOT_SUPPORTED` | 21 | 18 | `RFC_CODEPAGE_CONVERSION_FAILURE` |
| `RFC_INVALID_PARAMETER` | 12 | 20 | `RFC_SERIALIZATION_FAILURE` |

Invisible inside erpl-proto — its tests use the same constants, so they agreed with themselves. `RfcConnection::Close` treats `RFC_INVALID_HANDLE` as benign (#78), so getting 8 turned every close of a stale connection into a thrown `IOException`. Note which leg found it: the SQL suites were green throughout; the C++ suite caught it the first time it ran on proto.

Fixed in erpl-proto, and `scripts/check_proto_backend_symbols.sh` now gates both the entry-point set and every `RFC_RC` constant against the SDK header.

## Release packaging

The trampoline embeds the shim (+1.29 MB against the SDK + ICU's ~30 MB) and extracts it next to the other extensions, where the dispatch layer finds it with no search path involved. Extracted but deliberately **not** loaded — the trampoline loads `RTLD_GLOBAL`, which would defeat the isolation.

Verified end to end on the released artifact: clean `HOME`, no env vars, `SET erpl_rfc_backend='proto'`, then `sap_read_table('SFLIGHT')` and `STFC_CONNECTION` round-tripping through the Rust stack.

## Companion PRs

Merge these first — this PR's submodule pointers reference them:

- DataZooDE/erpl-bics `claude/erpl-proto-dispatch`
- DataZooDE/erpl-odp `claude/erpl-proto-dispatch`
- DataZooDE/erpl-proto `claude/fix-rfc-rc-ordinals`

## Also here

- `sap_rfc_invoke`'s advertised example was wrong — `REQUTEXT='Hello'` is rejected by the binder (only `path` and `secret` are named parameters). Corrected to the STRUCT form the tests use; both examples executed against a4h.
- `add_erpl_proto_backend()` briefly drove cargo from a `CONFIGURE_DEPENDS` glob, which forced a full CMake reconfigure before every build. Cargo owns its own change detection now; a no-op build is 0.1s.

## Not covered

Windows and macOS are written but unexercised — only Linux has been run. CI builds all three.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789831593&installation_model_id=425457&pr_number=118&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F118&signature=d6abef39939c24b2f29ea309bfe13cda3c97493f589917af1614930d30f820d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->