### PR TITLE
chore: pin erpl-proto to v2026.9.2.1 and empty the known-failure list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,15 @@ LOAD erpl;
   while holding the tracer mutex, which the writer re-locks. The sequence documented for
   diagnosing SAP communication was itself the trigger; it presents as a hung query.
 
+### Changed
+
+- **[all]** **The `erpl-proto` backend is pinned to `v2026.9.2.1`, and its known-failure
+  list is now empty.** The previous pin carried a table-delta padding gap
+  (`sap_rfc_struct_layout`), and the releases that fixed it regressed BICS from 45/45 to
+  23/45 on a nested-`TTYP` basXML defect. Both are now fixed upstream, so every suite
+  passes on the proto backend with no recorded gaps for the first time: RFC 34/34,
+  ODP 25/25, BICS 45/45.
+
 ### Added
 
 - **[rfc]** `sap_rfc_live_connections()`, `sap_rfc_connections_opened()` and
@@ -190,9 +199,7 @@ that had been silently doing nothing at all.
 ### Build
 
 - **[all]** The `erpl-proto` backend is pinned to the `v2026.8.29.1` release rather than
-  an untagged commit. Newer proto releases fix a table-delta padding gap
-  (`sap_rfc_struct_layout`, tracked as a known gap on that backend) but regress BICS from
-  45/45 to 23/45 on a nested-`TTYP` basXML defect, so the pin stays until that is closed.
+  an untagged commit.
 
 ---
 

--- a/rfc/test/proto_known_failures.txt
+++ b/rfc/test/proto_known_failures.txt
@@ -6,15 +6,3 @@
 # unchallenged. Remove a line as soon as its gap closes.
 #
 # See ERPL_PROTO_INTEGRATION_PLAN.md, Phase 6.
-
-# Table parameters whose row needs trailing alignment padding are rejected:
-#   "unexpected record during table delta: a 29-byte row for TAB2, whose rows are 32 bytes"
-# Bisected to erpl-proto fea9e44 ("five decoding defects"), which rewrote table-delta
-# handling; its direct parent ce59c98 passes. Present in every tagged release, so there is
-# no pin that both is a release and avoids it. Passes on nwrfc.
-#
-# FIXED upstream in erpl-proto v2026.9.2, but we cannot pin to it yet: that release
-# regresses BICS from 45/45 to 23/45 via a nested-TTYP basXML defect.
-# https://github.com/DataZooDE/erpl-proto/issues/54
-# https://github.com/DataZooDE/erpl-proto/issues/60
-sap_rfc_struct_layout.test


### PR DESCRIPTION
The pin sat at `v2026.8.29.1` because every newer release traded one defect for another: `v2026.9.2` fixed the table-delta padding gap (`sap_rfc_struct_layout`) but regressed BICS from **45/45 to 23/45** on a nested-`TTYP` basXML defect, and the release before it broke ODP outright.

Both are fixed upstream (DataZooDE/erpl-proto#60, #61), so `rfc/test/proto_known_failures.txt` is now **empty**. That is an assertion, not a formality — the runner fails the run if a listed test passes, so an empty list means the suite is strict.

Verified live at this pin, on top of the three scan-path fixes merged today:

| suite | result |
|---|---|
| RFC proto | **34/34**, 0 failures, 0 known gaps |
| ODP proto | **25/25**, 0 failures, 0 known gaps |
| BICS proto | **45/45**, 0 failures, 0 known gaps |

First time the proto backend passes every suite with nothing recorded as a gap.

Also drops the `v2026.09.02` changelog paragraph that explained why the pin was held back — it no longer describes reality.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791101958&installation_model_id=425457&pr_number=142&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F142&signature=34fca03ce496a3b66321600a6fe27c0995a961d9385aab30ebc40853c54e8830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->