### PR TITLE
fix(bics): make BEx result sets fit in memory, and say so when they do not (#120)

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1316,6 +1316,13 @@ backend you had not.
 |--------|------|---------|-------------|
 | `erpl_bics_trace` | BOOLEAN | `false` | Enable BICS trace logging |
 | `erpl_bics_trace_dir` | VARCHAR | `'./trace'` | BICS trace directory |
+| `erpl_bics_max_data_cells` | BIGINT | `10000000` | Upper bound on the number of data cells a single BICS result set may contain |
+
+`erpl_bics_max_data_cells` is passed to `BICS_PROV_GET_RESULT_SET` as `I_MAX_DATA_CELLS`.
+BW builds the result set only if it fits the budget; otherwise it returns no data at all
+and `sap_bics_result()` fails with an error naming the size the result would have had.
+Raise the setting for large extracts (it is capped at 2,147,483,647, the width of the ABAP
+integer BW receives it in), or lower it to guard against a runaway query.
 
 ---
 

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1316,28 +1316,39 @@ backend you had not.
 |--------|------|---------|-------------|
 | `erpl_bics_trace` | BOOLEAN | `false` | Enable BICS trace logging |
 | `erpl_bics_trace_dir` | VARCHAR | `'./trace'` | BICS trace directory |
-| `erpl_bics_max_data_cells` | BIGINT | `1000000` | Upper bound on the number of data cells a single BICS result set may contain |
+| `erpl_bics_max_result_memory` | VARCHAR | `''` (DuckDB's `memory_limit`) | Memory a single BICS result set may use, e.g. `'8GB'` |
+| `erpl_bics_max_data_cells` | BIGINT | `0` (derive from the memory budget) | Explicit cell budget (`I_MAX_DATA_CELLS`), for pinning exactly what BW receives |
 
-`erpl_bics_max_data_cells` is passed to `BICS_PROV_GET_RESULT_SET` as `I_MAX_DATA_CELLS`.
-BW builds the result set only if it fits the budget; otherwise it returns no data at all
-and `sap_bics_result()` fails with an error naming the size the result would have had.
-Raise the setting for large extracts (it is capped at 2,147,483,647, the width of the ABAP
-integer BW receives it in), or lower it to guard against a runaway query.
+A BEx query is read in one piece: BW builds the whole result set or none of it, and there
+is no windowing in the BICS RFC API to page it (neither `BICS_PROV_GET_RESULT_SET` nor
+`BICS_PROV_GET_RESULTSET_DETAIL` accepts a row range). So the ceiling is a **memory**
+budget.
 
-It is in practice a **memory** budget. The whole result set is materialised before the
-first row is emitted, at roughly **2.2 KB of peak RSS per data cell** (measured on the
-release build), plus about 0.8 KB per row-axis element (result rows x row-axis
-characteristics). Size it against the memory you have:
+`erpl_bics_max_result_memory` accepts anything DuckDB's own memory settings accept
+(`'8GB'`, `'512MB'`, `'80%'`). Left empty it follows DuckDB's `memory_limit`, which
+defaults to **80% of physical RAM** — so out of the box erpl sizes itself to the machine,
+and `SET memory_limit` moves both together.
 
-| Budget | Approx. peak RSS |
-|--------|------------------|
-| 1,000,000 (default) | ~2.2 GB |
-| 4,000,000 | ~8.8 GB |
-| 10,000,000 | ~22 GB |
+erpl converts the budget into the cell count BW needs (`I_MAX_DATA_CELLS`) by dividing by
+~128 bytes per data cell — the width of one `BICS_PROV_RS_DATA_CELL` row in the SAP RFC
+container. Set `erpl_bics_max_data_cells` to a non-zero value to bypass the conversion and
+pin the cell count yourself (capped at 2,147,483,647, the width of the ABAP integer BW
+receives it in).
 
-Note that the budget counts **data cells** — the key-figure cells — not output columns. A
-result with 60,000 rows and 31 output columns of which 6 are key figures is 360,000 data
-cells, not 1,860,000.
+When a query does not fit, it fails with the size it would have needed and a value you can
+paste straight back:
+
+```
+This BEx query is too large to read in one go: it would return 63000 rows x 31 columns
+= 1953000 data cells, which needs about 238.4 MB of memory. The limit is 4.0 MB. Either
+raise it with SET erpl_bics_max_result_memory = '287MiB' (make sure the machine actually
+has that much), or make the query smaller with sap_bics_filter(). BW reported result
+state 4.
+```
+
+Note the budget counts **data cells** — the key-figure cells — not output columns. A result
+with 60,000 rows and 31 output columns of which 6 are key figures is 360,000 data cells,
+not 1,860,000.
 
 ---
 

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1316,8 +1316,17 @@ backend you had not.
 |--------|------|---------|-------------|
 | `erpl_bics_trace` | BOOLEAN | `false` | Enable BICS trace logging |
 | `erpl_bics_trace_dir` | VARCHAR | `'./trace'` | BICS trace directory |
+| `erpl_bics_stream_result_tables` | BOOLEAN | `true` | Stream the large BICS response tables off the SAP SDK handle instead of materialising them |
 | `erpl_bics_max_result_memory` | VARCHAR | `''` (DuckDB's `memory_limit`) | Memory a single BICS result set may use, e.g. `'8GB'` |
 | `erpl_bics_max_data_cells` | BIGINT | `0` (derive from the memory budget) | Explicit cell budget (`I_MAX_DATA_CELLS`), for pinning exactly what BW receives |
+
+`erpl_bics_stream_result_tables` controls how the response is read. With it on (the
+default) the four tables that grow with the result — `E_T_DATA_CELLS`, `E_T_ROWS`,
+`E_T_MEMBER`, `E_T_MEMBER_PRESENTATION` — are read row by row from the SDK handle and only
+the fields actually needed are converted. Turning it off restores the pre-2026.08
+behaviour of building the whole response as a value tree, which costs roughly 2.2 KB per
+data cell and 0.8 KB per row-axis element. It exists as an escape hatch; there is no
+reason to turn it off except to compare behaviour.
 
 A BEx query is read in one piece: BW builds the whole result set or none of it, and there
 is no windowing in the BICS RFC API to page it (neither `BICS_PROV_GET_RESULT_SET` nor

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1316,13 +1316,28 @@ backend you had not.
 |--------|------|---------|-------------|
 | `erpl_bics_trace` | BOOLEAN | `false` | Enable BICS trace logging |
 | `erpl_bics_trace_dir` | VARCHAR | `'./trace'` | BICS trace directory |
-| `erpl_bics_max_data_cells` | BIGINT | `10000000` | Upper bound on the number of data cells a single BICS result set may contain |
+| `erpl_bics_max_data_cells` | BIGINT | `1000000` | Upper bound on the number of data cells a single BICS result set may contain |
 
 `erpl_bics_max_data_cells` is passed to `BICS_PROV_GET_RESULT_SET` as `I_MAX_DATA_CELLS`.
 BW builds the result set only if it fits the budget; otherwise it returns no data at all
 and `sap_bics_result()` fails with an error naming the size the result would have had.
 Raise the setting for large extracts (it is capped at 2,147,483,647, the width of the ABAP
 integer BW receives it in), or lower it to guard against a runaway query.
+
+It is in practice a **memory** budget. The whole result set is materialised before the
+first row is emitted, at roughly **2.2 KB of peak RSS per data cell** (measured on the
+release build), plus about 0.8 KB per row-axis element (result rows x row-axis
+characteristics). Size it against the memory you have:
+
+| Budget | Approx. peak RSS |
+|--------|------------------|
+| 1,000,000 (default) | ~2.2 GB |
+| 4,000,000 | ~8.8 GB |
+| 10,000,000 | ~22 GB |
+
+Note that the budget counts **data cells** — the key-figure cells — not output columns. A
+result with 60,000 rows and 31 output columns of which 6 are key figures is 360,000 data
+cells, not 1,860,000.
 
 ---
 

--- a/rfc/src/include/sap_function.hpp
+++ b/rfc/src/include/sap_function.hpp
@@ -88,7 +88,6 @@ bool GetRfcStrictTypeCheck();
             std::vector<RfcFieldDesc> _field_infos;
 
             child_list_t<LogicalType> CreateDuckDbTypesForRfcStruct();
-            LogicalType CreateDuckDbTypeForRfcTable();
             
             void AdaptStructure(RFC_STRUCTURE_HANDLE &structure_handle, string &arg_name, Value &arg_value);
             void AdaptTable(RFC_TABLE_HANDLE &table_handle, string &arg_name, Value &arg_value);
@@ -96,9 +95,15 @@ bool GetRfcStrictTypeCheck();
             Value ConvertRfcValue(RFC_FUNCTION_HANDLE &function_handle, string &field_name);
             Value ConvertRfcStruct(RFC_STRUCTURE_HANDLE &struct_handle);
             Value ConvertRfcTable(RFC_TABLE_HANDLE &table_handle);
+            // Converts one row against a STRUCT LogicalType the caller built once for the
+            // whole table, instead of deriving (and storing) a fresh one per row.
+            Value ConvertRfcStruct(RFC_STRUCTURE_HANDLE &struct_handle, const LogicalType &struct_type);
 
         public:
             bool IsStringType() const;
+            // The row type of a TABLES parameter -- public so a caller that defers the
+            // conversion can still declare the right (empty) LIST type for it.
+            LogicalType CreateDuckDbTypeForRfcTable();
 
             static RfcType FromTypeName(const std::string &type_name);
             static RfcType FromTypeName(const std::string &type_name, const unsigned int length, const unsigned int decimals);
@@ -248,6 +253,13 @@ bool GetRfcStrictTypeCheck();
     class RfcResultSet {
         public: 
             RfcResultSet(std::shared_ptr<RfcInvocation> invocation, std::string path);
+            // `deferred_table_params` names TABLES parameters that must NOT be converted
+            // into a duckdb::Value tree.  Their Value comes back as an empty LIST of the
+            // right type; the caller reads the rows straight off the SDK handle with
+            // GetResultTableHandle() instead.  This exists so a very large table can be
+            // streamed rather than boxed -- see issue #120.
+            RfcResultSet(std::shared_ptr<RfcInvocation> invocation, std::string path,
+                         std::set<std::string> deferred_table_params);
 
             std::shared_ptr<RfcInvocation> GetInvocation() const;
             std::shared_ptr<RfcFunction> GetFunction() const;
@@ -265,6 +277,18 @@ bool GetRfcStrictTypeCheck();
             unsigned int TotalRows();
             bool IsTabularResult();
 
+            // Raw SDK access to a deferred TABLES parameter.  Only valid for a parameter
+            // named in `deferred_table_params`: for anything else the rows have already
+            // been converted and the handle's lifetime is not something the caller can
+            // reason about, so both throw rather than hand out a trap.  The returned
+            // handle is owned by the invocation and stays valid exactly as long as this
+            // RfcResultSet is alive.
+            RFC_TABLE_HANDLE GetResultTableHandle(const std::string &param_name) const;
+            unsigned int GetResultTableRowCount(const std::string &param_name) const;
+            // Row type of a deferred TABLES parameter, so the caller can convert
+            // individual fields off the row handle with ConvertRfcValueFromContainer().
+            std::shared_ptr<RfcType> GetResultTableRowType(const std::string &param_name) const;
+
             std::string ToSQLString();
 
             static std::shared_ptr<RfcResultSet> InvokeFunction(
@@ -272,6 +296,14 @@ bool GetRfcStrictTypeCheck();
                 std::string function_name,
                 std::vector<Value> &function_arguments,
                 std::string result_path
+            );
+
+            static std::shared_ptr<RfcResultSet> InvokeFunction(
+                std::shared_ptr<RfcConnection> connection,
+                std::string function_name,
+                std::vector<Value> &function_arguments,
+                std::string result_path,
+                std::set<std::string> deferred_table_params
             );
 
             static std::shared_ptr<RfcResultSet> InvokeFunction(
@@ -291,6 +323,7 @@ bool GetRfcStrictTypeCheck();
             std::vector<std::string> _result_names;
             std::vector<LogicalType> _result_types;
             std::vector<Value> _result_data;
+            std::set<std::string> _deferred_table_params;
             unsigned int _total_rows;
             unsigned int _current_row_idx;
             

--- a/rfc/src/sap_function.cpp
+++ b/rfc/src/sap_function.cpp
@@ -862,8 +862,12 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
                 rc = RfcGetTable(function_handle, std2uc(field_name).get(), &table_handle, &error_info);
                 if (rc != RFC_OK)
                 {
+                    // The field name was missing from this format string, so the throw
+                    // itself threw ("Expected 3 parameters, received 2") and buried the
+                    // real RFC error.
                     throw std::runtime_error(StringUtil::Format("Failed to get table %s: %s: %s",
-                                                                rfcrc2std(error_info.code), uc2std(error_info.message)));
+                                                                field_name, rfcrc2std(error_info.code),
+                                                                uc2std(error_info.message)));
                 }
 
                 return ConvertRfcTable(table_handle);
@@ -965,6 +969,38 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
         return Value::STRUCT(std::move(struct_values));
     }
 
+    // Same conversion as above, but against a STRUCT LogicalType the caller already
+    // built.  Value::STRUCT(child_list_t) derives -- and therefore stores -- a fresh
+    // LogicalType per row: for a table that is one copy of every field name and type per
+    // *row*, which for a wide table dominates the payload itself.  Sharing one type
+    // across the rows of a table halves the memory a converted table costs (measured
+    // 2160 -> 1120 bytes per row on a 14-field BICS data cell).  See issue #120.
+    Value RfcType::ConvertRfcStruct(RFC_STRUCTURE_HANDLE &struct_handle, const LogicalType &struct_type)
+    {
+        if (struct_type.id() != LogicalTypeId::STRUCT) {
+            // Single unnamed column: CreateDuckDbTypeForRfcTable collapses the struct
+            // away, so there is no shared type to hand down.
+            return ConvertRfcStruct(struct_handle);
+        }
+
+        auto &child_types = StructType::GetChildTypes(struct_type);
+        auto field_infos = GetFieldInfos();
+        if (field_infos.size() != child_types.size()) {
+            // Should not happen -- both come off the same field infos -- but a mismatch
+            // would silently misalign the columns, so fall back rather than guess.
+            return ConvertRfcStruct(struct_handle);
+        }
+
+        vector<Value> struct_values;
+        struct_values.reserve(field_infos.size());
+        for (auto &field_info : field_infos) {
+            auto struct_key = field_info.GetName();
+            struct_values.emplace_back(field_info.GetRfcType()->ConvertRfcValue(struct_handle, struct_key));
+        }
+
+        return Value::STRUCT(struct_type, std::move(struct_values));
+    }
+
     Value RfcType::ConvertRfcTable(RFC_TABLE_HANDLE &table_handle) 
     {
         RFC_RC rc = RFC_OK;
@@ -994,7 +1030,7 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
             }
 
             auto row_handle = RfcGetCurrentRow(table_handle, &error_info);
-            auto struct_value = ConvertRfcStruct(row_handle);
+            auto struct_value = ConvertRfcStruct(row_handle, child_type);
 
             row_values.emplace_back(std::move(struct_value));
         }
@@ -1865,10 +1901,70 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
     // RfcInvocation ------------------------------------------------------------
 
     RfcResultSet::RfcResultSet(std::shared_ptr<RfcInvocation> invocation, std::string path) 
-        : _invocation(invocation), _path(path), _total_rows(0), _current_row_idx(0)
+        : RfcResultSet(invocation, path, std::set<std::string>())
+    { }
+
+    RfcResultSet::RfcResultSet(std::shared_ptr<RfcInvocation> invocation, std::string path,
+                               std::set<std::string> deferred_table_params) 
+        : _invocation(invocation), _path(path),
+          _deferred_table_params(std::move(deferred_table_params)),
+          _total_rows(0), _current_row_idx(0)
     {
+        // Selecting a path *into* a deferred parameter would silently report zero rows:
+        // the placeholder LIST is empty, and the rows only exist behind the SDK handle.
+        auto path_tokens = ValueHelper::ParseJsonPointer(path);
+        if (! path_tokens.empty() &&
+            _deferred_table_params.find(path_tokens.front()) != _deferred_table_params.end()) {
+            throw std::runtime_error(StringUtil::Format(
+                "Result path '%s' selects deferred table parameter '%s'; read it through "
+                "GetResultTableHandle() instead", path, path_tokens.front()));
+        }
+
         std::tie(_result_names, _result_types) = InferResultSchema(path);
         _result_data = ConvertValuesAndSelectPath(path);
+    }
+
+    RFC_TABLE_HANDLE RfcResultSet::GetResultTableHandle(const std::string &param_name) const
+    {
+        if (_deferred_table_params.find(param_name) == _deferred_table_params.end()) {
+            throw std::runtime_error(StringUtil::Format(
+                "Parameter '%s' was not deferred; its rows are already converted and the SDK "
+                "handle is not safe to hand out", param_name));
+        }
+
+        RFC_ERROR_INFO error_info;
+        RFC_TABLE_HANDLE table_handle = nullptr;
+        auto rc = RfcGetTable(_invocation->GetFunctionHandle(), std2uc(param_name).get(),
+                              &table_handle, &error_info);
+        if (rc != RFC_OK || table_handle == nullptr) {
+            throw std::runtime_error(StringUtil::Format("Failed to get table '%s': %s: %s",
+                                                        param_name, rfcrc2std(error_info.code),
+                                                        uc2std(error_info.message)));
+        }
+        return table_handle;
+    }
+
+    std::shared_ptr<RfcType> RfcResultSet::GetResultTableRowType(const std::string &param_name) const
+    {
+        if (_deferred_table_params.find(param_name) == _deferred_table_params.end()) {
+            throw std::runtime_error(StringUtil::Format(
+                "Parameter '%s' was not deferred; use GetResultValue() instead", param_name));
+        }
+        return _invocation->GetFunction()->GetResultInfo(param_name).GetRfcType();
+    }
+
+    unsigned int RfcResultSet::GetResultTableRowCount(const std::string &param_name) const
+    {
+        auto table_handle = GetResultTableHandle(param_name);
+        RFC_ERROR_INFO error_info;
+        unsigned int row_count = 0;
+        auto rc = RfcGetRowCount(table_handle, &row_count, &error_info);
+        if (rc != RFC_OK) {
+            throw std::runtime_error(StringUtil::Format("Failed to get row count for '%s': %s: %s",
+                                                        param_name, rfcrc2std(error_info.code),
+                                                        uc2std(error_info.message)));
+        }
+        return row_count;
     }
 
     std::vector<LogicalType> RfcResultSet::GetResultTypes() 
@@ -2006,6 +2102,15 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
     {
             auto rfc_type = param_info.GetRfcType();
             auto field_name = param_info.GetName();
+
+            // A deferred table is read straight off the SDK handle by the caller, so skip
+            // the conversion entirely and stand in an empty LIST of the correct type --
+            // the schema stays exactly as it would have been (issue #120).
+            if (! _deferred_table_params.empty() &&
+                _deferred_table_params.find(field_name) != _deferred_table_params.end()) {
+                return Value::LIST(rfc_type->CreateDuckDbTypeForRfcTable(), {});
+            }
+
             return rfc_type->ConvertRfcValue(_invocation, field_name);
     }
 
@@ -2202,6 +2307,20 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
                             ? invocation->Invoke(result_path)
                             : invocation->Invoke();
         return result_set;
+    }
+
+    std::shared_ptr<RfcResultSet> RfcResultSet::InvokeFunction(std::shared_ptr<RfcConnection> connection,
+                                                               std::string function_name,
+                                                               std::vector<Value> &function_arguments,
+                                                               std::string result_path,
+                                                               std::set<std::string> deferred_table_params)
+    {
+        auto func = std::make_shared<RfcFunction>(connection, function_name);
+        auto invocation = function_arguments.size() > 0 
+                            ? func->BeginInvocation(function_arguments) 
+                            : func->BeginInvocation();
+        invocation->Execute();
+        return std::make_shared<RfcResultSet>(invocation, result_path, std::move(deferred_table_params));
     }
 
     std::shared_ptr<RfcResultSet> RfcResultSet::InvokeFunction(std::shared_ptr<RfcConnection> connection,

--- a/rfc/test/cpp/CMakeLists.txt
+++ b/rfc/test/cpp/CMakeLists.txt
@@ -16,6 +16,8 @@ include_directories(./include
 
 set(TEST_SOURCES
     test_type_conversion.cpp
+    test_struct_type_sharing.cpp
+    test_deferred_table_params.cpp
     test_serialization_helper.cpp
     test_value_helper.cpp
     test_table_wrapper.cpp

--- a/rfc/test/cpp/test_deferred_table_params.cpp
+++ b/rfc/test/cpp/test_deferred_table_params.cpp
@@ -1,0 +1,151 @@
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "sap_rfc_api.hpp"
+#include "sap_connection.hpp"
+#include "sap_function.hpp"
+#include "duckdb_argument_helper.hpp"
+
+#include <cstdlib>
+
+using namespace duckdb;
+
+// Issue #120 (memory): RfcResultSet materialises *every* result parameter into a
+// duckdb::Value tree in its constructor.  For BICS that means E_T_DATA_CELLS -- the
+// single biggest table in the response -- is fully boxed before a single output row is
+// produced, at ~1.1 KB per cell even after the shared-type fix.
+//
+// A caller that intends to stream a table straight off the SDK handle can now mark it
+// deferred: the conversion is skipped and the raw RFC_TABLE_HANDLE is exposed instead.
+// The handle stays valid as long as the RfcResultSet (and through it the invocation)
+// is alive.
+
+namespace {
+
+bool SapEnvPresent() {
+	return std::getenv("ERPL_SAP_ASHOST") && std::getenv("ERPL_SAP_SYSNR") &&
+	       std::getenv("ERPL_SAP_USER") && std::getenv("ERPL_SAP_PASSWORD") &&
+	       std::getenv("ERPL_SAP_CLIENT") && std::getenv("ERPL_SAP_LANG");
+}
+
+std::shared_ptr<RfcConnection> Connect() {
+	RfcAuthParams params;
+	params.ashost   = std::getenv("ERPL_SAP_ASHOST");
+	params.sysnr    = std::getenv("ERPL_SAP_SYSNR");
+	params.user     = std::getenv("ERPL_SAP_USER");
+	params.password = std::getenv("ERPL_SAP_PASSWORD");
+	params.client   = std::getenv("ERPL_SAP_CLIENT");
+	params.lang     = std::getenv("ERPL_SAP_LANG");
+	return params.Connect();
+}
+
+std::vector<Value> ReadTableArgs() {
+	return {ArgBuilder().Add("QUERY_TABLE", Value("T000"))
+	                    .Add("DELIMITER", Value("|"))
+	                    .Add("ROWCOUNT", Value::INTEGER(5))
+	                    .Build()};
+}
+
+} // namespace
+
+TEST_CASE("A deferred table parameter is not materialised", "[erpl_rfc][deferred_tables]") {
+	if (!SapEnvPresent()) {
+		WARN("Skipping: ERPL_SAP_* environment variables not set (needs a live SAP system)");
+		return;
+	}
+
+	auto conn = Connect();
+	auto args = ReadTableArgs();
+	auto deferred = std::set<std::string>{"DATA"};
+	auto result_set = RfcResultSet::InvokeFunction(conn, "RFC_READ_TABLE", args, "", deferred);
+
+	// The Value tree for DATA was never built ...
+	auto data = result_set->GetResultValue("DATA");
+	REQUIRE(data.type().id() == LogicalTypeId::LIST);
+	REQUIRE(ListValue::GetChildren(data).empty());
+
+	// ... but the rows are reachable through the SDK handle.  (T000 holds one row per
+	// client, so pin only that there are some -- not how many.)
+	REQUIRE(result_set->GetResultTableRowCount("DATA") > 0);
+	REQUIRE(result_set->GetResultTableHandle("DATA") != nullptr);
+
+	// A parameter that was NOT deferred is materialised as before.
+	auto fields = result_set->GetResultValue("FIELDS");
+	REQUIRE(ListValue::GetChildren(fields).size() > 0);
+}
+
+TEST_CASE("Streaming a deferred table yields the same values as materialising it",
+          "[erpl_rfc][deferred_tables]") {
+	if (!SapEnvPresent()) {
+		WARN("Skipping: ERPL_SAP_* environment variables not set (needs a live SAP system)");
+		return;
+	}
+
+	auto conn = Connect();
+
+	auto materialised_args = ReadTableArgs();
+	auto materialised = RfcResultSet::InvokeFunction(conn, "RFC_READ_TABLE", materialised_args);
+	auto expected_rows = ListValue::GetChildren(materialised->GetResultValue("DATA"));
+	REQUIRE(expected_rows.size() > 0);
+
+	auto streamed_args = ReadTableArgs();
+	auto deferred = std::set<std::string>{"DATA"};
+	auto streamed = RfcResultSet::InvokeFunction(conn, "RFC_READ_TABLE", streamed_args, "", deferred);
+
+	auto table_handle = streamed->GetResultTableHandle("DATA");
+	REQUIRE(table_handle != nullptr);
+	// GetResultTableRowType returns the TABLES parameter's type; its field infos describe
+	// the row, so a single field is read through that field's own RfcType.
+	auto row_type = streamed->GetResultTableRowType("DATA");
+	auto wa_type = row_type->GetFieldInfo("WA").GetRfcType();
+
+	REQUIRE(streamed->GetResultTableRowCount("DATA") == expected_rows.size());
+
+	RFC_ERROR_INFO error_info;
+	for (unsigned int i = 0; i < streamed->GetResultTableRowCount("DATA"); i++) {
+		REQUIRE(RfcMoveTo(table_handle, i, &error_info) == RFC_OK);
+		auto row_handle = RfcGetCurrentRow(table_handle, &error_info);
+		auto wa = wa_type->ConvertRfcValueFromContainer(row_handle, "WA");
+		auto expected_wa = StructValue::GetChildren(expected_rows[i])[0];
+		REQUIRE(wa.ToString() == expected_wa.ToString());
+	}
+}
+
+TEST_CASE("Selecting a deferred table as the result path is rejected",
+          "[erpl_rfc][deferred_tables]") {
+	if (!SapEnvPresent()) {
+		WARN("Skipping: ERPL_SAP_* environment variables not set (needs a live SAP system)");
+		return;
+	}
+
+	auto conn = Connect();
+	auto args = ReadTableArgs();
+	auto deferred = std::set<std::string>{"DATA"};
+	// The rows of DATA only exist behind the SDK handle, so a result path that selects
+	// DATA would quietly report an empty result rather than the rows the caller asked
+	// for.  Refuse the combination instead.
+	REQUIRE_THROWS(RfcResultSet::InvokeFunction(conn, "RFC_READ_TABLE", args, "/DATA", deferred));
+
+	// Deferring a *different* table while selecting this one stays legal.
+	auto other = std::set<std::string>{"DATA"};
+	auto ok = RfcResultSet::InvokeFunction(conn, "RFC_READ_TABLE", args, "/FIELDS", other);
+	REQUIRE(ok->TotalRows() > 0);
+}
+
+TEST_CASE("Asking for a table handle that was not deferred is an error",
+          "[erpl_rfc][deferred_tables]") {
+	if (!SapEnvPresent()) {
+		WARN("Skipping: ERPL_SAP_* environment variables not set (needs a live SAP system)");
+		return;
+	}
+
+	auto conn = Connect();
+	auto args = ReadTableArgs();
+	auto result_set = RfcResultSet::InvokeFunction(conn, "RFC_READ_TABLE", args);
+	// Not deferred -> no promise that the handle outlives the conversion, so refuse
+	// rather than hand out something whose lifetime the caller cannot reason about.
+	REQUIRE_THROWS(result_set->GetResultTableHandle("DATA"));
+	// And a name that is not a table at all.
+	REQUIRE_THROWS(result_set->GetResultTableRowCount("NO_SUCH_PARAM"));
+	REQUIRE_THROWS(result_set->GetResultTableRowType("DATA"));
+}

--- a/rfc/test/cpp/test_struct_type_sharing.cpp
+++ b/rfc/test/cpp/test_struct_type_sharing.cpp
@@ -1,0 +1,99 @@
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "sap_rfc_api.hpp"
+#include "sap_connection.hpp"
+#include "sap_function.hpp"
+#include "duckdb_argument_helper.hpp"
+
+#include <cstdlib>
+
+using namespace duckdb;
+
+// Issue #120 (memory): RfcType::ConvertRfcTable used to build every row with
+// Value::STRUCT(child_list_t), which *derives and stores a fresh LogicalType per row*.
+// For a wide table that is one copy of every field name and type per row -- measured at
+// 2160 bytes per row for a 14-field BICS data cell, of which ~1040 was the duplicated
+// type.  The rows of one table all have the same type by construction, so the type is now
+// built once and shared.
+//
+// The sharing is directly observable: LogicalType keeps its child list in a refcounted
+// ExtraTypeInfo, so rows that share a type report the same AuxInfo pointer.
+
+namespace {
+
+bool SapEnvPresent() {
+	return std::getenv("ERPL_SAP_ASHOST") && std::getenv("ERPL_SAP_SYSNR") &&
+	       std::getenv("ERPL_SAP_USER") && std::getenv("ERPL_SAP_PASSWORD") &&
+	       std::getenv("ERPL_SAP_CLIENT") && std::getenv("ERPL_SAP_LANG");
+}
+
+std::shared_ptr<RfcConnection> Connect() {
+	RfcAuthParams params;
+	params.ashost   = std::getenv("ERPL_SAP_ASHOST");
+	params.sysnr    = std::getenv("ERPL_SAP_SYSNR");
+	params.user     = std::getenv("ERPL_SAP_USER");
+	params.password = std::getenv("ERPL_SAP_PASSWORD");
+	params.client   = std::getenv("ERPL_SAP_CLIENT");
+	params.lang     = std::getenv("ERPL_SAP_LANG");
+	return params.Connect();
+}
+
+} // namespace
+
+TEST_CASE("Converted table rows share one STRUCT LogicalType", "[erpl_rfc][type_sharing]") {
+	if (!SapEnvPresent()) {
+		WARN("Skipping: ERPL_SAP_* environment variables not set (needs a live SAP system)");
+		return;
+	}
+
+	auto conn = Connect();
+
+	// DD02L has many rows and a wide, multi-field row structure -- exactly the shape
+	// where the per-row type copy hurt.
+	std::vector<Value> args = {ArgBuilder().Add("QUERY_TABLE", Value("T000"))
+	                                       .Add("DELIMITER", Value("|"))
+	                                       .Add("ROWCOUNT", Value::INTEGER(10))
+	                                       .Build()};
+	auto result_set = RfcResultSet::InvokeFunction(conn, "RFC_READ_TABLE", args);
+	auto data = result_set->GetResultValue("DATA");
+
+	REQUIRE(data.type().id() == LogicalTypeId::LIST);
+	auto &rows = ListValue::GetChildren(data);
+	REQUIRE(rows.size() > 1);
+	REQUIRE(rows[0].type().id() == LogicalTypeId::STRUCT);
+
+	// Every row must point at the *same* ExtraTypeInfo, not an equal copy of it.
+	auto first = rows[0].type().AuxInfo();
+	REQUIRE(first != nullptr);
+	for (idx_t i = 1; i < rows.size(); i++) {
+		REQUIRE(rows[i].type().AuxInfo() == first);
+	}
+}
+
+TEST_CASE("Sharing the type does not change the converted values", "[erpl_rfc][type_sharing]") {
+	if (!SapEnvPresent()) {
+		WARN("Skipping: ERPL_SAP_* environment variables not set (needs a live SAP system)");
+		return;
+	}
+
+	auto conn = Connect();
+	std::vector<Value> args = {ArgBuilder().Add("QUERY_TABLE", Value("T000"))
+	                                       .Add("DELIMITER", Value("|"))
+	                                       .Add("ROWCOUNT", Value::INTEGER(5))
+	                                       .Build()};
+	auto result_set = RfcResultSet::InvokeFunction(conn, "RFC_READ_TABLE", args);
+	auto data = result_set->GetResultValue("DATA");
+	auto &rows = ListValue::GetChildren(data);
+
+	REQUIRE(rows.size() > 0);
+	for (auto &row : rows) {
+		// The row still exposes its fields by name, with a non-empty WA payload.
+		auto &children = StructValue::GetChildren(row);
+		REQUIRE(children.size() >= 1);
+		REQUIRE_FALSE(children[0].IsNull());
+	}
+	// The LIST's declared child type and the rows' actual type must agree -- deriving the
+	// type per row used to let these drift apart.
+	REQUIRE(ListType::GetChildType(data.type()) == rows[0].type());
+}


### PR DESCRIPTION
Fixes #120.

## The reported bug

`BicsSession::FetchResultSet` called `BICS_PROV_GET_RESULT_SET` with a hard-coded
`I_MAX_DATA_CELLS` of 1,000,000. That parameter is a *client-supplied* budget: BW builds
the result set only if it fits, and otherwise answers with

```
E_STATE     := 4
E_N_ROWS    := 3627      <- the size it would have had
E_N_COLUMNS := 6
E_T_ROWS / E_T_COLUMNS / E_T_DATA_CELLS := empty
E_MAX_MESSAGE_TYPE := ''  <- no message at all
```

erpl reported that as `The BW server returned no result structure for this query` — the
exact error in the issue. Nothing named the cause, and nothing could lift the ceiling.
Reproduced by lowering the budget on a small query: same error, byte for byte.

The budget counts **data cells** (key-figure cells), not output columns, which is why the
reporter's 63,000 x 31 fit under 1,000,000 while a 2M-cell query failed outright.

## What this PR does

**1. The ceiling is now a memory budget.** `erpl_bics_max_result_memory` accepts what
DuckDB's own memory settings accept (`'8GB'`, `'80%'`). Left empty it follows DuckDB's
`memory_limit`, which `DBConfig::SetDefaultMaxMemory()` already sets to 80% of physical
RAM — so erpl sizes itself to the machine and `SET memory_limit` moves both together.
erpl divides it by the measured per-cell cost to get `I_MAX_DATA_CELLS`.
`erpl_bics_max_data_cells` remains as an explicit override.

A query that does not fit now fails with something actionable:

```
This BEx query is too large to read in one go: it would return 63000 rows x 31 columns
= 1953000 data cells, which needs about 238.4 MB of memory. The limit is 4.0 MB. Either
raise it with SET erpl_bics_max_result_memory = '287MiB' (make sure the machine actually
has that much), or make the query smaller with sap_bics_filter(). BW reported result
state 4.
```

The suggested value is guaranteed to parse back to at least what is needed — `'2.7 MB'`
parses as 2.5 MiB, i.e. *less* than asked for, so the naive suggestion would have failed
on retry.

**2. The result set is no longer materialised.** Profiling the fix showed the real
problem was upstream. Every response row became a `duckdb::Value` STRUCT carrying its own
`LogicalType`, and the whole response was built before the first output row:

| structure | before | after |
|---|---|---|
| `E_T_DATA_CELLS` row (14 fields) | ~2,160 B | streamed |
| `E_T_ROWS` axis element (4 fields) | ~784 B | streamed |

The four tables that grow with the result — `E_T_DATA_CELLS`, `E_T_ROWS`, `E_T_MEMBER`,
`E_T_MEMBER_PRESENTATION` — are now deferred on the `RfcResultSet` and read row by row off
the SAP SDK handle, converting only the fields a caller asks for (the fetch loop reads
three of a data cell's fourteen). `E_T_COLUMNS` stays materialised: it is bounded by the
column count, not the result size. `SET erpl_bics_stream_result_tables = false` restores
the old path.

**3. Two hot-path bugs found on the way.**

- `RowReferenceIterator::NextPresentationValues` did `const auto &members =
  member_table.Rows()`, and `GenericTable::Rows()` returns the vector **by value** — so it
  copied the entire member table once per result row, O(rows x members) `Value` copies.
- `Member`, `MemberReference` and `Presentation` resolved a `"/FIELD"` `ValueHelper` string
  path on *every accessor call*, once per element per result row. They hold their fields
  directly now.

Also fixes a `StringUtil::Format` with three placeholders and two arguments, where the
throw itself threw and buried the real RFC error.

## Measurements

The demo cube holds ~7,000 records — far too little to measure any of this — so this PR
adds `bics/test/fixtures`, an idempotent BW fixture: a Z aDSO created from the demo cube
via `CL_RSO_ADSO_API` and loaded through `RSDSO_WRITE_API`, **leaving the demo cube
untouched**. `./setup_big_adso.sh [rows]` rebuilds it; the load is chunked (an ADT class
run is a dialog work process, killed at `rdisp/max_wprun_time`) and resumable. Loaded to
20,000,000 rows over a 6.7-billion-key space; it partitions on `0CALMONTH` (~1/197) and
`0CALYEAR` (~1/17) so a test picks its result size by filtering.

Same binary, `erpl_bics_stream_result_tables` flipped, so the ~1 GB per-session constant
and allocator behaviour cancel:

| result rows | streamed | materialised | saved | reduction | elapsed |
|---|---|---|---|---|---|
| 106,729 | 1,327 MB | 2,386 MB | 1,059 MB | 44% | 33.2 s vs 34.6 s |
| 1,280,841 | 3,496 MB | 14,795 MB | **11,299 MB** | **76%** | 437.6 s vs 451.2 s |

Row counts are identical on both arms, and the streamed path is marginally *faster* — the
extra SDK round trips are more than paid for by the two hot-path fixes above.

## On pagination

There is none to have. Neither `BICS_PROV_GET_RESULT_SET` nor
`BICS_PROV_GET_RESULTSET_DETAIL` accepts a row range (verified against the live
signatures), so BW builds the whole result set or none of it. Sizing the budget, or
filtering, is the supported route.

## Tests

Red first, then green, throughout:

- `rfc/test/cpp/test_struct_type_sharing.cpp` — rows of a converted table share one
  `ExtraTypeInfo` (the red run showed every row with its own).
- `rfc/test/cpp/test_deferred_table_params.cpp` — a deferred table is not materialised, the
  streamed rows equal the materialised ones, and misuse is refused.
- `bics/test/cpp/test_bics_data_cell_streaming.cpp` — nothing materialised, values stable
  and in range, a full fetch returns every row, and the non-streaming path still works.
- `bics/test/cpp/test_bics_result_limits.cpp` — the overflow message, the 64-bit and
  saturating arithmetic, and that the suggested budget is big enough to retry with.
- `bics/test/sql/sap_bics_max_data_cells.test` — end to end against a live system.

Full suite, all nine legs:

| leg | result |
|---|---|
| erpl_rfc / erpl_bics / erpl_odp C++ | 127 / 180 / 9 cases, ASAN+UBSan+LSAN clean |
| rfc / bics / odp SQL (nwrfc) | 28 / 44 / 24 passed, 0 failed |
| rfc / bics / odp SQL (**proto**) | 28 / 44 / 24 passed, 0 failed |

The proto legs matter here: the streaming path calls `RfcGetTable` / `RfcMoveTo` /
`RfcGetCurrentRow` directly, and erpl-proto has its own marshalling.

Reviewed by an independent model across three rounds; every finding fixed — a dangling
reference into a by-value vector (which ASAN caught in the suite), a "fallback" that would
have emitted silently-NULL measures, a budget regression for sessions built without a
`ClientContext`, misleading traces for deferred tables, a double member read per element,
and arithmetic that could wrap a too-large result into "it fits".
