### PR TITLE
fix(scripts): what the first real cold start found

### DIFF
--- a/scripts/A4H_D00_vhcala4hci.profile
+++ b/scripts/A4H_D00_vhcala4hci.profile
@@ -307,3 +307,13 @@ snc/permit_insecure_start = 1
 snc/data_protection/min = 1
 snc/data_protection/max = 3
 snc/data_protection/use = 3
+
+# --- external RFC server registration ---------------------------------------
+# erpl-proto's and erpl-rev's live tests register RFC *servers* against this system
+# (SM59 destinations with method='R'). The gateway rejects that unless it is allowed,
+# either here or via a reginfo entry -- and the failure surfaces as a registration
+# timeout rather than anything naming the gateway.
+#
+# This trial is a local throwaway; on any real system prefer a reginfo allowlist.
+gw/acl_mode = 0
+

--- a/scripts/sap/lib.sh
+++ b/scripts/sap/lib.sh
@@ -14,6 +14,9 @@
 
 export SAP_PASSWORD                   # erpl-adt reads this name via --password-env
 
+# Objects whose activation failed; retried by retry_failed() after the list is walked.
+_DEFERRED=()
+
 # Credentials are passed as explicit flags on purpose: erpl-adt reads --password-env /
 # SAP_PASSWORD, never ERPL_ADT_*, and a cached .adt.creds is invalidated by an instance
 # restart -- which BW activation requires, so the cache cannot be relied on here.
