### PR TITLE
fix(rfc): honour the row budget for single-column scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,28 @@ LOAD erpl;
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- **[rfc]** **`fetch_size` and `partitions` did nothing to the batch size of a
+  single-column scan.** `MaxBatchSizeForColumnCount` returned the full 32768-row cap
+  whenever a scan projected one column, discarding the budget that
+  `ResolveEffectiveMaxBatchSize` had just divided across the partition workers — so every
+  worker asked SAP for `ROWCOUNT=32768` however `erpl_rfc_fetch_size` and `partitions`
+  were set. The exemption was deliberate, on the reasoning that a narrow scan is already
+  under any sane budget; that reasoning ignored the division, and a narrow scan is
+  precisely what partitioning exists for.
+
+  Measured on a 300,000-row single-column read at `partitions = 8`: peak RSS **405 MB →
+  307 MB (−24%)** with no loss of throughput (2.17s → 2.07s). The budget now binds for
+  every column count; only a zero budget or a scan with no projected column bypasses it.
+
+- **[rfc]** A partitioned scan never returned its allocator arenas to the OS. The serial
+  path calls `malloc_trim(0)` when the scan finishes, but each partition worker retires on
+  a different code path that did not, so every worker thread's glibc arena kept its
+  high-water mark — which is what `getrusage` reports.
+
 ## v2026.09.02 — a narrow extract can finally use more than one connection
 
 `sap_read_table` parallelised across *columns*, so reading a few columns out of a very

--- a/rfc/src/sap_rfc.cpp
+++ b/rfc/src/sap_rfc.cpp
@@ -1234,8 +1234,8 @@ namespace duckdb
         // so without dividing here the budget would be per worker and peak memory would
         // scale with the partition count -- the opposite of what a budget is for.
         //
