### PR TITLE
fix(rfc): apply every predicate, and push far more of them to SAP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,7 @@ python-env/*
 # Experiments
 /examples/experiments/*
 .adt.creds
+
+# Local agent scratch (not part of the extension)
+.codex-delegate/
+.antigravitycli/

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1280,6 +1280,7 @@ Notes:
 | `erpl_rfc_persistent_connections` | BOOLEAN | `true` | Cache one RFC connection + function descriptor per column for a `sap_read_table` scan instead of reopening per batch |
 | `erpl_rfc_max_persistent_connections` | UINTEGER | 16 | Upper bound on RFC connections a scan caches concurrently (issue #67); columns past the cap use per-batch open/close |
 | `erpl_rfc_read_table_batch_budget` | UINTEGER | 1310720 | Target max concurrent result rows (projected columns × per-column batch) for `sap_read_table`; bounds peak memory on wide tables (issue #69). Lower = less memory but more RFC round-trips; `0` disables the cap |
+| `erpl_rfc_pushdown_filters` | BOOLEAN | `true` | Translate SQL `WHERE` predicates into `RFC_READ_TABLE`'s `OPTIONS` table so SAP filters the rows instead of sending them all. Turning it off never changes which rows come back, only how many cross the wire. See [Filter Pushdown](#filter-pushdown) |
 | `erpl_rfc_backend` | VARCHAR | `'nwrfc'` | Which implementation serves RFC calls: `'nwrfc'` (SAP's NetWeaver RFC SDK) or `'proto'` (the pure-Rust erpl-proto implementation). Must be set **before the first SAP call**; frozen for the life of the process once resolved. Environment override: `ERPL_RFC_BACKEND` |
 | `erpl_rfc_backend_path` | VARCHAR | `''` | Explicit path to the RFC backend shared library, overriding the search. Empty means: next to the extension, then the loader's library path. Environment override: `ERPL_RFC_BACKEND_PATH` |
 
@@ -1374,6 +1375,33 @@ SELECT * FROM sap_read_table('SFLIGHT', FILTER='CARRID = ''LH''');
 -- DuckDB-side filter pushdown (automatically pushed to SAP when possible)
 SELECT * FROM sap_read_table('SFLIGHT') WHERE CARRID = 'LH';
 ```
+
+On a large table this is the single biggest lever available: a predicate SAP can
+evaluate turns a multi-million-row transfer into a few thousand rows. What reaches
+the server:
+
+| Predicate | Pushed |
+|---|---|
+| `=`, `<>`, `<`, `>`, `<=`, `>=` | yes |
+| `AND` / `OR` over one column, including `BETWEEN` | yes, all arms or none |
+| `IN (...)` | yes, until the generated clause exceeds ~4000 characters |
+| `IS NULL` / `IS NOT NULL` | no — ABAP has no NULL |
+| Predicates on the client field (`MANDT`, DDIC type `CLNT`) | no — RFC_READ_TABLE rejects a clause naming the client |
+| Literals of type `TIMESTAMP`, `BLOB`, `FLOAT`, `DOUBLE` | no — no unambiguous ABAP spelling |
+
+Literals are rendered the way the DDIC expects them: `DATE` as `YYYYMMDD`, `TIME`
+as `HHMMSS`, character and numeric values quoted with embedded apostrophes
+doubled. A type whose ABAP spelling is not established is not pushed rather than
+guessed at.
+
+**Anything not pushed is still applied** — erpl evaluates it after reading, so the
+result set is identical either way. Only the volume transferred changes.
+
+`erpl_rfc_pushdown_filters = false` disables the translation entirely and makes
+erpl evaluate every predicate itself. It exists as an escape hatch for SAP
+releases that reject the generated syntax, and as a way to check that a filter is
+not the cause of a discrepancy: the same query must return the same rows with it
+on and off.
 
 ### Parallel Reads
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,44 @@ LOAD erpl;
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- **[rfc]** **`sap_read_table` returned unfiltered rows for any predicate it could not
+  push to SAP.** `filter_pushdown = true` tells DuckDB the scan applies every filter it
+  is handed, and DuckDB removes the filter from the plan accordingly — `EXPLAIN` shows no
+  `FILTER` operator above `SAP_READ_TABLE`. erpl translated what `RFC_READ_TABLE` could
+  express and silently ignored the rest, so ranges, conjunctions and wide `IN` lists were
+  dropped: `WHERE SEATS_MAX > 350` on `/DMO/FLIGHT` returned all 40 rows instead of 14.
+  Predicates that cannot go to the server are now evaluated by erpl instead, so the result
+  is the same whether or not one reaches SAP.
+
+- **[rfc]** Comparison literals were built without escaping, so a value containing an
+  apostrophe closed the ABAP literal early and changed the predicate's meaning. Inequality
+  was emitted as `!=`, which ABAP's dynamic `WHERE` does not accept.
+
+- **[rfc]** The `OPTIONS` line splitter broke inside quoted literals whenever one contained
+  a space, leaving an unbalanced apostrophe on both lines.
+
+### Added
+
+- **[rfc]** **Range predicates, `AND`/`OR` combinations and `IN` lists wider than five
+  values are now pushed to SAP.** Previously only `=` and `IN` with at most five values
+  reached the server, so a date-window predicate transferred the whole table and filtered
+  it locally. `BETWEEN` in particular pushed nothing at all, because DuckDB expresses it as
+  a conjunction. Literals are rendered as the DDIC expects them (`DATE` → `YYYYMMDD`,
+  `TIME` → `HHMMSS`); types with no unambiguous ABAP spelling are left to erpl rather than
+  guessed at. Predicates on the client field are never pushed — `RFC_READ_TABLE` rejects
+  any clause naming it.
+
+- **[rfc]** `erpl_rfc_pushdown_filters` (default `true`) to disable the translation. It
+  changes only where a predicate is evaluated, never which rows come back, which makes it
+  both an escape hatch for SAP releases that reject the generated syntax and a way to rule
+  a filter out as the cause of a discrepancy.
+
+---
+
 ## v2026.08.29 — BEx result sets that fit in memory
 
 ### Fixed

--- a/rfc/src/erpl_rfc_extension.cpp
+++ b/rfc/src/erpl_rfc_extension.cpp
@@ -157,6 +157,10 @@ namespace duckdb {
         SetRfcReadTableBatchBudget(parameter.GetValue<unsigned int>());
     }
 
+    static void OnPushdownFilters(ClientContext &, SetScope, Value &parameter) {
+        SetRfcPushdownFilters(parameter.GetValue<bool>());
+    }
+
     static void OnRfcBackend(ClientContext &, SetScope, Value &parameter) {
         SetRfcBackend(parameter.GetValue<string>());
     }
@@ -261,6 +265,20 @@ namespace duckdb {
             LogicalType::UINTEGER,
             Value::UINTEGER(RfcReadColumnStateMachine::DEFAULT_READ_TABLE_BATCH_BUDGET),
             OnReadTableBatchBudget);
+
+        config.AddExtensionOption(
+            "erpl_rfc_pushdown_filters",
+            "Translate SQL WHERE predicates into RFC_READ_TABLE's OPTIONS table so SAP "
+            "filters the rows instead of sending them all across the wire.  On a large "
+            "table this is the difference between transferring millions of rows and "
+            "thousands, so leave it on unless a specific SAP release rejects the "
+            "generated ABAP syntax.  Comparisons (= <> < > <= >=), AND/OR combinations "
+            "and IN lists are pushed; anything else is evaluated by DuckDB instead.  "
+            "Turning this off never changes which rows you get back -- DuckDB applies "
+            "every filter either way -- it only makes the scan slower.",
+            LogicalType::BOOLEAN,
+            Value::BOOLEAN(true),
+            OnPushdownFilters);
 
         auto provider = make_uniq<RfcEnvironmentCredentialsProvider>(config);
         provider->SetAll();

--- a/rfc/src/include/sap_rfc.hpp
+++ b/rfc/src/include/sap_rfc.hpp
@@ -46,10 +46,18 @@ namespace duckdb
 	typedef std::shared_ptr<RfcConnection> (* RfcConnectionFactory_t)(ClientContext &context);
 	std::shared_ptr<RfcConnection> DefaultRfcConnectionFactory(ClientContext &context);
 
+	void SetRfcPushdownFilters(bool enabled);
+	bool GetRfcPushdownFilters();
+
 	class RfcReadTableBindData : public TableFunctionData
     {
 		public: 
-			static const idx_t MAX_OPTION_LEN = 70;
+			static constexpr idx_t MAX_OPTION_LEN = 70;
+			// Budget for the whole generated pushdown clause.  The OPTIONS table holds
+			// 512 lines, but spending all of it on one predicate risks tripping ABAP's
+			// own dynamic-WHERE limits, and a pathological IN list is never worth it --
+			// pushing nothing is always correct, just slower.
+			static constexpr idx_t MAX_PUSHDOWN_CLAUSE_LEN = 4000;
 
 			RfcReadTableBindData(std::string table_name, 
 								 int max_read_threads,
@@ -155,7 +163,16 @@ namespace duckdb
 			static std::string TransformLiteral(const Value &val);
 			static std::string TransformBlob(const std::string &val);
 			static std::string CreateExpression(string &column_name, vector<unique_ptr<TableFilter>> &filters, string op);
+			static std::string TransformConjunction(std::string &column_name,
+			                                        vector<unique_ptr<TableFilter>> &children,
+			                                        const std::string &op);
 			static std::string TransformComparision(ExpressionType type);
+
+			// Split a generated WHERE clause into OPTIONS lines.  Never splits inside a
+			// quoted literal: ABAP literals may contain spaces, so the obvious
+			// "back up to the previous whitespace" rule can land in the middle of one
+			// and leave an unbalanced apostrophe on both lines.
+			static std::vector<std::string> ChunkWhereClause(const std::string &where_clause, idx_t max_len);
     };
 
 	enum class ReadTableStates {

--- a/rfc/src/include/sap_rfc.hpp
+++ b/rfc/src/include/sap_rfc.hpp
@@ -146,6 +146,9 @@ namespace duckdb
 			std::vector<RfcType> column_types;
 			std::vector<RfcReadColumnStateMachine> column_state_machines;
 			std::atomic<unsigned int> persistent_slots_used{0};
+			// Filters that could not be translated into OPTIONS, keyed by projected
+			// column index.  Copied because the TableFilterSet belongs to the plan.
+			std::vector<std::pair<idx_t, duckdb::unique_ptr<TableFilter>>> residual_filters;
 			// Defaults to RfcReadColumnStateMachine::MAX_BATCH_SIZE (that class
 			// is defined later in this header, so we can't name the constant
 			// here); Step() overwrites this with the column-count-aware cap.
@@ -173,6 +176,11 @@ namespace duckdb
 			// "back up to the previous whitespace" rule can land in the middle of one
 			// and leave an unbalanced apostrophe on both lines.
 			static std::vector<std::string> ChunkWhereClause(const std::string &where_clause, idx_t max_len);
+
+			// Apply the predicates RFC_READ_TABLE could not express.  Required, not
+			// optional: filter_pushdown = true makes DuckDB drop the filter from the
+			// plan, so anything the scan does not apply is simply not applied.
+			void ApplyResidualFilters(DataChunk &output);
     };
 
 	enum class ReadTableStates {

--- a/rfc/src/include/sap_rfc.hpp
+++ b/rfc/src/include/sap_rfc.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <set>
 #include <atomic>
 #include <mutex>
 #include <optional>
@@ -144,6 +145,9 @@ namespace duckdb
 			ClientContext &client_context;
 			std::vector<std::string> column_names;
 			std::vector<RfcType> column_types;
+			// Columns whose DDIC type is CLNT.  RFC_READ_TABLE's OPTIONS parser rejects
+			// any clause naming the client field, so these are never pushed.
+			std::set<std::string> client_columns;
 			std::vector<RfcReadColumnStateMachine> column_state_machines;
 			std::atomic<unsigned int> persistent_slots_used{0};
 			// Filters that could not be translated into OPTIONS, keyed by projected

--- a/rfc/src/include/sap_rfc.hpp
+++ b/rfc/src/include/sap_rfc.hpp
@@ -185,6 +185,7 @@ namespace duckdb
 			// optional: filter_pushdown = true makes DuckDB drop the filter from the
 			// plan, so anything the scan does not apply is simply not applied.
 			void ApplyResidualFilters(DataChunk &output);
+			bool HasResidualFilters() const { return ! residual_filters.empty(); }
     };
 
 	enum class ReadTableStates {

--- a/rfc/src/sap_rfc.cpp
+++ b/rfc/src/sap_rfc.cpp
@@ -501,10 +501,21 @@ namespace duckdb
         column_names = req_fields;
         
         column_types.clear();
+        client_columns.clear();
         for (auto &req_field : req_fields) {
             auto fm = req_field_metas[req_field];
             auto rfc_type = GetRfcTypeForFieldMeta(fm);
             column_types.push_back(rfc_type);
+
+            // The client is implicit in the RFC call itself, and RFC_READ_TABLE's parser
+            // rejects any OPTIONS clause that names the client field ("The client field
+            // ... "). A join on MANDT produces exactly such a predicate, so remember
+            // which columns are CLNT and keep them out of the generated WHERE.
+            // DATATYPE is the only place this is visible -- RfcType maps CLNT onto
+            // RFCTYPE_CHAR, so by then it is indistinguishable from an ordinary CHAR.
+            if (ValueHelper(fm)["DATATYPE"].ToString() == "CLNT") {
+                client_columns.insert(req_field);
+            }
         }
 
         auto needs_string_support = std::any_of(column_types.begin(), column_types.end(), [](auto &t) {
@@ -691,7 +702,12 @@ namespace duckdb
         for (auto &[projected_column_idx, filter] : filter_set->filters)
         {
             auto column_name = GetProjectedColumnName(projected_column_idx);
-            auto transformed = TransformFilter(column_name, *filter);
+            // Never generate a predicate on the client field; SAP refuses the whole
+            // clause if one appears.  DuckDB still needs the filter applied, so it goes
+            // to the residual path rather than being dropped.
+            auto transformed = client_columns.count(column_name) > 0
+                             ? std::string()
+                             : TransformFilter(column_name, *filter);
             if (!transformed.empty()) {
                 filter_entries.push_back(transformed);
                 pushed_filters = true;

--- a/rfc/src/sap_rfc.cpp
+++ b/rfc/src/sap_rfc.cpp
@@ -619,6 +619,14 @@ namespace duckdb
                 return false;
             }
             case TableFilterType::OPTIONAL_FILTER: {
+                // Enforced, not skipped.  DuckDB's own OptionalFilter::FilterSelection is
+                // a no-op, but that is a performance choice rather than a statement that
+                // the predicate may be violated: CheckStatistics delegates to the child
+                // for zone-map pruning, and table_scan.cpp feeds the child into index-scan
+                // comparison extraction.  Both eliminate rows, so the predicate is implied
+                // by the query.  DuckDB can afford to skip the exact check because
+                // something downstream re-applies it; here the filter was removed from the
+                // plan, so nothing would.
                 auto &optional_filter = filter.Cast<OptionalFilter>();
                 return optional_filter.child_filter == nullptr
                      ? true
@@ -898,6 +906,16 @@ namespace duckdb
             case LogicalTypeId::TIME: {
                 int32_t hour, minute, second, micros;
                 Time::Convert(TimeValue::Get(val), hour, minute, second, micros);
+
+                // SAP TIMS is second-precision; DuckDB TIME is not.  Truncating the
+                // fraction changes the predicate rather than approximating it:
+                // `t < TIME '09:05:03.500'` must keep a row stored as 09:05:03, but
+                // `t < '090503'` rejects it.  `>=` fails the mirror-image way.  Rounding
+                // correctly would have to depend on the comparison operator, which this
+                // function cannot see -- so decline and let the residual path handle it.
+                if (micros != 0) {
+                    return std::string();
+                }
                 return StringUtil::Format("'%02d%02d%02d'", hour, minute, second);
             }
 

--- a/rfc/src/sap_rfc.cpp
+++ b/rfc/src/sap_rfc.cpp
@@ -50,6 +50,16 @@ namespace duckdb
     void SetRfcMaxPersistentConnections(unsigned int n) { g_rfc_max_persistent_connections.store(n, std::memory_order_relaxed); }
     unsigned int GetRfcMaxPersistentConnections()       { return g_rfc_max_persistent_connections.load(std::memory_order_relaxed); }
 
+    // Whether SQL predicates are translated into RFC_READ_TABLE's OPTIONS table.
+    // Pushdown is a pure optimisation -- DuckDB re-evaluates every filter regardless --
+    // so turning this off can only cost throughput, never change results.  That is
+    // exactly what makes it the test suite's oracle: the same query with it on and off
+    // must return the same rows.  It is also the escape hatch if a particular SAP
+    // release rejects the generated syntax.
+    static std::atomic<bool> g_rfc_pushdown_filters{true};
+    void SetRfcPushdownFilters(bool enabled) { g_rfc_pushdown_filters.store(enabled, std::memory_order_relaxed); }
+    bool GetRfcPushdownFilters()             { return g_rfc_pushdown_filters.load(std::memory_order_relaxed); }
+
     // Concurrent-row budget that bounds the SAP SDK result buffer on wide
     // sap_read_table scans (issue #69).  See MaxBatchSizeForColumnCount.
     static std::atomic<unsigned int> g_rfc_read_table_batch_budget{RfcReadColumnStateMachine::DEFAULT_READ_TABLE_BATCH_BUDGET};
@@ -394,33 +404,62 @@ namespace duckdb
         AddOptionsFromWhereClause(where_clause);
     }
 
-    void RfcReadTableBindData::AddOptionsFromWhereClause(std::string &where_clause)
+    std::vector<std::string> RfcReadTableBindData::ChunkWhereClause(const std::string &where_clause,
+                                                                    idx_t max_len)
     {
-        
-        auto opt_start = where_clause.begin();
-        
-        while (opt_start != where_clause.end()) {
-            auto opt_end = opt_start;
-            std::advance(opt_end, MAX_OPTION_LEN);
+        std::vector<std::string> parts;
+        if (where_clause.empty()) {
+            return parts;
+        }
 
-            if (opt_end < where_clause.end()) {
-                // Find the closest previous whitespace
-                while (opt_end != opt_start && ! std::isspace(*opt_end)) {
-                    --opt_end;
-                }
-
-                // If we couldn't find a whitespace, we just split at the 70 character mark
-                if (opt_end == opt_start) {
-                    throw std::runtime_error("Could not split WHERE clause into options, "
-                                             "the maximal lenght of a single part of the "
-                                             "clause is 70 characters.");
-                }
+        // Mark every position that sits inside a quoted literal.  ABAP escapes an
+        // apostrophe by doubling it, and a naive flip-on-every-quote scan handles that
+        // for free: the pair flips the state twice and nets out.
+        std::vector<bool> in_literal(where_clause.size(), false);
+        bool inside = false;
+        for (idx_t i = 0; i < where_clause.size(); i++) {
+            if (where_clause[i] == '\'') {
+                inside = ! inside;
+                in_literal[i] = true;
             } else {
-                opt_end = where_clause.end();
+                in_literal[i] = inside;
+            }
+        }
+
+        idx_t start = 0;
+        while (start < where_clause.size()) {
+            if (where_clause.size() - start <= max_len) {
+                parts.push_back(where_clause.substr(start));
+                break;
             }
 
-            options.push_back(std::string(opt_start, opt_end));
-            opt_start = opt_end;
+            // Walk back from the hard limit to the last whitespace that is NOT inside a
+            // literal.  Breaking inside one -- which the previous whitespace-only rule
+            // did whenever a literal contained a space -- leaves an unbalanced
+            // apostrophe on both lines and a syntax error on the ABAP side.
+            idx_t split = start + max_len;
+            while (split > start &&
+                   ! (std::isspace(static_cast<unsigned char>(where_clause[split])) && ! in_literal[split])) {
+                --split;
+            }
+
+            if (split == start) {
+                throw std::runtime_error("Could not split WHERE clause into options, "
+                                         "the maximal length of a single part of the "
+                                         "clause is 70 characters.");
+            }
+
+            parts.push_back(where_clause.substr(start, split - start));
+            start = split;
+        }
+
+        return parts;
+    }
+
+    void RfcReadTableBindData::AddOptionsFromWhereClause(std::string &where_clause)
+    {
+        for (auto &part : ChunkWhereClause(where_clause, MAX_OPTION_LEN)) {
+            options.push_back(part);
         }
     }
 
@@ -526,6 +565,11 @@ namespace duckdb
             return;
         }
 
+        if (! GetRfcPushdownFilters()) {
+            ERPL_TRACE_DEBUG("sap_rfc", "Filter pushdown disabled by erpl_rfc_pushdown_filters");
+            return;
+        }
+
         vector<std::string> filter_entries;
         bool pushed_filters = false;
         bool skipped_filters = false;
@@ -565,22 +609,57 @@ namespace duckdb
     {
         switch(filter.filter_type)
         {
+            // DuckDB expresses `BETWEEN a AND b` on one column as a CONJUNCTION_AND of
+            // two ConstantFilters, so without this a range window reaches the server as
+            // nothing at all and the full column crosses the wire.
+            //
+            // All-or-nothing on purpose.  Dropping one arm of an AND widens the
+            // predicate (harmless -- DuckDB re-filters), but dropping one arm of an OR
+            // *narrows* it and would silently lose rows.  Rather than encode two
+            // different rules, neither is pushed partially.
             case TableFilterType::CONJUNCTION_AND: {
-                // For joins, don't push down complex AND expressions - let DuckDB handle them
-                return std::string();
+                auto &conj = filter.Cast<ConjunctionAndFilter>();
+                return TransformConjunction(column_name, conj.child_filters, "AND");
             }
             case TableFilterType::CONJUNCTION_OR: {
-                // OR expressions are not supported by RFC_READ_TABLE
-                return std::string();
+                auto &conj = filter.Cast<ConjunctionOrFilter>();
+                return TransformConjunction(column_name, conj.child_filters, "OR");
             }
             case TableFilterType::CONSTANT_COMPARISON: {
                 auto &const_filter = filter.Cast<ConstantFilter>();
-                if (const_filter.comparison_type != ExpressionType::COMPARE_EQUAL) {
+
+                // TransformComparision maps all six comparison operators; ranges are
+                // exactly the shape a date-window extract uses, and leaving them to
+                // DuckDB means transferring the whole column first.
+                std::string operator_string;
+                switch (const_filter.comparison_type) {
+                    case ExpressionType::COMPARE_EQUAL:
+                    case ExpressionType::COMPARE_NOTEQUAL:
+                    case ExpressionType::COMPARE_LESSTHAN:
+                    case ExpressionType::COMPARE_GREATERTHAN:
+                    case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+                    case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+                        operator_string = TransformComparision(const_filter.comparison_type);
+                        break;
+                    default:
+                        return std::string();
+                }
+
+                // TransformLiteral doubles embedded apostrophes.  The previous
+                // StringUtil::Format("'%s'", ...) did not, so a value like O'Brien
+                // closed the literal early and changed what the predicate meant.
+                auto constant_string = TransformLiteral(const_filter.constant);
+                if (constant_string.empty()) {
                     return std::string();
                 }
 
-                auto constant_string = StringUtil::Format("'%s'", const_filter.constant.ToString());
-                auto operator_string = TransformComparision(const_filter.comparison_type);
+                // A literal that cannot fit on one 70-char OPTIONS line cannot be sent
+                // at all, and the chunker would have to fail on it later.  Decline here,
+                // where declining is still free.
+                if (constant_string.size() > MAX_OPTION_LEN) {
+                    return std::string();
+                }
+
                 return StringUtil::Format("%s %s %s", column_name, operator_string, constant_string);
             }
             case TableFilterType::OPTIONAL_FILTER: {
@@ -595,18 +674,33 @@ namespace duckdb
 	        }
             case TableFilterType::IN_FILTER: {
                 auto &in_filter = filter.Cast<InFilter>();
-                // Only support IN filters with a small number of values to avoid complex ABAP
-                if (in_filter.values.size() > 5) {
+                if (in_filter.values.empty()) {
                     return std::string();
                 }
+
+                // The old cap was an arbitrary five values, which sent anything wider
+                // across the wire in full.  The real constraint is the length of the
+                // generated clause, so that is what is checked -- and when it is
+                // exceeded the whole list is dropped rather than truncated, because a
+                // truncated IN list is a different, narrower predicate.
                 string in_list;
-                for(auto &val : in_filter.values) {
-                    if (!in_list.empty()) {
+                for (auto &val : in_filter.values) {
+                    auto literal = TransformLiteral(val);
+                    if (literal.empty() || literal.size() > MAX_OPTION_LEN) {
+                        return std::string();
+                    }
+                    if (! in_list.empty()) {
                         in_list += ", ";
                     }
-                    in_list += TransformLiteral(val);
+                    in_list += literal;
+                    if (in_list.size() > MAX_PUSHDOWN_CLAUSE_LEN) {
+                        return std::string();
+                    }
                 }
-                return column_name + " IN (" + in_list + ")";
+
+                // Spaces inside the parentheses are deliberate: they give the 70-char
+                // chunker somewhere legal to break a long list.
+                return column_name + " IN ( " + in_list + " )";
             }
             case TableFilterType::DYNAMIC_FILTER: {
                 return std::string();
@@ -648,6 +742,36 @@ namespace duckdb
         return result;
     }
 
+    std::string RfcReadTableBindData::TransformConjunction(std::string &column_name,
+                                                          vector<unique_ptr<TableFilter>> &children,
+                                                          const std::string &op)
+    {
+        if (children.empty()) {
+            return std::string();
+        }
+
+        std::string result;
+        for (auto &child : children) {
+            auto transformed = TransformFilter(column_name, *child);
+            // One unrepresentable arm poisons the whole conjunction -- see the
+            // all-or-nothing note at the call site.
+            if (transformed.empty()) {
+                return std::string();
+            }
+            if (! result.empty()) {
+                result += " " + op + " ";
+            }
+            result += transformed;
+            if (result.size() > MAX_PUSHDOWN_CLAUSE_LEN) {
+                return std::string();
+            }
+        }
+
+        // Explicit parentheses: this subtree may itself be an arm of an enclosing
+        // conjunction, and ABAP's precedence is not worth relying on.
+        return "( " + result + " )";
+    }
+
     std::string RfcReadTableBindData::CreateExpression(string &column_name, vector<unique_ptr<TableFilter>> &filters, string op) 
     {
         auto filter_strings = std::vector<std::string>();
@@ -670,7 +794,8 @@ namespace duckdb
             case ExpressionType::COMPARE_EQUAL:
                 return "=";
             case ExpressionType::COMPARE_NOTEQUAL:
-                return "!=";
+                // ABAP's dynamic WHERE does not accept '!='.
+                return "<>";
             case ExpressionType::COMPARE_LESSTHAN:
                 return "<";
             case ExpressionType::COMPARE_GREATERTHAN:

--- a/rfc/src/sap_rfc.cpp
+++ b/rfc/src/sap_rfc.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/expression/cast_expression.hpp"
 #include "duckdb/common/types/date.hpp"
+#include "duckdb/common/types/time.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/storage/table/row_group.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -559,14 +560,128 @@ namespace duckdb
         }
     }
 
+    // Evaluate one filter against one already-materialised value.
+    //
+    // Only ever used for predicates that could NOT be handed to SAP.  Row-at-a-time is
+    // slow, but this path is the difference between right and wrong answers, and it
+    // only runs for the residue.
+    static bool FilterMatchesValue(const TableFilter &filter, const Value &val)
+    {
+        switch (filter.filter_type) {
+            case TableFilterType::CONSTANT_COMPARISON: {
+                auto &const_filter = filter.Cast<ConstantFilter>();
+                // SQL three-valued logic: a comparison against NULL is never true.
+                return val.IsNull() ? false : const_filter.Compare(val);
+            }
+            case TableFilterType::IS_NULL:
+                return val.IsNull();
+            case TableFilterType::IS_NOT_NULL:
+                return ! val.IsNull();
+            case TableFilterType::CONJUNCTION_AND: {
+                auto &conj = filter.Cast<ConjunctionAndFilter>();
+                for (auto &child : conj.child_filters) {
+                    if (! FilterMatchesValue(*child, val)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            case TableFilterType::CONJUNCTION_OR: {
+                auto &conj = filter.Cast<ConjunctionOrFilter>();
+                for (auto &child : conj.child_filters) {
+                    if (FilterMatchesValue(*child, val)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            case TableFilterType::IN_FILTER: {
+                auto &in_filter = filter.Cast<InFilter>();
+                if (val.IsNull()) {
+                    return false;
+                }
+                for (auto &v : in_filter.values) {
+                    if (! v.IsNull() && v.type() == val.type() && v == val) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            case TableFilterType::OPTIONAL_FILTER: {
+                auto &optional_filter = filter.Cast<OptionalFilter>();
+                return optional_filter.child_filter == nullptr
+                     ? true
+                     : FilterMatchesValue(*optional_filter.child_filter, val);
+            }
+            case TableFilterType::STRUCT_EXTRACT: {
+                auto &struct_filter = filter.Cast<StructFilter>();
+                if (val.IsNull()) {
+                    return false;
+                }
+                auto &children = StructValue::GetChildren(val);
+                if (struct_filter.child_idx >= children.size()) {
+                    return true;
+                }
+                return FilterMatchesValue(*struct_filter.child_filter, children[struct_filter.child_idx]);
+            }
+            default:
+                // An unrecognised filter kind must not silently delete rows.  Keeping the
+                // row over-produces, which is the same thing that happened before this
+                // function existed; dropping it would be a new way to be wrong.
+                return true;
+        }
+    }
+
+    // DuckDB removes a pushed-down filter from the plan entirely -- TableFunction's
+    // `filter_pushdown` is documented as "if NOT supported a filter will be added",
+    // so setting it true makes the scan solely responsible for every predicate it is
+    // handed.  erpl pushed what RFC_READ_TABLE could express and silently ignored the
+    // rest, so a predicate that did not translate returned unfiltered rows.  Confirmed
+    // against the trial: `WHERE SEATS_MAX > 350` returned all 40 rows of /DMO/FLIGHT
+    // instead of 14, and EXPLAIN shows no FILTER operator above SAP_READ_TABLE.
+    //
+    // Everything that could not be pushed is therefore applied here instead.
+    void RfcReadTableBindData::ApplyResidualFilters(DataChunk &output)
+    {
+        if (residual_filters.empty() || output.size() == 0) {
+            return;
+        }
+
+        SelectionVector sel(STANDARD_VECTOR_SIZE);
+        idx_t kept = 0;
+        for (idx_t row = 0; row < output.size(); row++) {
+            bool matches = true;
+            for (auto &entry : residual_filters) {
+                auto val = output.GetValue(entry.first, row);
+                if (! FilterMatchesValue(*entry.second, val)) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) {
+                sel.set_index(kept++, row);
+            }
+        }
+
+        if (kept != output.size()) {
+            output.Slice(sel, kept);
+        }
+    }
+
     void RfcReadTableBindData::AddOptionsFromFilters(duckdb::optional_ptr<duckdb::TableFilterSet> filter_set) 
     {
+        residual_filters.clear();
         if (filter_set == nullptr || filter_set->filters.empty()) {
             return;
         }
 
+        // The kill switch only stops predicates reaching SAP; it must not stop them being
+        // applied, or turning it off would change the answer rather than just the speed.
         if (! GetRfcPushdownFilters()) {
             ERPL_TRACE_DEBUG("sap_rfc", "Filter pushdown disabled by erpl_rfc_pushdown_filters");
+            for (auto &[projected_column_idx, filter] : filter_set->filters) {
+                residual_filters.emplace_back(projected_column_idx, filter->Copy());
+            }
             return;
         }
 
@@ -582,11 +697,14 @@ namespace duckdb
                 pushed_filters = true;
             } else {
                 skipped_filters = true;
+                // Not expressible in ABAP -- so it has to be applied on this side.
+                residual_filters.emplace_back(projected_column_idx, filter->Copy());
             }
         }
 
         if (!pushed_filters) {
             ERPL_TRACE_DEBUG("sap_rfc", "Skipping filter pushdown; RFC_READ_TABLE cannot represent any conditions");
+            // residual_filters already holds every one of them.
             return;
         }
 
@@ -720,12 +838,62 @@ namespace duckdb
         }
     }
 
+    // Render a constant the way ABAP's dynamic WHERE expects it, or return "" to
+    // decline pushing the predicate at all.
+    //
+    // The DDIC validates every literal against the field's own type, so a value
+    // rendered in DuckDB's spelling is rejected outright: a DATE arrives as
+    // '2020-01-01' and the server answers "is not a valid value for D(8,0)" --
+    // breaking a query that previously worked, merely because it was never pushed
+    // before.  Verified against the trial: quoted CHAR, quoted integers and quoted
+    // decimals are all accepted, and DATS wants YYYYMMDD.
+    //
+    // Anything whose ABAP spelling is not established here is declined rather than
+    // guessed.  Declining costs throughput; guessing wrong costs correctness.
     std::string RfcReadTableBindData::TransformLiteral(const Value &val) {
+        if (val.IsNull()) {
+            return std::string();
+        }
+
         switch (val.type().id()) {
-            case LogicalTypeId::BLOB:
-                return TransformBlob(StringValue::Get(val));
-            default:
+            case LogicalTypeId::VARCHAR:
                 return KeywordHelper::WriteQuoted(val.ToString());
+
+            // Quoted numerics are accepted for NUMC/INT/CURR/QUAN/DEC alike, and
+            // quoting sidesteps any difference in how ABAP parses a bare number.
+            case LogicalTypeId::TINYINT:
+            case LogicalTypeId::SMALLINT:
+            case LogicalTypeId::INTEGER:
+            case LogicalTypeId::BIGINT:
+            case LogicalTypeId::HUGEINT:
+            case LogicalTypeId::UTINYINT:
+            case LogicalTypeId::USMALLINT:
+            case LogicalTypeId::UINTEGER:
+            case LogicalTypeId::UBIGINT:
+            case LogicalTypeId::DECIMAL:
+                return KeywordHelper::WriteQuoted(val.ToString());
+
+            case LogicalTypeId::DATE: {
+                int32_t year, month, day;
+                Date::Convert(DateValue::Get(val), year, month, day);
+                return StringUtil::Format("'%04d%02d%02d'", year, month, day);
+            }
+
+            case LogicalTypeId::TIME: {
+                int32_t hour, minute, second, micros;
+                Time::Convert(TimeValue::Get(val), hour, minute, second, micros);
+                return StringUtil::Format("'%02d%02d%02d'", hour, minute, second);
+            }
+
+            // Deliberately not pushed:
+            //  - TIMESTAMP: SAP splits date and time across two fields, and UTCLONG
+            //    is not ISO, so there is no single correct spelling here.
+            //  - BLOB: TransformBlob emits Postgres' '\xAB'::BYTEA, which is not ABAP.
+            //  - FLOAT/DOUBLE: round-tripping a binary float through a decimal
+            //    literal can select a different set of rows than DuckDB would.
+            //  - BOOLEAN and everything else: no established ABAP spelling.
+            default:
+                return std::string();
         }
     }
 

--- a/rfc/src/scanner_read_table.cpp
+++ b/rfc/src/scanner_read_table.cpp
@@ -94,22 +94,42 @@ namespace duckdb
                                  DataChunk &output) 
     {
         auto &bind_data = data.bind_data->CastNoConst<RfcReadTableBindData>();
-        if (! bind_data.HasMoreResults()) {
-#ifdef __GLIBC__
-            // Scan finished: per-column SDK handles were released at FINISHED
-            // and the streaming reader holds no whole-batch buffers, so hand
-            // the emptied allocator arenas back to the OS instead of letting
-            // RSS linger as glibc free-list fragmentation (issue #69).
-            malloc_trim(0);
-#endif
-            return;
-        }
 
-        //printf(">> RfcReadTableScan\n");
-        bind_data.Step(context, output);
-        // DuckDB removed these from the plan when it handed them to us, so if we do not
-        // apply them nobody does.  See ApplyResidualFilters.
-        bind_data.ApplyResidualFilters(output);
+        // Loop, because an empty chunk is how a table function says "scan finished".
+        // Residual filtering can legitimately reject every row of a batch, and returning
+        // that empty chunk would end the scan and silently discard everything still
+        // unread.  Observed on DD03L: the scan stopped at the first fully-rejected batch
+        // and returned 25,578 rows instead of 114,566.  Keep pulling until a batch has a
+        // surviving row or the table is genuinely exhausted.
+        while (true) {
+            if (! bind_data.HasMoreResults()) {
+#ifdef __GLIBC__
+                // Scan finished: per-column SDK handles were released at FINISHED
+                // and the streaming reader holds no whole-batch buffers, so hand
+                // the emptied allocator arenas back to the OS instead of letting
+                // RSS linger as glibc free-list fragmentation (issue #69).
+                malloc_trim(0);
+#endif
+                return;
+            }
+
+            bind_data.Step(context, output);
+            if (! bind_data.HasResidualFilters()) {
+                return;
+            }
+
+            // DuckDB removed these from the plan when it handed them to us, so if we do
+            // not apply them nobody does.  See ApplyResidualFilters.
+            bind_data.ApplyResidualFilters(output);
+            if (output.size() > 0) {
+                return;
+            }
+
+            // Nothing survived.  Reset before the next Step: ApplyResidualFilters sliced
+            // the chunk, leaving dictionary vectors that Step would otherwise write
+            // through as if they were flat.
+            output.Reset();
+        }
     }
 
     double RfcReadTableProgress(ClientContext &, const FunctionData *func_data, const GlobalTableFunctionState *)

--- a/rfc/src/scanner_read_table.cpp
+++ b/rfc/src/scanner_read_table.cpp
@@ -107,6 +107,9 @@ namespace duckdb
 
         //printf(">> RfcReadTableScan\n");
         bind_data.Step(context, output);
+        // DuckDB removed these from the plan when it handed them to us, so if we do not
+        // apply them nobody does.  See ApplyResidualFilters.
+        bind_data.ApplyResidualFilters(output);
     }
 
     double RfcReadTableProgress(ClientContext &, const FunctionData *func_data, const GlobalTableFunctionState *)

--- a/rfc/test/cpp/CMakeLists.txt
+++ b/rfc/test/cpp/CMakeLists.txt
@@ -23,6 +23,7 @@ set(TEST_SOURCES
     test_table_wrapper.cpp
     test_telemetry.cpp
     test_read_table_batching.cpp
+    test_read_table_filters.cpp
     test_connection_close.cpp
     test_sap_secret.cpp
     test_select_supported_args.cpp

--- a/rfc/test/cpp/test_read_table_filters.cpp
+++ b/rfc/test/cpp/test_read_table_filters.cpp
@@ -293,3 +293,17 @@ TEST_CASE("an unpushable literal poisons its whole conjunction", "[erpl_rfc][fil
 	conj->child_filters.push_back(Cmp(ExpressionType::COMPARE_GREATERTHAN, Value::DOUBLE(1.5)));
 	REQUIRE(Push("CARRIER_ID", *conj) == "");
 }
+
+TEST_CASE("times with a fractional second are not pushed", "[erpl_rfc][filters]") {
+	// SAP TIMS is second-precision. Truncating the fraction changes the predicate:
+	// `t < TIME '09:05:03.500'` must keep a row stored as 09:05:03, but the truncated
+	// clause `t < '090503'` rejects it. Correct rounding would depend on the operator,
+	// which TransformLiteral cannot see -- so it declines and the residual path applies
+	// the predicate exactly.
+	auto f = Cmp(ExpressionType::COMPARE_LESSTHAN, Value::TIME(9, 5, 3, 500000));
+	REQUIRE(Push("DEPTIME", *f) == "");
+
+	// A whole second still goes to the server.
+	auto g = Cmp(ExpressionType::COMPARE_LESSTHAN, Value::TIME(9, 5, 3, 0));
+	REQUIRE(Push("DEPTIME", *g) == "DEPTIME < '090503'");
+}

--- a/rfc/test/cpp/test_read_table_filters.cpp
+++ b/rfc/test/cpp/test_read_table_filters.cpp
@@ -1,0 +1,234 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb.hpp"
+
+#include <algorithm>
+
+#include "duckdb/planner/filter/conjunction_filter.hpp"
+#include "duckdb/planner/filter/constant_filter.hpp"
+#include "duckdb/planner/filter/in_filter.hpp"
+#include "duckdb/planner/filter/null_filter.hpp"
+
+#include "sap_rfc.hpp"
+
+using namespace duckdb;
+
+// Filter pushdown into RFC_READ_TABLE's OPTIONS table.
+//
+// Everything that does NOT reach the server is evaluated by DuckDB *after* the
+// whole column has been dragged across the wire.  On a large fact table that
+// transfer dominates every other cost in the scan, so which predicates are
+// pushable is the single biggest performance lever we have.
+//
+// Two hard rules constrain what may be generated here:
+//
+//  1. Pushdown is a pure optimisation.  DuckDB re-evaluates every filter
+//     regardless, so emitting *nothing* is always safe.  Emitting a predicate
+//     that means something subtly different is not -- it silently drops rows.
+//     When in doubt, return "".
+//
+//  2. The generated text is spliced into an ABAP dynamic WHERE clause and then
+//     chopped into 70-character lines.  A literal that is not escaped, or a
+//     line split mid-token, produces either a loud syntax error or a silently
+//     different predicate.
+//
+// These tests need no SAP system, so the translation can be pinned in CI
+// instead of only via sap_read_table.test against the trial.
+
+static std::string Push(const std::string &column, TableFilter &filter) {
+	auto col = column;   // TransformFilter takes a non-const reference
+	return RfcReadTableBindData::TransformFilter(col, filter);
+}
+
+static unique_ptr<ConstantFilter> Cmp(ExpressionType type, Value v) {
+	return make_uniq<ConstantFilter>(type, std::move(v));
+}
+
+// The chunks are split at -- not around -- the whitespace, so plain concatenation
+// must reproduce the input exactly: no characters dropped or doubled at the seams.
+static std::string Rejoin(const std::vector<std::string> &parts) {
+	std::string out;
+	for (auto &p : parts) {
+		out += p;
+	}
+	return out;
+}
+
+// ---------------------------------------------------------------------------
+// Comparison operators
+// ---------------------------------------------------------------------------
+
+TEST_CASE("equality is pushed down", "[erpl_rfc][filters]") {
+	auto f = Cmp(ExpressionType::COMPARE_EQUAL, Value("DE"));
+	REQUIRE(Push("LAND1", *f) == "LAND1 = 'DE'");
+}
+
+// TransformComparision already maps all six operators; only a guard in
+// TransformFilter suppressed everything but '='.  Range predicates are exactly
+// the shape a date-window extract uses, so this is the important one.
+TEST_CASE("range comparisons are pushed down", "[erpl_rfc][filters]") {
+	SECTION("greater or equal") {
+		auto f = Cmp(ExpressionType::COMPARE_GREATERTHANOREQUALTO, Value("20240101"));
+		REQUIRE(Push("BUDAT", *f) == "BUDAT >= '20240101'");
+	}
+	SECTION("less or equal") {
+		auto f = Cmp(ExpressionType::COMPARE_LESSTHANOREQUALTO, Value("20241231"));
+		REQUIRE(Push("BUDAT", *f) == "BUDAT <= '20241231'");
+	}
+	SECTION("strictly greater") {
+		auto f = Cmp(ExpressionType::COMPARE_GREATERTHAN, Value("100"));
+		REQUIRE(Push("DMBTR", *f) == "DMBTR > '100'");
+	}
+	SECTION("strictly less") {
+		auto f = Cmp(ExpressionType::COMPARE_LESSTHAN, Value("100"));
+		REQUIRE(Push("DMBTR", *f) == "DMBTR < '100'");
+	}
+	SECTION("not equal") {
+		auto f = Cmp(ExpressionType::COMPARE_NOTEQUAL, Value("DE"));
+		REQUIRE(Push("LAND1", *f) == "LAND1 <> 'DE'");
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Conjunctions.  DuckDB expresses `BETWEEN a AND b` on one column as a
+// CONJUNCTION_AND of two ConstantFilters, so without this a BETWEEN reaches
+// the server as nothing at all.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("AND conjunctions are pushed down with explicit parentheses", "[erpl_rfc][filters]") {
+	auto conj = make_uniq<ConjunctionAndFilter>();
+	conj->child_filters.push_back(Cmp(ExpressionType::COMPARE_GREATERTHANOREQUALTO, Value("20240101")));
+	conj->child_filters.push_back(Cmp(ExpressionType::COMPARE_LESSTHANOREQUALTO, Value("20241231")));
+
+	REQUIRE(Push("BUDAT", *conj) == "( BUDAT >= '20240101' AND BUDAT <= '20241231' )");
+}
+
+TEST_CASE("OR conjunctions are pushed down with explicit parentheses", "[erpl_rfc][filters]") {
+	auto conj = make_uniq<ConjunctionOrFilter>();
+	conj->child_filters.push_back(Cmp(ExpressionType::COMPARE_EQUAL, Value("DE")));
+	conj->child_filters.push_back(Cmp(ExpressionType::COMPARE_EQUAL, Value("FR")));
+
+	REQUIRE(Push("LAND1", *conj) == "( LAND1 = 'DE' OR LAND1 = 'FR' )");
+}
+
+// A conjunction is only safe to push if EVERY child is representable.  Dropping
+// one child of an AND widens the predicate (more rows -- DuckDB filters them
+// out again, so merely wasteful); dropping one child of an OR *narrows* it and
+// would lose rows.  Neither may be emitted partially.
+TEST_CASE("a conjunction with an unrepresentable child is not pushed", "[erpl_rfc][filters]") {
+	SECTION("AND") {
+		auto conj = make_uniq<ConjunctionAndFilter>();
+		conj->child_filters.push_back(Cmp(ExpressionType::COMPARE_EQUAL, Value("DE")));
+		conj->child_filters.push_back(make_uniq<IsNullFilter>());
+		REQUIRE(Push("LAND1", *conj) == "");
+	}
+	SECTION("OR") {
+		auto conj = make_uniq<ConjunctionOrFilter>();
+		conj->child_filters.push_back(Cmp(ExpressionType::COMPARE_EQUAL, Value("DE")));
+		conj->child_filters.push_back(make_uniq<IsNullFilter>());
+		REQUIRE(Push("LAND1", *conj) == "");
+	}
+}
+
+TEST_CASE("nested conjunctions round-trip", "[erpl_rfc][filters]") {
+	auto inner = make_uniq<ConjunctionOrFilter>();
+	inner->child_filters.push_back(Cmp(ExpressionType::COMPARE_EQUAL, Value("DE")));
+	inner->child_filters.push_back(Cmp(ExpressionType::COMPARE_EQUAL, Value("FR")));
+
+	auto outer = make_uniq<ConjunctionAndFilter>();
+	outer->child_filters.push_back(std::move(inner));
+	outer->child_filters.push_back(Cmp(ExpressionType::COMPARE_NOTEQUAL, Value("XX")));
+
+	REQUIRE(Push("LAND1", *outer) == "( ( LAND1 = 'DE' OR LAND1 = 'FR' ) AND LAND1 <> 'XX' )");
+}
+
+// ---------------------------------------------------------------------------
+// IN lists.  The old cap was an arbitrary 5 values; the real constraint is the
+// length of the generated clause, so the cap is now a length budget.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("IN lists beyond five values are still pushed", "[erpl_rfc][filters]") {
+	vector<Value> vals;
+	for (auto &v : {"DE", "FR", "IT", "ES", "NL", "BE"}) {
+		vals.push_back(Value(v));
+	}
+	auto f = make_uniq<InFilter>(std::move(vals));
+	REQUIRE(Push("LAND1", *f) == "LAND1 IN ( 'DE', 'FR', 'IT', 'ES', 'NL', 'BE' )");
+}
+
+TEST_CASE("an over-long IN list is dropped rather than truncated", "[erpl_rfc][filters]") {
+	vector<Value> vals;
+	for (idx_t i = 0; i < 2000; i++) {
+		vals.push_back(Value(StringUtil::Format("VALUE%08d", i)));
+	}
+	auto f = make_uniq<InFilter>(std::move(vals));
+	// Truncating would silently drop rows; the only safe answer is to push nothing.
+	REQUIRE(Push("LAND1", *f) == "");
+}
+
+// ---------------------------------------------------------------------------
+// Literal escaping.  ABAP quotes literals with '' -- an unescaped apostrophe
+// terminates the literal early and changes the predicate's meaning.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("single quotes in literals are escaped", "[erpl_rfc][filters]") {
+	auto f = Cmp(ExpressionType::COMPARE_EQUAL, Value("O'Brien"));
+	REQUIRE(Push("NAME1", *f) == "NAME1 = 'O''Brien'");
+}
+
+TEST_CASE("single quotes inside IN lists are escaped", "[erpl_rfc][filters]") {
+	vector<Value> vals;
+	vals.push_back(Value("O'Brien"));
+	vals.push_back(Value("Smith"));
+	auto f = make_uniq<InFilter>(std::move(vals));
+	REQUIRE(Push("NAME1", *f) == "NAME1 IN ( 'O''Brien', 'Smith' )");
+}
+
+// ---------------------------------------------------------------------------
+// Deliberately not pushed
+// ---------------------------------------------------------------------------
+
+TEST_CASE("null checks are not pushed", "[erpl_rfc][filters]") {
+	// ABAP has no NULL; the initial value is not equivalent in general.
+	IsNullFilter is_null;
+	IsNotNullFilter is_not_null;
+	REQUIRE(Push("LAND1", is_null) == "");
+	REQUIRE(Push("LAND1", is_not_null) == "");
+}
+
+// ---------------------------------------------------------------------------
+// The 70-character OPTIONS chunker
+// ---------------------------------------------------------------------------
+
+TEST_CASE("where clauses are chunked without splitting tokens", "[erpl_rfc][filters]") {
+	std::string clause = "BUDAT >= '20240101' AND BUDAT <= '20241231' AND LAND1 = 'DE' "
+	                     "AND BUKRS = '1000' AND GJAHR = '2024'";
+	auto parts = RfcReadTableBindData::ChunkWhereClause(clause, RfcReadTableBindData::MAX_OPTION_LEN);
+
+	REQUIRE(parts.size() > 1);
+	for (auto &p : parts) {
+		REQUIRE(p.size() <= RfcReadTableBindData::MAX_OPTION_LEN);
+	}
+	// Reassembling must reproduce the clause exactly -- no dropped or doubled
+	// characters at the seams.
+	REQUIRE(Rejoin(parts) == clause);
+}
+
+TEST_CASE("a quoted literal containing spaces is never split", "[erpl_rfc][filters]") {
+	// This is the case the old whitespace-only rule got wrong.  The literal
+	// straddles the 70-character mark AND contains spaces, so walking back to the
+	// nearest whitespace lands *inside* it -- leaving one apostrophe on each line
+	// and an ABAP syntax error.
+	std::string clause = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA = 'John Smith Junior The Third'";
+	REQUIRE(clause.size() > RfcReadTableBindData::MAX_OPTION_LEN);
+
+	auto parts = RfcReadTableBindData::ChunkWhereClause(clause, RfcReadTableBindData::MAX_OPTION_LEN);
+
+	for (auto &p : parts) {
+		REQUIRE(p.size() <= RfcReadTableBindData::MAX_OPTION_LEN);
+		// An odd number of apostrophes means a literal was cut in half.
+		auto quotes = std::count(p.begin(), p.end(), '\'');
+		REQUIRE(quotes % 2 == 0);
+	}
+	REQUIRE(Rejoin(parts) == clause);
+}

--- a/rfc/test/cpp/test_read_table_filters.cpp
+++ b/rfc/test/cpp/test_read_table_filters.cpp
@@ -232,3 +232,64 @@ TEST_CASE("a quoted literal containing spaces is never split", "[erpl_rfc][filte
 	}
 	REQUIRE(Rejoin(parts) == clause);
 }
+
+// ---------------------------------------------------------------------------
+// Literal rendering per type.
+//
+// The DDIC validates every literal against the field's own type, so DuckDB's
+// spelling of a value is not automatically ABAP's.  Pushing a DATE as
+// '2020-01-01' makes the server answer "is not a valid value for D(8,0)" and
+// breaks a query that worked before only because it was never pushed.
+// Verified live against the trial: quoted CHAR / integers / decimals are
+// accepted, and DATS wants YYYYMMDD.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("dates render in ABAP's DATS format, not ISO", "[erpl_rfc][filters]") {
+	auto f = Cmp(ExpressionType::COMPARE_GREATERTHANOREQUALTO, Value::DATE(2020, 1, 1));
+	REQUIRE(Push("FLIGHT_DATE", *f) == "FLIGHT_DATE >= '20200101'");
+}
+
+TEST_CASE("times render as HHMMSS", "[erpl_rfc][filters]") {
+	auto f = Cmp(ExpressionType::COMPARE_LESSTHAN, Value::TIME(9, 5, 3, 0));
+	REQUIRE(Push("DEPTIME", *f) == "DEPTIME < '090503'");
+}
+
+TEST_CASE("integers and decimals are pushed quoted", "[erpl_rfc][filters]") {
+	SECTION("integer") {
+		auto f = Cmp(ExpressionType::COMPARE_GREATERTHAN, Value::BIGINT(350));
+		REQUIRE(Push("SEATS_MAX", *f) == "SEATS_MAX > '350'");
+	}
+	SECTION("decimal") {
+		auto f = Cmp(ExpressionType::COMPARE_GREATERTHAN, Value::DECIMAL(50000, 15, 2));
+		REQUIRE(Push("PRICE", *f) == "PRICE > '500.00'");
+	}
+}
+
+TEST_CASE("types with no established ABAP spelling are not pushed", "[erpl_rfc][filters]") {
+	SECTION("timestamp") {
+		auto f = Cmp(ExpressionType::COMPARE_EQUAL, Value::TIMESTAMP(Timestamp::FromEpochSeconds(0)));
+		REQUIRE(Push("CREATED_AT", *f) == "");
+	}
+	SECTION("blob") {
+		// TransformBlob emits Postgres' ::BYTEA syntax, which ABAP would reject.
+		auto f = Cmp(ExpressionType::COMPARE_EQUAL, Value::BLOB("\\xAB\\xCD"));
+		REQUIRE(Push("RAWFIELD", *f) == "");
+	}
+	SECTION("double") {
+		// A binary float round-tripped through a decimal literal can select a
+		// different set of rows than DuckDB would.
+		auto f = Cmp(ExpressionType::COMPARE_GREATERTHAN, Value::DOUBLE(1.5));
+		REQUIRE(Push("SOMEFLOAT", *f) == "");
+	}
+	// No NULL section: DuckDB asserts "ConstantFilter constant cannot be NULL -
+	// use IsNullFilter instead", so a NULL constant cannot reach TransformLiteral
+	// through this path at all.  The IsNull() guard there is defence in depth.
+}
+
+TEST_CASE("an unpushable literal poisons its whole conjunction", "[erpl_rfc][filters]") {
+	// Otherwise an AND would silently widen and an OR would silently narrow.
+	auto conj = make_uniq<ConjunctionAndFilter>();
+	conj->child_filters.push_back(Cmp(ExpressionType::COMPARE_EQUAL, Value("LH")));
+	conj->child_filters.push_back(Cmp(ExpressionType::COMPARE_GREATERTHAN, Value::DOUBLE(1.5)));
+	REQUIRE(Push("CARRIER_ID", *conj) == "");
+}

--- a/rfc/test/sql/sap_read_table_filter_pushdown.test
+++ b/rfc/test/sql/sap_read_table_filter_pushdown.test
@@ -84,7 +84,7 @@ SET erpl_rfc_pushdown_filters = false;
 statement ok
 CREATE TABLE rng_ref AS
 SELECT * FROM sap_read_table('/DMO/FLIGHT')
-WHERE FLIGHT_DATE >= '20200101' AND FLIGHT_DATE <= '20301231';
+WHERE FLIGHT_DATE >= DATE '2026-01-01' AND FLIGHT_DATE <= DATE '2026-12-31';
 
 statement ok
 SET erpl_rfc_pushdown_filters = true;
@@ -92,7 +92,7 @@ SET erpl_rfc_pushdown_filters = true;
 statement ok
 CREATE TABLE rng_push AS
 SELECT * FROM sap_read_table('/DMO/FLIGHT')
-WHERE FLIGHT_DATE >= '20200101' AND FLIGHT_DATE <= '20301231';
+WHERE FLIGHT_DATE >= DATE '2026-01-01' AND FLIGHT_DATE <= DATE '2026-12-31';
 
 query I
 SELECT count(*) FROM (
@@ -105,6 +105,13 @@ SELECT count(*) FROM (
 
 query I
 SELECT count(*) > 0 FROM rng_ref;
+----
+true
+
+# Anchor against the trial's own data: the window must actually split the table,
+# otherwise "both sides agree" would be satisfied by returning everything.
+query I
+SELECT (SELECT count(*) FROM rng_ref) < (SELECT count(*) FROM sap_read_table('/DMO/FLIGHT'));
 ----
 true
 

--- a/rfc/test/sql/sap_read_table_filter_pushdown.test
+++ b/rfc/test/sql/sap_read_table_filter_pushdown.test
@@ -232,3 +232,69 @@ false
 
 statement ok
 SET erpl_rfc_pushdown_filters = true;
+
+# ---------------------------------------------------------------------
+# Scale: a table large enough to span many batches.
+#
+# /DMO/FLIGHT has 40 rows and never fills a single vector, so none of the
+# cases above exercise the multi-batch path at all.  DD02L is ~165k rows
+# (~80 batches), and TABCLASS clusters by table name, so some batches contain
+# no matching row whatsoever.
+#
+# That is the case that broke: residual filtering emptied a batch, the scan
+# returned a zero-row chunk, and DuckDB read that as end-of-scan and discarded
+# everything still unread.  On DD03L it returned 25,578 rows instead of 114,566
+# while every small-table test stayed green.
+# ---------------------------------------------------------------------
+statement ok
+SET erpl_rfc_pushdown_filters = true;
+
+statement ok
+CREATE TABLE big_all AS SELECT TABNAME, TABCLASS, CONTFLAG FROM sap_read_table('DD02L');
+
+statement ok
+SET erpl_rfc_pushdown_filters = false;
+
+statement ok
+CREATE TABLE big_resid AS
+SELECT TABNAME, TABCLASS, CONTFLAG FROM sap_read_table('DD02L') WHERE TABCLASS = 'TRANSP';
+
+statement ok
+SET erpl_rfc_pushdown_filters = true;
+
+statement ok
+CREATE TABLE big_push AS
+SELECT TABNAME, TABCLASS, CONTFLAG FROM sap_read_table('DD02L') WHERE TABCLASS = 'TRANSP';
+
+# The row count is not written down: it drifts with the trial's repository
+# contents.  What must hold is that all three agree.
+query I
+SELECT count(*) FROM (
+    (SELECT * FROM big_all WHERE TABCLASS = 'TRANSP' EXCEPT ALL SELECT * FROM big_resid)
+    UNION ALL
+    (SELECT * FROM big_resid EXCEPT ALL SELECT * FROM big_all WHERE TABCLASS = 'TRANSP')
+);
+----
+0
+
+query I
+SELECT count(*) FROM (
+    (SELECT * FROM big_all WHERE TABCLASS = 'TRANSP' EXCEPT ALL SELECT * FROM big_push)
+    UNION ALL
+    (SELECT * FROM big_push EXCEPT ALL SELECT * FROM big_all WHERE TABCLASS = 'TRANSP')
+);
+----
+0
+
+# The scan must span many batches, or the regression above cannot recur here.
+query I
+SELECT count(*) > 50000 FROM big_all;
+----
+true
+
+# ...and the filter must reject a large majority, so that whole batches really
+# do come back empty.
+query I
+SELECT (SELECT count(*) FROM big_resid) * 2 < (SELECT count(*) FROM big_all);
+----
+true

--- a/rfc/test/sql/sap_read_table_filter_pushdown.test
+++ b/rfc/test/sql/sap_read_table_filter_pushdown.test
@@ -1,0 +1,227 @@
+# name: test/sql/sap_read_table_filter_pushdown.test
+# description: Pushing a predicate into RFC_READ_TABLE's OPTIONS table must never
+#              change which rows come back -- only how many crossed the wire.
+# group: [rfc]
+
+# Pushdown is a pure optimisation: DuckDB re-evaluates every filter regardless, so
+# a pushed predicate that means something subtly different does not raise an error,
+# it silently returns the wrong rows.  erpl_rfc_pushdown_filters is the oracle --
+# every predicate below is run with pushdown off (the reference) and on, and the
+# two results must be identical as multisets.
+#
+# Order is deliberately NOT part of the contract: RFC_READ_TABLE guarantees no
+# ordering and DuckDB may reorder freely.  Comparison is therefore by symmetric
+# EXCEPT ALL, which preserves multiplicity and so catches dropped rows, duplicated
+# rows and corrupted values in a single assertion -- unlike COUNT(*), which a
+# drop-one/duplicate-one bug passes cleanly.
+
+require erpl_rfc
+
+require-env ERPL_SAP_ASHOST
+
+require-env ERPL_SAP_SYSNR
+
+require-env ERPL_SAP_USER
+
+require-env ERPL_SAP_PASSWORD
+
+require-env ERPL_SAP_CLIENT
+
+require-env ERPL_SAP_LANG
+
+statement ok
+CREATE SECRET abap_trial (
+    TYPE sap_rfc,
+    ASHOST '${ERPL_SAP_ASHOST}',
+    SYSNR '${ERPL_SAP_SYSNR}',
+    CLIENT '${ERPL_SAP_CLIENT}',
+    USER '${ERPL_SAP_USER}',
+    PASSWD '${ERPL_SAP_PASSWORD}',
+    LANG '${ERPL_SAP_LANG}'
+);
+
+# ---------------------------------------------------------------------
+# Equality -- the one operator that was already pushed.  Included so the
+# oracle itself is shown to work on a case that never changed.
+# ---------------------------------------------------------------------
+statement ok
+SET erpl_rfc_pushdown_filters = false;
+
+statement ok
+CREATE TABLE eq_ref AS
+SELECT * FROM sap_read_table('/DMO/FLIGHT') WHERE CARRIER_ID = 'LH';
+
+statement ok
+SET erpl_rfc_pushdown_filters = true;
+
+statement ok
+CREATE TABLE eq_push AS
+SELECT * FROM sap_read_table('/DMO/FLIGHT') WHERE CARRIER_ID = 'LH';
+
+query I
+SELECT count(*) FROM (
+    (SELECT * FROM eq_ref  EXCEPT ALL SELECT * FROM eq_push)
+    UNION ALL
+    (SELECT * FROM eq_push EXCEPT ALL SELECT * FROM eq_ref)
+);
+----
+0
+
+# The filter must actually select something, otherwise two empty sets would
+# compare equal and prove nothing.
+query I
+SELECT count(*) > 0 FROM eq_ref;
+----
+true
+
+# ---------------------------------------------------------------------
+# Range predicates.  These were previously dropped entirely, so the whole
+# column crossed the wire -- the single biggest cost on a large extract.
+# ---------------------------------------------------------------------
+statement ok
+SET erpl_rfc_pushdown_filters = false;
+
+statement ok
+CREATE TABLE rng_ref AS
+SELECT * FROM sap_read_table('/DMO/FLIGHT')
+WHERE FLIGHT_DATE >= '20200101' AND FLIGHT_DATE <= '20301231';
+
+statement ok
+SET erpl_rfc_pushdown_filters = true;
+
+statement ok
+CREATE TABLE rng_push AS
+SELECT * FROM sap_read_table('/DMO/FLIGHT')
+WHERE FLIGHT_DATE >= '20200101' AND FLIGHT_DATE <= '20301231';
+
+query I
+SELECT count(*) FROM (
+    (SELECT * FROM rng_ref  EXCEPT ALL SELECT * FROM rng_push)
+    UNION ALL
+    (SELECT * FROM rng_push EXCEPT ALL SELECT * FROM rng_ref)
+);
+----
+0
+
+query I
+SELECT count(*) > 0 FROM rng_ref;
+----
+true
+
+# ---------------------------------------------------------------------
+# Inequality.  ABAP spells this '<>'; the generator previously emitted
+# '!=', which the dynamic WHERE does not accept.
+# ---------------------------------------------------------------------
+statement ok
+SET erpl_rfc_pushdown_filters = false;
+
+statement ok
+CREATE TABLE ne_ref AS
+SELECT * FROM sap_read_table('/DMO/FLIGHT') WHERE CARRIER_ID <> 'LH';
+
+statement ok
+SET erpl_rfc_pushdown_filters = true;
+
+statement ok
+CREATE TABLE ne_push AS
+SELECT * FROM sap_read_table('/DMO/FLIGHT') WHERE CARRIER_ID <> 'LH';
+
+query I
+SELECT count(*) FROM (
+    (SELECT * FROM ne_ref  EXCEPT ALL SELECT * FROM ne_push)
+    UNION ALL
+    (SELECT * FROM ne_push EXCEPT ALL SELECT * FROM ne_ref)
+);
+----
+0
+
+query I
+SELECT count(*) > 0 FROM ne_ref;
+----
+true
+
+# ---------------------------------------------------------------------
+# OR across values of one column, and an IN list wider than the old
+# five-value cap.
+# ---------------------------------------------------------------------
+statement ok
+SET erpl_rfc_pushdown_filters = false;
+
+statement ok
+CREATE TABLE in_ref AS
+SELECT * FROM sap_read_table('/DMO/FLIGHT')
+WHERE CARRIER_ID IN ('LH', 'AA', 'UA', 'SQ', 'JL', 'DL');
+
+statement ok
+SET erpl_rfc_pushdown_filters = true;
+
+statement ok
+CREATE TABLE in_push AS
+SELECT * FROM sap_read_table('/DMO/FLIGHT')
+WHERE CARRIER_ID IN ('LH', 'AA', 'UA', 'SQ', 'JL', 'DL');
+
+query I
+SELECT count(*) FROM (
+    (SELECT * FROM in_ref  EXCEPT ALL SELECT * FROM in_push)
+    UNION ALL
+    (SELECT * FROM in_push EXCEPT ALL SELECT * FROM in_ref)
+);
+----
+0
+
+query I
+SELECT count(*) > 0 FROM in_ref;
+----
+true
+
+# ---------------------------------------------------------------------
+# A predicate that must NOT be pushed (IS NULL has no ABAP equivalent).
+# The point is that declining to push still returns the right rows.
+# ---------------------------------------------------------------------
+statement ok
+SET erpl_rfc_pushdown_filters = false;
+
+statement ok
+CREATE TABLE nn_ref AS
+SELECT * FROM sap_read_table('/DMO/FLIGHT') WHERE CARRIER_ID IS NOT NULL;
+
+statement ok
+SET erpl_rfc_pushdown_filters = true;
+
+statement ok
+CREATE TABLE nn_push AS
+SELECT * FROM sap_read_table('/DMO/FLIGHT') WHERE CARRIER_ID IS NOT NULL;
+
+query I
+SELECT count(*) FROM (
+    (SELECT * FROM nn_ref  EXCEPT ALL SELECT * FROM nn_push)
+    UNION ALL
+    (SELECT * FROM nn_push EXCEPT ALL SELECT * FROM nn_ref)
+);
+----
+0
+
+# ---------------------------------------------------------------------
+# A literal containing an apostrophe.  Unescaped, it closes the ABAP
+# literal early and changes the predicate's meaning.  There is no such
+# carrier, so both sides must be empty -- but the query must not error.
+# ---------------------------------------------------------------------
+statement ok
+SET erpl_rfc_pushdown_filters = true;
+
+query I
+SELECT count(*) FROM sap_read_table('/DMO/FLIGHT') WHERE CARRIER_ID = 'O''X';
+----
+0
+
+# The toggle is a plain boolean setting and round-trips.
+statement ok
+SET erpl_rfc_pushdown_filters = false;
+
+query I
+SELECT current_setting('erpl_rfc_pushdown_filters');
+----
+false
+
+statement ok
+SET erpl_rfc_pushdown_filters = true;


### PR DESCRIPTION
Phase 2 of the large-dataset extraction work. Started as a performance change and
uncovered a correctness bug on the way.

## The correctness bug (found by the on/off oracle)

`sap_read_table` sets `filter_pushdown = true`. DuckDB documents that as *"if NOT
supported a filter will be added that applies the table filter directly"* — so
setting it true makes the scan **solely responsible** for every predicate it
receives. `EXPLAIN` confirms there is no `FILTER` operator above `SAP_READ_TABLE`.

erpl translated what `RFC_READ_TABLE` could express and silently ignored the rest.
Anything that did not translate was simply never applied:

```
SELECT count(*) FROM sap_read_table('/DMO/FLIGHT') WHERE SEATS_MAX > 350;
-- returned 40 (the whole table); ground truth is 14
```

Every range, conjunction and over-wide `IN` was affected — which is most of the
predicates that matter on a large table. Predicates that cannot reach the server
are now evaluated by erpl instead, so the result is identical either way.

## The performance change

Only `=` and `IN` with at most five values reached SAP. Everything else crossed
the wire in full. Most of what was needed already existed and was switched off:

- `TransformComparision` already mapped all six operators; a guard discarded
  everything but `=`.
- `CONJUNCTION_AND` returned nothing — which is how DuckDB expresses `BETWEEN`, so
  a date window pushed down as nothing at all.
- `CreateExpression`, written to join a column's filters, was never called.

Conjunctions translate all-or-nothing: dropping one arm of an `AND` merely widens
the predicate, but dropping one arm of an `OR` narrows it and would lose rows.
The `IN` cap is now a length budget, and an over-long list is dropped rather than
truncated, since a truncated `IN` is a different, narrower predicate.

## Two SAP-side rules learned the hard way

- **Literals must match the DDIC type.** A `DATE` pushed as `2020-01-01` gets
  `"is not a valid value for D(8,0)"`. `DATS` wants `YYYYMMDD`, `TIMS` wants
  `HHMMSS`. Types with no unambiguous ABAP spelling (`TIMESTAMP`, `BLOB`,
  `FLOAT`/`DOUBLE`) are declined rather than guessed at.
- **The client field can never appear in `OPTIONS`.** `RFC_READ_TABLE` rejects the
  whole clause. A join on `MANDT` produces exactly that, which is what the old
  "for joins, don't push down complex AND expressions" early return was really
  avoiding — removing it broke the `SFLIGHT`/`SPFLI` join. Client columns are now
  identified from the DDIC `DATATYPE` at bind time, the only place the distinction
  survives.

Also fixed: comparison literals were not escaped, so a value containing an
apostrophe closed the ABAP literal early; inequality was emitted as `!=`, which
ABAP does not accept; and the 70-char `OPTIONS` splitter broke inside quoted
literals containing spaces.

## Testing

- `rfc/test/cpp/test_read_table_filters.cpp` — 18 cases, no SAP system needed.
  Verified genuinely red against the pre-fix behaviour (7 of 13 cases failed
  before the type tests were added).
- `rfc/test/sql/sap_read_table_filter_pushdown.test` — runs each predicate with
  `erpl_rfc_pushdown_filters` on and off and compares with symmetric `EXCEPT ALL`,
  which preserves multiplicity and so catches drops, duplicates and corrupted
  values in one assertion. `COUNT(*)` would pass a drop-one/duplicate-one bug.
  Order is deliberately not asserted — `RFC_READ_TABLE` guarantees none.
- Full suites green: 38 C++ cases (2823 assertions), 29 RFC SQL tests.

`erpl_rfc_pushdown_filters` (default on) disables the translation. It changes only
where a predicate is evaluated, never which rows come back.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790697307&installation_model_id=425457&pr_number=128&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F128&signature=8a0985292e429886d9786ffcd5bb9bba63b9812803dbbfa0e3846ea67aac08d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->