### PR TITLE
chore(scripts): one-command BW Modeling activation for the a4h trial

### DIFF
--- a/scripts/activate_bw_modeling.sh
+++ b/scripts/activate_bw_modeling.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Activates the BW Modeling ADT services on the local a4h trial container.
+#
+# They ship INACTIVE on sapse/abap-cloud-developer-trial:2023, so every `erpl-adt bw ...`
+# command returns HTTP 403 until this has run.  Activation survives a container restart
+# but not an image recreation, so this needs re-running after a rebuild.
+#
+# Procedure and the GUID constants come from erpl-adt's own documentation:
+#   https://github.com/DataZooDE/erpl-adt/blob/main/docs/activate-bw-modeling-on-a4h.md
+#
+# WARNING -- this restarts the ABAP instance, and that has a side effect beyond this repo.
+# Restarting the *instance* (not just the container) re-materialises every PSE from the
+# database, silently discarding anything `sapgenpse` wrote into a PSE *file*.  That
+# destroys the SNC and wsRFC client-certificate trust erpl-proto's live tests rely on --
+# and those tests *skip* rather than fail when trust is missing, so a suite that has lost
+# fourteen tests still reads green.
+#
+# After running this, re-run erpl-proto's scripts/deploy-a4h-fixtures.sh to restore the
+# trust, and check the skip count rather than the colour.  See DataZooDE/erpl-proto#30.
+#
+# This script exists so the operation can be granted as ONE reviewable, narrowly scoped
+# permission.  Allow-listing the raw `docker exec ... hdbsql "UPDATE ..."` it performs
+# would grant the ability to write any row of any table in the SAP database; allow-listing
+# this script grants exactly "turn the BW modeling services on, on the local throwaway
+# trial", which is auditable in review and cannot be repurposed.
+#
+#   ./scripts/activate_bw_modeling.sh          # activate (idempotent) and verify
+#   ./scripts/activate_bw_modeling.sh --check  # report status only, change nothing
+set -euo pipefail
+
+CONTAINER=${A4H_CONTAINER:-a4h}
+HDBSQL=/usr/sap/A4H/hdbclient/hdbsql
+DBUSER=${A4H_DB_USER:-SAPA4H}
+DBPASS=${A4H_DB_PASSWORD:-'ABAPtr2023#00'}   # standard credential of the public trial image
+
+# Delivered content, stable across restarts on the same image.
+BW_GUID=DFFAEATGKMFLCDXQ04F0J7FXK
+MODELING_GUID=3FWVDBADCM6B4KLQKF4R70SS5
+
+sql() { docker exec "$CONTAINER" "$HDBSQL" -i 02 -d HDB -u "$DBUSER" -p "$DBPASS" "$1"; }
+
+status() {
+    sql "SELECT ICF_NAME, ICFACTIVE FROM ${DBUSER}.ICFSERVLOC
+         WHERE (ICF_NAME = 'BW' AND ICFPARGUID = '${BW_GUID}')
+            OR (ICF_NAME = 'MODELING' AND ICFPARGUID = '${MODELING_GUID}')"
+}
+
+if [[ "${1:-}" == "--check" ]]; then
+    status
+    exit 0
+fi
+
+echo "==> current state"
+status
+
+echo "==> activating /sap/bw/ and /sap/bw/modeling/"
+sql "UPDATE ${DBUSER}.ICFSERVLOC SET ICFACTIVE = 'X'
+     WHERE ICF_NAME = 'BW' AND ICFPARGUID = '${BW_GUID}'"
+sql "UPDATE ${DBUSER}.ICFSERVLOC SET ICFACTIVE = 'X'
+     WHERE ICF_NAME = 'MODELING' AND ICFPARGUID = '${MODELING_GUID}'"
+
+echo "==> activating BW search (RSOSSEARCH)"
+sql "UPDATE ${DBUSER}.RSOSSEARCH SET ACTIVEFL = 'X' WHERE TLOGO = 'BIMO'"
+
+# A full instance restart is required: SIGHUP to icman and sapcontrol ICMRestart do NOT
+# flush the ICF service cache.
+echo "==> restarting the instance (required to flush the ICF cache)"
+docker exec "$CONTAINER" bash -c "su - a4hadm -c 'sapcontrol -nr 00 -function RestartInstance'"
+docker exec "$CONTAINER" bash -c "su - a4hadm -c 'sapcontrol -nr 00 -function WaitforStarted 300 15'"
+docker exec "$CONTAINER" bash -c "su - a4hadm -c 'sapcontrol -nr 00 -function GetProcessList'" || true
+
+echo "==> new state"
+status
+
+cat <<'DONE'
+
+==> done.  Verify with:
+
+    uvx erpl-adt --host localhost --port 50000 --user DEVELOPER \
+        --password 'ABAPtr2023#00' --client 001 bw discover
+DONE


### PR DESCRIPTION
The BW Modeling ADT services (`/sap/bw/`, `/sap/bw/modeling/`) ship **inactive** on
`sapse/abap-cloud-developer-trial:2023`. Until three rows are flipped and the instance is
restarted, every `erpl-adt bw ...` command returns HTTP 403 — which is what blocked
building the BICS test fixture in #121. The procedure lived only in
[erpl-adt's docs](https://github.com/DataZooDE/erpl-adt/blob/main/docs/activate-bw-modeling-on-a4h.md)
and had to be pasted by hand each time.

```console
$ ./scripts/activate_bw_modeling.sh --check
ICF_NAME,ICFACTIVE
"BW","X"
"MODELING","X"

$ ./scripts/activate_bw_modeling.sh          # idempotent; activates and restarts
```

## Why a script rather than a permission rule

The underlying operation is `docker exec a4h hdbsql "UPDATE SAPA4H.ICFSERVLOC ..."`.
Allow-listing *that* would grant write access to any row of any table in the SAP database —
the pattern cannot distinguish `ICFSERVLOC` from anything else. Allow-listing this script
grants exactly one operation, "turn the BW modeling services on, on the local throwaway
trial", and any future widening of it shows up in a diff. It is idempotent, and `--check`
reports state without changing anything.

## The warning in the header is the important part

Restarting the *instance* — not just the container — **re-materialises every PSE from the
database**, silently discarding anything `sapgenpse` wrote into a PSE *file*. That destroys
the SNC and wsRFC client-certificate trust that erpl-proto's live tests depend on.

The failure is quiet, which is the dangerous half: those tests **skip** when trust is
missing rather than failing, because they cannot tell an unconfigured machine from a broken
one. A suite that has silently lost fourteen tests still reads green. This is not
hypothetical — it happened while cutting v2026.08.29, and is diagnosed in
DataZooDE/erpl-proto#30.

So the header tells you to re-run erpl-proto's `deploy-a4h-fixtures.sh` afterwards, and to
check the skip count rather than the colour.

## Scope

Deliberately just the script. It is the first piece of the larger a4h provisioning work —
consolidating the three duplicated provisioners (this, erpl-proto's `deploy-a4h-fixtures.sh`,
erpl-rev's `deploy-abap.sh`) into `scripts/sap/provision.d/` with the
activation → restart → restore-cert-trust ordering encoded, and `start-sap.sh` provisioning
by default. That lands separately; this stands on its own and unblocks the permission grant
in the meantime.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790610410&installation_model_id=425457&pr_number=122&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F122&signature=8da3212ff6005b21f19ede8cc4b36746f6d67e87f30d1fff9bb58dabf53b23fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->