### PR TITLE
chore(deps): raise the pip floor past CVE-2026-8643

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,5 @@ description = "Python helper for the Duckdb python extension"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "pip>=25.0.1",
+    "pip>=26.1.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 1
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -11,13 +11,13 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pip", specifier = ">=25.0.1" }]
+requires-dist = [{ name = "pip", specifier = ">=26.1.2" }]
 
 [[package]]
 name = "pip"
-version = "25.0.1"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/70/53/b309b4a497b09655cb7e07088966881a57d082f48ac3cb54ea729fd2c6cf/pip-25.0.1.tar.gz", hash = "sha256:88f96547ea48b940a3a385494e181e29fb8637898f88d88737c5049780f196ea", size = 1950850 }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/bc/b7db44f5f39f9d0494071bddae6880eb645970366d0a200022a1a93d57f5/pip-25.0.1-py3-none-any.whl", hash = "sha256:c46efd13b6aa8279f33f2864459c8ce587ea6a1a59ee20de055868d8f7688f7f", size = 1841526 },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]


### PR DESCRIPTION
Closes #141.

`pip < 26.1.2` treats `console_scripts` / `gui_scripts` entry points as paths rather than file names, without checking that the resolved absolute path stays inside the installation directory, so a crafted wheel can write its entry-point wrappers anywhere the installing user can write. CVSS v4.0 4.1 (MEDIUM); 8.0 (HIGH) under Red Hat's v3.1 assessment. The CVE checks out against the MITRE record — see the closing note on the issue.

## What changed

`pyproject.toml` `pip>=25.0.1` → `pip>=26.1.2`, and `uv lock`, which resolves to 26.2.1.

uv 0.12.9 also rewrites the lockfile header `revision = 1` → `3`. That is the current on-disk format, not part of the bump.

## Why a bump and not a deletion

My first read was that the root `pyproject.toml` was dead scaffolding from `4b7f593` ("initialize UV") — nothing in the Makefile, CMake or CI touches it, and its only declared dependency is pip itself. That was wrong. `rfc/test/parallel/README.md` documents `uv run pytest rfc/test/parallel` from the repo root, so this project *is* the harness's environment, and the root `.venv` had pip 25.0.1 actually installed. The vulnerable version was live, not merely recorded.

I upgraded that local `.venv` in place rather than via `uv sync` — see the follow-up below for why.

## Rest of the org is clean

Checked whether anything else pins a vulnerable pip: 25 `uv.lock`, 2 `requirements.txt` and 1 `poetry.lock` across DataZooDE; 48 Python manifests grepped across the locally-cloned repos plus API fetches for the four that are not cloned. This is the only pin of pip anywhere in the org. The ~30 repos that run pip in CI use the ambient `setup-python` pip, and several already `python -m pip install --upgrade pip`, which lands on a fixed version by itself.

## Follow-up, not in this PR

The root `.venv` carries `pytest`, `duckdb` and `adbc_driver_duckdb`, none of which are declared in `pyproject.toml` — they were installed ad hoc. A plain `uv sync` (or `uv run`, which syncs) would prune them and break the parallel harness. Worth declaring them so the documented command actually works from a clean checkout, but that changes what the harness resolves and belongs in its own change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791193564&installation_model_id=425457&pr_number=143&repository=DataZooDE%2Ferpl&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl%2Fpull%2F143&signature=dd6f5b6d0185511c7537ba3ec632748c4a3406ff047a9642e6faa375450dd5f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->