### PR TITLE
fix(rfc): sap_rfc_invoke on a module whose results are all tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@ LOAD erpl;
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- **[rfc]** **`sap_rfc_invoke` failed on any module whose result parameters are all
+  tables.** `RFC_READ_TABLE` is the canonical case — its results are `DATA`, `FIELDS`
+  and `OPTIONS`, with no scalar export — and invoking it raised
+  `Unimplemented type for cast (STRUCT(WA VARCHAR) -> STRUCT(WA VARCHAR)[])`.
+
+  The result was treated as *pivoted* whenever every value happened to be list-shaped,
+  so rows were unnested into columns still declared `LIST(STRUCT)`. Detection now also
+  requires each element type to match its declared column type, which distinguishes
+  genuinely pivoted (path-selected) data from a bare invoke. Selecting a table through
+  `path :=` still pivots to the row's fields, as before.
+
 ## v2026.08.31 — every predicate applied, and most of them pushed to SAP
 
 Two of the entries below are **silent wrong-results bugs in released erpl**, not

--- a/rfc/src/sap_function.cpp
+++ b/rfc/src/sap_function.cpp
@@ -2275,10 +2275,28 @@ RfcFieldDesc::RfcFieldDesc(const RFC_FIELD_DESC& sap_desc) : _desc_handle(sap_de
     }
 
     bool RfcResultSet::IsTabularResult() {
-        auto all_lists = std::all_of(_result_data.begin(), _result_data.end(), [](Value &v) {
-            return v.type().id() == LogicalTypeId::LIST;
-        });
-        return all_lists;
+        // "Tabular" means the data has been PIVOTED: one LIST per output column, whose
+        // element type is that column's declared type, so the rows can be unnested into
+        // the chunk. That is what a path-selected table produces.
+        //
+        // Being list-shaped is not enough. A bare invoke of a module whose results are
+        // all tables (RFC_READ_TABLE: DATA, FIELDS, OPTIONS) also yields all-LIST data,
+        // but its declared type is LIST(STRUCT) per parameter -- unnesting it wrote a
+        // STRUCT into a STRUCT[] column. Comparing element type against declared type
+        // separates the two cases exactly.
+        if (_result_data.empty() || _result_data.size() != _result_types.size()) {
+            return false;
+        }
+        for (std::size_t i = 0; i < _result_data.size(); i++) {
+            auto &value = _result_data[i];
+            if (value.type().id() != LogicalTypeId::LIST) {
+                return false;
+            }
+            if (ListType::GetChildType(value.type()) != _result_types[i]) {
+                return false;
+            }
+        }
+        return true;
     }
 
     std::string RfcResultSet::ToSQLString() 