@@ -34,13 +37,49 @@ fail() { printf '  FAIL %s\n' "$*"; }
 _write() {  # _write <TYPE> <NAME> <file> <desc>
     adt object create --type "$1" --name "$2" --package '$TMP' \
         --description "$4" >/dev/null 2>&1
-    if adt source write "$2" --file "$3" --activate 2>&1 \
-         | grep -aiqE 'Activated|Nothing to activate'; then
-        ok "$2"
-    else
-        warn "$2 (activation — check)"
-        return 1
-    fi
+    # Retried, because activation right after an instance restart fails transiently: the
+    # ADT search that gates readiness needs far less of the system up than the ABAP
+    # compiler does, so the first attempt can land too early.  Observed on a cold start --
+    # all twelve classes warned, and every one activated on a later manual attempt.
+    local attempt
+    for attempt in 1 2 3; do
+        if adt source write "$2" --file "$3" --activate 2>&1 \
+             | grep -aiqE 'Activated|Nothing to activate'; then
+            ok "$2"
+            return 0
+        fi
+        sleep $(( attempt * 10 ))
+    done
+    # Record rather than give up: ABAP lists are not in dependency order, and an object
+    # can fail purely because something it references is deployed later (observed with
+    # ZCL_ERPL_REV_CDSTEST, which activated cleanly once the rest of the list was in).
+    # retry_failed() below re-tries these once the list has been walked.
+    _DEFERRED+=("$1|$2|$3|$4")
+    warn "$2 (deferred — will retry after the rest of the list)"
+    return 0
+}
+
+# Re-try everything _write deferred.  One extra pass resolves forward dependencies without
+# anyone hand-maintaining a topological order; anything still failing after it is a real
+# failure and is reported as such.
+retry_failed() {
+    [ ${#_DEFERRED[@]} -eq 0 ] && return 0
+    local pending=("${_DEFERRED[@]}")
+    _DEFERRED=()
+    local rc=0 entry t n f d
+    say "second pass over ${#pending[@]} deferred object(s)"
+    for entry in "${pending[@]}"; do
+        IFS='|' read -r t n f d <<<"$entry"
+        if adt source write "$n" --file "$f" --activate 2>&1 \
+             | grep -aiqE 'Activated|Nothing to activate'; then
+            ok "$n (second pass)"
+        else
+            fail "$n (still failing after a second pass)"
+            rc=1
+        fi
+    done
+    _DEFERRED=()
+    return $rc
 }
 cls()  { _write CLAS/OC "$1" "$2" "${3:-a4h fixture}"; }
 intf() { _write INTF/OI "$1" "$2" "${3:-a4h fixture}"; }
@@ -55,21 +94,48 @@ container_up() {
     docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "$A4H_CONTAINER"
 }
 
+_process_list() {
+    docker exec "$A4H_CONTAINER" bash -c \
+        "su - a4hadm -c 'sapcontrol -nr 00 -function GetProcessList'" 2>/dev/null
+}
+
+# Default 40 minutes.  A *restart* is back in about a minute, but a COLD container is not:
+# HANA recovers first and the ABAP processes do not even launch for ~14 minutes, after
+# which disp+work sits at "YELLOW / Server in state STARTING" for several more.  A 15
+# minute budget -- which is what this had, sized from restart experience -- gives up while
+# the system is still starting normally.
 wait_for_sap() {  # all four processes GREEN
+    local deadline=$(( SECONDS + ${1:-2400} ))
+    while (( SECONDS < deadline )); do
+        if _process_list | grep -cE '\bGREEN\b' | grep -qx 4; then
+            return 0
+        fi
+        sleep 15
+    done
+    # Say what it was doing when time ran out.  "instance did not come up" on its own sent
+    # me looking for a broken system when it was simply still starting.
+    echo "wait_for_sap: gave up after $(( ${1:-2400} / 60 )) minutes; last state was:" >&2
+    _process_list | tail -5 >&2
+    return 1
+}
+
+# The gateway (gwrd) has to be up before an RFC *server* can register against it, which is
+# what erpl-proto's destinations do.  Right after a restart it is still "Scheduled", and a
+# registration attempt then fails with a bare "Connection reset by peer" naming nothing.
+wait_for_rfc() {
     local deadline=$(( SECONDS + ${1:-600} ))
     while (( SECONDS < deadline )); do
-        if docker exec "$A4H_CONTAINER" bash -c \
-             "su - a4hadm -c 'sapcontrol -nr 00 -function GetProcessList'" 2>/dev/null \
-             | grep -cE '\bGREEN\b' | grep -qx 4; then
+        if _process_list | grep -E '^gwrd' | grep -q GREEN; then
             return 0
         fi
         sleep 10
     done
+    echo "wait_for_rfc: the gateway never reached GREEN" >&2
     return 1
 }
 
 wait_for_adt() {  # ABAP HTTP stack actually answering an authenticated request
-    local deadline=$(( SECONDS + ${1:-600} ))
+    local deadline=$(( SECONDS + ${1:-1200} ))
     while (( SECONDS < deadline )); do
         if adt search CL_RSO_ADSO_API --type CLAS --max 1 >/dev/null 2>&1; then
             return 0

--- a/scripts/sap/provision.d/10-bw-modeling.sh
+++ b/scripts/sap/provision.d/10-bw-modeling.sh
@@ -29,7 +29,11 @@ if "$HERE/../activate_bw_modeling.sh" >/dev/null 2>&1; then
     # Tell the rest of the run that every PSE was just re-materialised from the database.
     RESTARTED=1
     export RESTARTED
-    if wait_for_adt 600; then
+    # All three gates, not just ADT.  ADT answering only proves the HTTP stack is up;
+    # activating ABAP needs the compiler, and registering an RFC server needs the gateway.
+    # Gating on ADT alone let the next steps start too early -- twelve classes failed to
+    # activate and every destination died with "Connection reset by peer".
+    if wait_for_sap 900 && wait_for_rfc 600 && wait_for_adt 600; then
         ok "BW Modeling services activated; instance back up"
     else
         fail "instance did not come back within 10 minutes"

--- a/scripts/sap/provision.d/20-proto-fixtures.sh
+++ b/scripts/sap/provision.d/20-proto-fixtures.sh
@@ -34,11 +34,22 @@ for f in "$_AB"/zcl_saprfc_*.abap "$_AB"/zcl_erpl_abi_*.abap; do
         "erpl-proto live server test" || rc=1
 done
 
+retry_failed || rc=1
+
 # --- destinations, delegated ------------------------------------------------
+# ERPL_A4H_DELEGATED is the recursion guard, and BOTH sides must spell it the same way.
+# They did not on the first attempt -- this side set ERPL_SKIP_ABAP while erpl-proto
+# checked ERPL_A4H_DELEGATED -- so neither guard fired and the two scripts called each
+# other until the run was killed.
+if [ -n "${ERPL_A4H_DELEGATED:-}" ]; then
+    say "destinations: handled by the caller (erpl-proto invoked us)"
+    return $rc
+fi
+
 _PROTO="${ERPL_PROTO_DIR:-$HERE/../../../erpl-proto}"
 if [ -f "$_PROTO/scripts/deploy-a4h-fixtures.sh" ]; then
     say "delegating SM59 destinations to $_PROTO"
-    if ( cd "$_PROTO" && SAP_PASSWD="$SAP_PASSWORD" ERPL_SKIP_ABAP=1 \
+    if ( cd "$_PROTO" && SAP_PASSWD="$SAP_PASSWORD" ERPL_A4H_DELEGATED=1 \
             ./scripts/deploy-a4h-fixtures.sh 2>&1 | sed 's/^/    /' ); then
         ok "erpl-proto destinations"
     else

--- a/scripts/sap/provision.d/25-rev-fixtures.sh
+++ b/scripts/sap/provision.d/25-rev-fixtures.sh
@@ -51,6 +51,8 @@ _d prog Z_ERPL_REV_DELTA z_erpl_rev_delta.prog.abap "delta orchestration loop (c
 _d prog Z_ERPL_REV_DELTA_SFLIGHT z_erpl_rev_delta_sflight.prog.abap "SFLIGHT delta demo (load/change/run/inspect, GUI)" || rc=1 || rc=1
 _d cls ZCL_ERPL_REV_REPLRUN zcl_erpl_rev_replrun.abap "Z_ERPL_REV_REPLICATE parallel-branch E2E" || rc=1 || rc=1
 
+retry_failed || rc=1
+
 # The destination and the generated RFC FMs come from the classes just deployed.
 if adt object run ZCL_ERPL_REV_SETUP >/dev/null 2>&1; then ok "ZERPL_REV destination"; else warn "ZERPL_REV destination"; rc=1; fi
 if adt object run ZCL_ERPL_REV_MKFM  >/dev/null 2>&1; then ok "RFC FMs (Z_DUCKDB_*)";  else warn "RFC FMs (Z_DUCKDB_*)";  rc=1; fi

--- a/scripts/sap/provision.sh
+++ b/scripts/sap/provision.sh
@@ -64,7 +64,12 @@ export RESTARTED=0
 export PROVISION_STATE_DIR="$STATE_DIR"
 export PROVISION_MODE="$MODE"
 
-rc=0
+# _PROVISION_RC, not rc: the steps are SOURCED, so they share this namespace.  A plain
+# `rc` was clobbered by the next step initialising its own -- step 25 failed, step 30 set
+# rc=0, and the run exited 0 reporting success.  A provisioner that returns green while a
+# step failed is the exact failure mode this whole file exists to prevent.
+_PROVISION_RC=0
+_PROVISION_FAILED=
 shopt -s nullglob
 for step in "$HERE"/provision.d/*.sh; do
     name="$(basename "$step")"
@@ -73,14 +78,16 @@ for step in "$HERE"/provision.d/*.sh; do
     # shellcheck disable=SC1090
     if ! . "$step"; then
         fail "$name"
-        rc=1
+        _PROVISION_RC=1
+        _PROVISION_FAILED="$_PROVISION_FAILED $name"
     fi
 done
+rc="$_PROVISION_RC"
 
 if [ "$rc" = 0 ]; then
     echo "== provisioning complete =="
     echo "   backgrounded steps, if any: ./scripts/sap/provision.sh --status"
 else
-    echo "== provisioning finished WITH FAILURES ==" >&2
+    echo "== provisioning finished WITH FAILURES:$_PROVISION_FAILED ==" >&2
 fi
 exit $rc

--- a/scripts/start-sap.sh
+++ b/scripts/start-sap.sh
@@ -38,12 +38,12 @@ provision_when_ready() {
     # shellcheck source=sap/lib.sh
     . "$SCRIPT_DIR/sap/lib.sh"
     echo "==> waiting for the instance"
-    wait_for_sap 900 || { echo "instance did not come up" >&2; return 1; }
+    wait_for_sap 2400 || { echo "instance did not come up (see the state above)" >&2; return 1; }
     # sapcontrol reporting GREEN is NOT enough: it says started while the ABAP HTTP stack
     # is still coming up, so an ADT call right after it fails in a way that looks like a
     # broken system rather than an early one.
     echo "==> waiting for ADT to answer"
-    wait_for_adt 900 || { echo "ADT never answered" >&2; return 1; }
+    wait_for_adt 1200 || { echo "ADT never answered" >&2; return 1; }
     echo "==> provisioning"
     "$SCRIPT_DIR/sap/provision.sh"
 }


### PR DESCRIPTION
#123 shipped with the cold-start path untested — I said so in that PR rather than letting
it read as complete. Running it found **five** defects. None were visible from reading the
code or from a green PR; all five needed a container that had genuinely never been
provisioned.

## What was wrong

**1. Timeouts sized from restarts.** A restart is back in about a minute. A *cold*
container spends ~14 minutes in HANA recovery before the ABAP processes even launch, then
sits at `YELLOW / Server in state STARTING` for several more. The 15-minute budget gave up
while the system was starting perfectly normally and said `instance did not come up` —
which reads as a fault rather than impatience. Now 40 minutes, and the last
`GetProcessList` is printed on timeout.

**2. The recursion guard did not exist.** This side set `ERPL_SKIP_ABAP`; erpl-proto checked
`ERPL_A4H_DELEGATED`. Neither fired, and the two scripts called each other until I killed
the run. One name now, honoured on both sides, with a comment naming the mismatch.

**3. The readiness gate was too weak.** Step 10 waited only for ADT to answer. An ADT
`search` needs far less of the system up than an ABAP activation or an RFC server
registration does — so twelve classes failed to activate and every destination died with a
bare `Connection reset by peer`. It now waits for the instance, the gateway *and* ADT.

**4. `wait_for_rfc` was documented and never written.** `lib.sh`'s own header advertised it.
It exists now and gates the gateway.

**5. The orchestrator exited 0 while a step failed.** The steps are **sourced**, so a plain
`rc` was clobbered by the next step initialising its own: step 25 failed, step 30 set
`rc=0`, and the run reported success. Renamed `_PROVISION_RC`, and failing steps are named
in the summary. A provisioner that returns green while broken is the exact failure this
tree exists to prevent — it would have hidden the next problem exactly as the silent test
skips hid the missing certificate trust.

## Also

- **Deferred retry.** Activation is retried, and objects that still fail are deferred and
  retried once the rest of the list is deployed. ABAP lists are not in dependency order —
  `ZCL_ERPL_REV_CDSTEST` failed purely because something it references came later, and
  activated cleanly on a manual attempt afterwards. A second pass resolves that without
  anyone hand-maintaining a topological order.
- **`gw/acl_mode = 0` in the instance profile.** Registered-server destinations are rejected
  by the gateway without it. The running container had it (appended by erpl-rev); the
  repo's copy did not — so a cold start would have come up looking healthy while every RFC
  registration failed.

## Verified

After the fixes, a full run against the provisioned system:

```
== 10-bw-modeling.sh
  OK   BW Modeling services already active
== 20-proto-fixtures.sh
  OK   ZCL_SAPRFC_CALL2 … (12 classes)
  delegating SM59 destinations to …/erpl-proto
  created ZERPL_PING -> program id ERPL_PING … (8 destinations)
  == ABAP + certificate trust: handled by the caller (erpl provisioner) ==   <- guard fired
== 25-rev-fixtures.sh
  OK   … (30 objects) + ZERPL_REV destination + RFC FMs
== 30-cert-trust.sh
  OK   SNC client cert -> SAPSNCS.pse (already trusted)
  OK   wsRFC client cert -> SAPSSLS.pse (already trusted)
  OK   ICM reloaded its PSE (ICM_SSL_PSE_CHANGED subrc=0)
```

A sixth defect was found in the BICS fixture itself and is fixed separately in
DataZooDE/erpl-bics#10: the loader is typed against the table the aDSO generates, so it
could not compile on a system where `ZERPLBIG` had never existed.

**Still to do:** a second cold start, to exercise all of this together — the run above was
against a warm system, so the restart-then-restore-trust handshake is still only half
proven.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790671518&installation_model_id=425457&pr_number=124&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F124&signature=d1924f025ae8d4b856605d4847bfbef8c2b9f1b5ea5fa8e74b62e2341541fe45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->