### PR TITLE
build: make the ODP real-change delta tests runnable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
-.PHONY: all clean format debug debug_tests release pull update wasm_mvp wasm_eh wasm_threads sql_tests_rfc sql_tests_bics sql_tests_odp sql_tests_rfc_proto sql_tests_bics_proto sql_tests_odp_proto sql_tests_all_backends smoke_test smoke_test_musl
+.PHONY: all clean format debug debug_tests release pull update wasm_mvp wasm_eh wasm_threads sql_tests_rfc sql_tests_bics sql_tests_odp sql_tests_rfc_proto sql_tests_bics_proto sql_tests_odp_proto sql_tests_all_backends delta_fixtures_odp delta_tests_odp smoke_test smoke_test_musl
 
 # Test file argument - if provided, run only that specific test
 TEST_FILE ?=
@@ -158,6 +158,23 @@ sql_tests_bics_proto: debug_tests
 
 sql_tests_odp_proto: debug_tests
 	$(call RUN_SQL_TESTS,odp,$(SAP_COMMON_VARS),$(PROTO_BACKEND_VARS),proto,odp/test/proto_known_failures.txt)
+
+# Real-change delta tests for sap_odp_read_delta.
+#
+# Deliberately NOT part of sql_tests_odp.  Every delta test in odp/test/sql runs against
+# 0D_FC_C01$F, a static fact cube that never changes -- so they can only ever assert
+# "a second call returns nothing".  This harness is the only thing in the repo that
+# proves the protocol streams actual inserts, updates and deletes, and it asserts real
+# values (VAL, REV, ODQ_CHANGEMODE), not row counts.
+#
+# It is separate because it MUTATES the SAP system: it writes rows to a Z table through
+# a CDS view, so it cannot run unattended alongside other suites on a shared trial.
+# Run delta_fixtures_odp once per fresh system, then delta_tests_odp as often as needed.
+delta_fixtures_odp:
+	./odp/test/harness/setup.sh
+
+delta_tests_odp: debug_tests
+	./odp/test/harness/run_delta_tests.sh
 
 # Every suite on every backend.  Serial on purpose: the suites share one SAP system and
 # one unittest binary, and running them concurrently corrupts both.


### PR DESCRIPTION
`odp/test/harness/run_delta_tests.sh` was wired into nothing — not the Makefile, not
CI, not any script. `grep -r run_delta_tests` matches only the file itself.

That matters because it is the only delta coverage in the repo that proves anything.
Every delta test in `odp/test/sql` runs against `0D_FC_C01$F`, a **static** fact cube
that never changes, so they can assert at most "a second call returns nothing". The
harness writes rows through a CDS view and asserts the actual values that come back —
`VAL`, `REV`, `ODQ_CHANGEMODE` — across insert, update, delete, mixed and bulk
scenarios.

Adds two targets:

```
make delta_fixtures_odp   # deploy the ABAP fixtures, once per fresh system
make delta_tests_odp      # run the real-change scenarios
```

Deliberately **not** folded into `sql_tests_odp`: the harness mutates the SAP system,
so it cannot run unattended beside the other suites on a shared trial.

Found while auditing the ODP suite for assertion rigour (see DataZooDE/erpl-odp#8,
which fixes 17 assertions that could not fail).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790760506&installation_model_id=425457&pr_number=130&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F130&signature=28d039b4692f09060b7f7e6f0d51e712f0cf3095f7b5b1320934796b85417d8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->