--- a/rfc/test/sql/sap_rfc_invoke_all_tables.test
+++ b/rfc/test/sql/sap_rfc_invoke_all_tables.test
@@ -1,0 +1,62 @@
+# name: test/sql/sap_rfc_invoke_all_tables.test
+# description: sap_rfc_invoke on a function whose result parameters are ALL tables.
+#
+#              RfcResultSet::FetchNextResult unnests the result into rows when every
+#              result value is a LIST ("tabular"). That is correct for a path-selected
+#              list, whose schema is pivoted to the row's fields -- but for a bare
+#              invoke the schema is LIST(STRUCT) per parameter, so unnesting wrote a
+#              STRUCT into a STRUCT[] column and the scan died with
+#                "Unimplemented type for cast (STRUCT(WA VARCHAR) -> STRUCT(WA VARCHAR)[])".
+#
+#              Any module with no scalar or structure export triggers it. RFC_READ_TABLE
+#              is the canonical one: its results are DATA, FIELDS and OPTIONS, all tables.
+# group: [rfc]
+
+require erpl_rfc
+
+require-env ERPL_SAP_ASHOST
+
+require-env ERPL_SAP_SYSNR
+
+require-env ERPL_SAP_USER
+
+require-env ERPL_SAP_PASSWORD
+
+require-env ERPL_SAP_CLIENT
+
+require-env ERPL_SAP_LANG
+
+statement ok
+CREATE SECRET abap_trial (
+    TYPE sap_rfc,
+    ASHOST '${ERPL_SAP_ASHOST}',
+    SYSNR '${ERPL_SAP_SYSNR}',
+    CLIENT '${ERPL_SAP_CLIENT}',
+    USER '${ERPL_SAP_USER}',
+    PASSWD '${ERPL_SAP_PASSWORD}',
+    LANG '${ERPL_SAP_LANG}'
+);
+
+# A bare invoke returns one row, with each TABLES parameter as a list column.
+query III
+SELECT len(DATA), len(FIELDS) >= 1, len(OPTIONS)
+FROM sap_rfc_invoke('RFC_READ_TABLE', {'QUERY_TABLE': 'T000', 'ROWCOUNT': 2});
+----
+2	true	0
+
+# The rows are reachable through the list, and carry real data.
+query I
+SELECT count(*) FROM (
+    SELECT unnest(DATA) AS r
+    FROM sap_rfc_invoke('RFC_READ_TABLE', {'QUERY_TABLE': 'T000', 'ROWCOUNT': 2})
+) WHERE length(r.WA) > 0;
+----
+2
+
+# Selecting the table through a path still pivots to the row's fields -- the behaviour
+# the tabular branch exists for, and which must not regress.
+query I
+SELECT count(*) FROM sap_rfc_invoke('RFC_READ_TABLE',
+       {'QUERY_TABLE': 'T000', 'ROWCOUNT': 2}, path := '/DATA');
+----
+2


### PR DESCRIPTION
Fixes #136.

```sql
SELECT * FROM sap_rfc_invoke('RFC_READ_TABLE', {'QUERY_TABLE': 'T000', 'ROWCOUNT': 2});
-- Unimplemented type for cast (STRUCT(WA VARCHAR) -> STRUCT(WA VARCHAR)[])
```

`RFC_READ_TABLE` is the canonical case — its result parameters are `DATA`, `FIELDS` and `OPTIONS`, all tables, with no scalar export. So this is not the ODP corner the issue was filed from; a headline function was broken.

## Cause

`IsTabularResult()` inferred that the result was **pivoted** — one LIST per output column, ready to unnest into the chunk — from every value merely being list-shaped.

That holds for a path-selected table, whose schema *is* pivoted to the row's fields. It also holds for a bare invoke of an all-tables module, whose schema is `LIST(STRUCT)` per parameter — and there, unnesting wrote a `STRUCT` into a `STRUCT[]` column.

Detection now additionally requires each value's element type to equal its declared column type, which separates the two cases exactly.

A module with **any** scalar or structure export was never affected — it needs a result set with no scalar at all, which is why this survived.

## Note on the issue text

#136 speculated an *empty* table was the trigger and flagged that as unverified. It was wrong: emptiness is irrelevant, the trigger is the all-tables shape. The control experiment recorded there was inconclusive rather than exonerating.

## Tests

`test/sql/sap_rfc_invoke_all_tables.test` pins the bare-invoke shape, that the rows are reachable through the list, and the path-selected pivot that must not regress. I verified it red on the cast and green on the fix by reverting and restoring the change — my first red run had failed on a missing secret instead, which would have proved nothing.

| suite | result |
|---|---|
| RFC nwrfc | 32/32 |
| RFC proto | 31 + 1 known gap |
| BICS nwrfc | 45/45 (shares this code path) |
| ODP both backends | 25/25 |

The ODP half of this work (#134, #135) is DataZooDE/erpl-odp#9; its gitlink bump follows once that merges.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790887283&installation_model_id=425457&pr_number=137&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F137&signature=beb2a978d69c5702fa924ef8f280c9e25fa48e61214b27831f5a05dab9841359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->