### PR TITLE
docs: how to parallelise a narrow sap_read_table extract, and what it is worth

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1442,6 +1442,48 @@ running a large parallel extract against a production system.
 `erpl_rfc_fetch_size`. Both remain supported and write the same value — they are two
 names for one knob, not two knobs.
 
+#### Narrow tables: `threads` will not help
+
+`sap_read_table`'s parallelism is **per column**: it issues one concurrent
+`RFC_READ_TABLE` call per projected column. That is a good fit for a wide extract and
+no help at all for a narrow one — a single-column scan runs one call, and `threads`
+has nothing to spread.
+
+If you are extracting few columns from a large table, split it by a key range instead
+and let SQL run the pieces:
+
+```sql
+SELECT * FROM sap_read_table('DD02L') WHERE TABNAME <  'D'
+UNION ALL
+SELECT * FROM sap_read_table('DD02L') WHERE TABNAME >= 'D' AND TABNAME < 'R'
+UNION ALL
+SELECT * FROM sap_read_table('DD02L') WHERE TABNAME >= 'R' AND TABNAME < 'V'
+UNION ALL
+SELECT * FROM sap_read_table('DD02L') WHERE TABNAME >= 'V';
+```
+
+The range predicates are pushed to SAP (see [Filter Pushdown](#filter-pushdown)), so
+each branch reads only its own slice rather than filtering locally.
+
+**What to expect.** Measured on a 164,664-row single-column extract, four branches ran
+in 6.6s against 8.3s for the equivalent single scan — about **1.2x**, not 4x. Each
+branch pays its own connection and metadata round-trip, and the SAP system applies each
+range filter separately, so the gain is far smaller than the branch count suggests.
+Splitting into many small branches makes it worse, not better.
+
+Two things matter more than the branch count:
+
+- **Pick boundaries that split the data evenly.** A range that covers most of the table
+  leaves you with one long branch and three short ones, and the long one sets the wall
+  time.
+- **Split on an indexed key.** If SAP has to scan the whole table to evaluate each
+  range, you have multiplied the server's work rather than divided it.
+
+For a genuinely large extract, running several *processes* against SAP scales
+considerably better than either approach — concurrency limits on the SAP side apply per
+client program, so separate processes are not aggregated the way threads within one are.
+Check with your Basis team before pointing many parallel readers at a production system.
+
 ### SSH Tunnel + SAP Connection
 
 Complete workflow for connecting through an SSH jump host:


### PR DESCRIPTION
Closes plan step 3.2 (RFC row-range partitioning) — **evaluated, decided, documented**.

## The gate could not be satisfied, so I measured the proxy

The plan conditioned the refactor on "run Phase 0's scaling curve on production-class
hardware first". That hardware is not available. What *could* be measured is whether
splitting a narrow scan into row ranges helps at all.

DD02L, 164,664 rows, single column, three alternating runs each. Identical checksums
in both arms (2,719,013), so the comparison is valid:

| arm | median wall |
|---|---|
| one scan | 8.25s |
| four range-partitioned scans | 6.63s |

**1.24x, not 4x.**

Confounded in both directions — the split arm pays four connection setups and makes
SAP evaluate four range filters, while a real in-scanner implementation would share
one setup and use `ROWSKIPS`. So this is suggestive, not decisive. It was also taken
on a trial under load average ~21.

## Why I did not do the refactor

`column_state_machines` lives in the bind data, shared across the whole scan.
Row-range partitioning needs them per worker, which means moving them into a local
state and reworking `Step()`, the batch budget, the persistent-connection cache,
progress reporting, `ActivateColumns()`, the lock-step invariant
`AreActiveStateMachineCaridnalitiesEqual()`, `HasMoreResults()`, and the
residual-filter application.

That is a re-architecture of the scan path in which **this same session found two
silent wrong-results bugs** — unapplied predicates, and truncation on a fully-filtered
batch. Against a measured 1.24x that cannot be soak-tested on a shared trial, that
trade does not look good.

The structural gap is real either way: a single-column extract gets **no** parallelism
at all. It is the payoff that is unproven, not the gap. A scaling curve on a
production-class system showing the knee well above 3 would reverse this.

## What this PR delivers instead

The plan's own "either way" item — the recipe that works today with no code:

- Why `threads` does nothing for a narrow extract (parallelism is **per column**;
  one column means one call and nothing to spread). Nothing said so, so the natural
  reaction to a slow narrow extract was to raise `threads` and watch it change nothing.
- The range-partition recipe, now that #128 pushes range predicates to SAP so each
  branch reads only its slice rather than filtering locally.
- **The measured 1.2x**, stated plainly so nobody expects 4x, plus the note that many
  small branches make it worse.
- The two things that matter more than branch count: even boundaries (one long branch
  sets the wall time) and an indexed split key (otherwise you multiply the server's
  work rather than divide it).
- That separate processes scale considerably better than either approach, since
  SAP-side concurrency limits apply per client program — with the caveat to ask Basis
  before pointing many parallel readers at production.

Docs only; no code changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790768882&installation_model_id=425457&pr_number=132&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F132&signature=7bf54ea6990a4349755ff0dc2feb1de8faa98cf06633d0f7fc872d496938c323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->