-        // Narrow scans, which is what partitioning is for, are unaffected: the batch is
-        // already capped at MAX_BATCH_SIZE long before the divided budget binds.
+        // Narrow scans are the point of partitioning, so they must feel this division
+        // too -- see MaxBatchSizeForColumnCount, which no longer exempts a single column.
         auto budget = EffectiveFetchSize();
         auto workers = GetPartitionCount();
         if (workers > 1 && budget > 0) {
@@ -1580,7 +1580,15 @@ namespace duckdb
         // concurrent-row budget, floored to a power of two in
         // [STANDARD_VECTOR_SIZE, MAX_BATCH_SIZE] so the doubling warm-up still
         // reaches the cap cleanly and ROWSKIPS % ROWCOUNT stays valid.
-        if (num_columns <= 1 || concurrent_row_budget == 0) {
+        // A zero budget disables the cap, and a scan with no projected column has
+        // nothing to bound. Note that num_columns == 1 is NOT exempt: it used to be,
+        // on the reasoning that a narrow scan is already under any sane budget -- but
+        // ResolveEffectiveMaxBatchSize divides the budget by the partition count, and
+        // a narrow scan is precisely what partitioning is for. Exempting it meant
+        // erpl_rfc_fetch_size and partitions silently did nothing to the batch for the
+        // one scan shape that most needed them (heaptrack showed 32768-row batches on
+        // every worker at partitions=8).
+        if (num_columns == 0 || concurrent_row_budget == 0) {
             return MAX_BATCH_SIZE;
         }
         unsigned int per_col = concurrent_row_budget / num_columns;

--- a/rfc/src/scanner_read_table.cpp
+++ b/rfc/src/scanner_read_table.cpp
@@ -160,6 +160,13 @@ namespace duckdb
                 idx_t offset = 0, rows = 0;
                 if (! gstate.scheduler->Claim(offset, rows)) {
                     // Nothing left to claim; an empty chunk retires this worker.
+#ifdef __GLIBC__
+                    // Mirror the serial path: this worker is done, its per-column SDK
+                    // handles are released, and each worker thread has its own glibc
+                    // arena. Without this the arenas keep their high-water mark and
+                    // getrusage still reports the peak long after the rows are gone.
+                    malloc_trim(0);
+#endif
                     return;
                 }
                 for (auto &sm : lstate.machines) {

--- a/rfc/test/cpp/test_read_table_batching.cpp
+++ b/rfc/test/cpp/test_read_table_batching.cpp
@@ -78,13 +78,39 @@ TEST_CASE("NextDesiredBatchSize doubles geometrically while keeping ROWSKIPS val
 	REQUIRE(size == SM::MAX_BATCH_SIZE);
 }
 
+TEST_CASE("A single-column scan honours a small budget instead of ignoring it",
+          "[erpl_rfc][batching]") {
+	using SM = RfcReadColumnStateMachine;
+
+	// ResolveEffectiveMaxBatchSize divides the budget across partition workers so that
+	// peak memory does not scale with the worker count. A single-column scan used to
+	// short-circuit to MAX_BATCH_SIZE before the divided budget was ever consulted, so
+	// every worker asked SAP for ROWCOUNT=32768 no matter what erpl_rfc_fetch_size or
+	// partitions said -- confirmed on a4h by heaptrack, which showed 32768-row batches
+	// under partitions=8. Narrow scans are exactly what partitioning is for, so this is
+	// the case where the budget matters most.
+	REQUIRE(SM::MaxBatchSizeForColumnCount(1, 2048) == (unsigned int)STANDARD_VECTOR_SIZE);
+	REQUIRE(SM::MaxBatchSizeForColumnCount(1, 8192) == 8192u);
+
+	// The default fetch size (16384 concurrent rows) split across 8 workers.
+	REQUIRE(SM::MaxBatchSizeForColumnCount(1, 16384u / 8u) == (unsigned int)STANDARD_VECTOR_SIZE);
+
+	// A budget large enough for the full batch still yields it -- the cap binds, it does
+	// not shrink for its own sake.
+	REQUIRE(SM::MaxBatchSizeForColumnCount(1, 256u * 1024u) == SM::MAX_BATCH_SIZE);
+
+	// Zero columns still means "no projection to bound"; a zero budget still disables it.
+	REQUIRE(SM::MaxBatchSizeForColumnCount(0, 2048) == SM::MAX_BATCH_SIZE);
+	REQUIRE(SM::MaxBatchSizeForColumnCount(1, 0) == SM::MAX_BATCH_SIZE);
+}
+
 TEST_CASE("MaxBatchSizeForColumnCount bounds the SDK buffer on wide scans",
           "[erpl_rfc][batching]") {
 	using SM = RfcReadColumnStateMachine;
 	// Use an explicit budget so the test is independent of the runtime default.
 	constexpr unsigned int BUDGET = 256u * 1024u;
 
-	// Narrow scans keep the full batch for throughput.
+	// Narrow scans keep the full batch when the budget is large enough to allow it.
 	REQUIRE(SM::MaxBatchSizeForColumnCount(0, BUDGET) == SM::MAX_BATCH_SIZE);
 	REQUIRE(SM::MaxBatchSizeForColumnCount(1, BUDGET) == SM::MAX_BATCH_SIZE);
 	REQUIRE(SM::MaxBatchSizeForColumnCount(2, BUDGET) == SM::MAX_BATCH_SIZE);


### PR DESCRIPTION
`sap_read_table`'s `fetch_size` and `partitions` did nothing to the batch size of a
single-column scan.

`MaxBatchSizeForColumnCount` short-circuited to `MAX_BATCH_SIZE` whenever a scan projected
one column, discarding the budget `ResolveEffectiveMaxBatchSize` had just divided across
the partition workers. Every worker issued `ROWCOUNT=32768` however `erpl_rfc_fetch_size`
and `partitions` were set.

The exemption was deliberate, and its comment said why: a narrow scan is already under any
sane budget. That is true of the *undivided* budget and stops being true the moment it is
divided by the worker count — which is the case partitioning creates. Narrow scans are what
partitioning is for, so this was the one shape where the knobs mattered most and did
nothing.

## How it was found

Profiling the two RFC backends against each other. heaptrack showed 32768-row batches on
every worker at `partitions=8`, on **both** backends, regardless of the settings — which
is not what the tuning API advertises.

The single-column bypass was first spotted by a multi-agent review of the two codebases;
the profiler then confirmed it and refuted that review's wider model.

## Measured

300,000 rows of `REPOSRC`, one column, `partitions=8`, release build, a4h:

| | peak RSS | wall |
|---|---|---|
| before | 405 MB | 2.17s |
| after | **307 MB** (−24%) | 2.07s |

No throughput cost at this shape. Checksums identical before and after, on both backends.

## Also

A partitioned scan never returned its allocator arenas. The serial path calls
`malloc_trim(0)` when the scan finishes (#69), but a partition worker retires through a
different branch that did not, so each worker thread's glibc arena kept its high-water
mark — which is the number `getrusage` reports.

## What this does NOT fix

The erpl-proto backend is unchanged at 691 MB. Its peak scales with rows *read* rather
than rows *in flight* — a 16× smaller batch does not move it, while total rows do
(293 / 389 / 694 MB for 75k / 150k / 300k rows, ~2.3 KB retained per row). That is a
separate defect, reported with its heaptrack attribution as DataZooDE/erpl-proto#61.

## Tests

- `test_read_table_batching.cpp`: a new case asserting the budget binds for one column —
  red before this change (`32768 == 2048` failed), green after. The existing wide-scan
  assertions are unchanged and still pass, because a large budget still yields the full
  batch; only a *small* (divided) budget now binds.
- Offline: batching 7/7, partition scheduler 11/11.
- Live: RFC **32/32** on nwrfc, **31 + 1 known gap** on erpl-proto.

## Behaviour note

A serial single-column scan now uses a 16384-row batch rather than 32768, because the
default budget is 16384 concurrent rows and it is now honoured rather than bypassed. That
is the documented contract; raise `erpl_rfc_fetch_size` to restore the old batch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790935299&installation_model_id=425457&pr_number=138&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F138&signature=d358f181b45bb80f8972dfae827cc9540c3b34270925b1603d1f559d8abe9be1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->